### PR TITLE
Added support for arguments to the toThrow() matcher

### DIFF
--- a/spec/suites/MatchersSpec.js
+++ b/spec/suites/MatchersSpec.js
@@ -515,6 +515,26 @@ describe("jasmine.Matchers", function() {
           expect(match(throwingFn).not.toThrow(new Error("Other Error"))).toPass();
         });
       });
+
+      describe("when function only throws based on provided arguments",function(){
+        beforeEach(function(){
+          throwingFn = function(fruit,vegetable) {
+            if(fruit === "Banana") {
+              throw new Error("Banana Error");
+            } else if(vegetable === "Tomato") {
+              throw new Error("Tomato Error");
+            }
+          };
+        });
+
+        it("should match when thrown because of argument",function(){
+          expect(match(throwingFn).toThrow(new Error("Banana Error"),"Banana")).toPass();
+        });
+
+        it("should match when thrown because of subsequent argument",function() {
+          expect(match(throwingFn).toThrow(new Error("Tomato Error"),"Apple","Tomato")).toPass();
+        });
+      });
     });
 
     describe("when actual is not a function", function() {

--- a/src/Matchers.js
+++ b/src/Matchers.js
@@ -303,7 +303,9 @@ jasmine.Matchers.prototype.toThrow = function(expected) {
     throw new Error('Actual is not a function');
   }
   try {
-    this.actual();
+    var args = [];
+    for(var i=1;i<arguments.length;i++) { args.push(arguments[i]); }
+    this.actual.apply(this,args);
   } catch (e) {
     exception = e;
   }


### PR DESCRIPTION
Because the toThrow() matcher is only currently useful if a function could be expected to throw an error because of broader-scoped state at the time the expectation is made. Because in reality, a number of exceptions are encountered because of the state of its arguments, I added support for invoking the function under test with whatever arbitrary arguments follow the expected error on the matcher.

For example, if I have a function:

```
var pants = function(zipper) {
  if(zipper === "open") throw new Error("No open zippers!");
};
```

I can now demand the above code by setting up an expectation like this:

```
expect(pants).toThrow(new Error("No open zippers!"),"open");
```

This commit doesn't (I believe) change the normal functionality of the matcher, unless there's an edge case involved with calling apply() over directly invoking the passed function that I'm not aware of.

I didn't change the message format to consider this, either, because I'm not sure whether I (or you will) like the semantic of using toThrow() this way. I'd prefer a chained semantic like this, ultimately, but I'm not sure that's currently possible in Jasmine:

```
expect(pants).withArguments("open").toThrow(new Error("No open zippers!"));
```
