### PR TITLE
fix broken download link on user guide

### DIFF
--- a/user-guide.html.md
+++ b/user-guide.html.md
@@ -6,7 +6,7 @@ title: User Guide
 # Quick Start
 
 ## For JavaScript-only projects:
-1. Get the latest standalone release from the [downloads page](index.html).
+1. Get the latest standalone release from the [downloads page](download.html).
 2. Open `SpecRunner.html` in your favorite browser.
 
 ## Other distributions:


### PR DESCRIPTION
A _download_ link goes to the index rather than the download. I tripped over this twice, so I fixed it.
