### PR TITLE
Namespacing

### DIFF
--- a/src/Env.js
+++ b/src/Env.js
@@ -1,264 +1,273 @@
-/**
- * Environment for Jasmine
- *
- * @constructor
- */
-jasmine.Env = function() {
-  this.currentSpec = null;
-  this.currentSuite = null;
-  this.currentRunner_ = new jasmine.Runner(this);
+jasmine.Env = (function(){ 
+	var _this = this /* @private scoped reference to "this".  (Avoids confusion/mistakes when scope of "this" changes due to events, apply, call, etc. */
+		, _undefined_  = jasmine.___undefined___ /* @private scoped reference to "undefined" */
+	;
 
-  this.reporter = new jasmine.MultiReporter();
-
-  this.updateInterval = jasmine.DEFAULT_UPDATE_INTERVAL;
-  this.defaultTimeoutInterval = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-  this.lastUpdate = 0;
-  this.specFilter = function() {
-    return true;
-  };
-
-  this.nextSpecId_ = 0;
-  this.nextSuiteId_ = 0;
-  this.equalityTesters_ = [];
-
-  // wrap matchers
-  this.matchersClass = function() {
-    jasmine.Matchers.apply(this, arguments);
-  };
-  jasmine.util.inherit(this.matchersClass, jasmine.Matchers);
-
-  jasmine.Matchers.wrapInto_(jasmine.Matchers.prototype, this.matchersClass);
-};
-
-
-jasmine.Env.prototype.setTimeout = jasmine.setTimeout;
-jasmine.Env.prototype.clearTimeout = jasmine.clearTimeout;
-jasmine.Env.prototype.setInterval = jasmine.setInterval;
-jasmine.Env.prototype.clearInterval = jasmine.clearInterval;
-
-/**
- * @returns an object containing jasmine version build info, if set.
- */
-jasmine.Env.prototype.version = function () {
-  if (jasmine.version_) {
-    return jasmine.version_;
-  } else {
-    throw new Error('Version not set');
-  }
-};
-
-/**
- * @returns string containing jasmine version build info, if set.
- */
-jasmine.Env.prototype.versionString = function() {
-  if (jasmine.version_) {
-    var version = this.version();
-    return version.major + "." + version.minor + "." + version.build + " revision " + version.revision;
-  } else {
-    return "version unknown";
-  }
-};
-
-/**
- * @returns a sequential integer starting at 0
- */
-jasmine.Env.prototype.nextSpecId = function () {
-  return this.nextSpecId_++;
-};
-
-/**
- * @returns a sequential integer starting at 0
- */
-jasmine.Env.prototype.nextSuiteId = function () {
-  return this.nextSuiteId_++;
-};
-
-/**
- * Register a reporter to receive status updates from Jasmine.
- * @param {jasmine.Reporter} reporter An object which will receive status updates.
- */
-jasmine.Env.prototype.addReporter = function(reporter) {
-  this.reporter.addReporter(reporter);
-};
-
-jasmine.Env.prototype.execute = function() {
-  this.currentRunner_.execute();
-};
-
-jasmine.Env.prototype.describe = function(description, specDefinitions) {
-  var suite = new jasmine.Suite(this, description, specDefinitions, this.currentSuite);
-
-  var parentSuite = this.currentSuite;
-  if (parentSuite) {
-    parentSuite.add(suite);
-  } else {
-    this.currentRunner_.add(suite);
-  }
-
-  this.currentSuite = suite;
-
-  var declarationError = null;
-  try {
-    specDefinitions.call(suite);
-  } catch(e) {
-    declarationError = e;
-  }
-
-  this.currentSuite = parentSuite;
-
-  if (declarationError) {
-    this.it("encountered a declaration exception", function() {
-      throw declarationError;
-    });
-  }
-
-  return suite;
-};
-
-jasmine.Env.prototype.beforeEach = function(beforeEachFunction) {
-  if (this.currentSuite) {
-    this.currentSuite.beforeEach(beforeEachFunction);
-  } else {
-    this.currentRunner_.beforeEach(beforeEachFunction);
-  }
-};
-
-jasmine.Env.prototype.currentRunner = function () {
-  return this.currentRunner_;
-};
-
-jasmine.Env.prototype.afterEach = function(afterEachFunction) {
-  if (this.currentSuite) {
-    this.currentSuite.afterEach(afterEachFunction);
-  } else {
-    this.currentRunner_.afterEach(afterEachFunction);
-  }
-
-};
-
-jasmine.Env.prototype.xdescribe = function(desc, specDefinitions) {
-  return {
-    execute: function() {
-    }
-  };
-};
-
-jasmine.Env.prototype.it = function(description, func) {
-  var spec = new jasmine.Spec(this, this.currentSuite, description);
-  this.currentSuite.add(spec);
-  this.currentSpec = spec;
-
-  if (func) {
-    spec.runs(func);
-  }
-
-  return spec;
-};
-
-jasmine.Env.prototype.xit = function(desc, func) {
-  return {
-    id: this.nextSpecId(),
-    runs: function() {
-    }
-  };
-};
-
-jasmine.Env.prototype.compareObjects_ = function(a, b, mismatchKeys, mismatchValues) {
-  if (a.__Jasmine_been_here_before__ === b && b.__Jasmine_been_here_before__ === a) {
-    return true;
-  }
-
-  a.__Jasmine_been_here_before__ = b;
-  b.__Jasmine_been_here_before__ = a;
-
-  var hasKey = function(obj, keyName) {
-    return obj != null && obj[keyName] !== jasmine.undefined;
-  };
-
-  for (var property in b) {
-    if (!hasKey(a, property) && hasKey(b, property)) {
-      mismatchKeys.push("expected has key '" + property + "', but missing from actual.");
-    }
-  }
-  for (property in a) {
-    if (!hasKey(b, property) && hasKey(a, property)) {
-      mismatchKeys.push("expected missing key '" + property + "', but present in actual.");
-    }
-  }
-  for (property in b) {
-    if (property == '__Jasmine_been_here_before__') continue;
-    if (!this.equals_(a[property], b[property], mismatchKeys, mismatchValues)) {
-      mismatchValues.push("'" + property + "' was '" + (b[property] ? jasmine.util.htmlEscape(b[property].toString()) : b[property]) + "' in expected, but was '" + (a[property] ? jasmine.util.htmlEscape(a[property].toString()) : a[property]) + "' in actual.");
-    }
-  }
-
-  if (jasmine.isArray_(a) && jasmine.isArray_(b) && a.length != b.length) {
-    mismatchValues.push("arrays were not the same length");
-  }
-
-  delete a.__Jasmine_been_here_before__;
-  delete b.__Jasmine_been_here_before__;
-  return (mismatchKeys.length == 0 && mismatchValues.length == 0);
-};
-
-jasmine.Env.prototype.equals_ = function(a, b, mismatchKeys, mismatchValues) {
-  mismatchKeys = mismatchKeys || [];
-  mismatchValues = mismatchValues || [];
-
-  for (var i = 0; i < this.equalityTesters_.length; i++) {
-    var equalityTester = this.equalityTesters_[i];
-    var result = equalityTester(a, b, this, mismatchKeys, mismatchValues);
-    if (result !== jasmine.undefined) return result;
-  }
-
-  if (a === b) return true;
-
-  if (a === jasmine.undefined || a === null || b === jasmine.undefined || b === null) {
-    return (a == jasmine.undefined && b == jasmine.undefined);
-  }
-
-  if (jasmine.isDomNode(a) && jasmine.isDomNode(b)) {
-    return a === b;
-  }
-
-  if (a instanceof Date && b instanceof Date) {
-    return a.getTime() == b.getTime();
-  }
-
-  if (a instanceof jasmine.Matchers.Any) {
-    return a.matches(b);
-  }
-
-  if (b instanceof jasmine.Matchers.Any) {
-    return b.matches(a);
-  }
-
-  if (jasmine.isString_(a) && jasmine.isString_(b)) {
-    return (a == b);
-  }
-
-  if (jasmine.isNumber_(a) && jasmine.isNumber_(b)) {
-    return (a == b);
-  }
-
-  if (typeof a === "object" && typeof b === "object") {
-    return this.compareObjects_(a, b, mismatchKeys, mismatchValues);
-  }
-
-  //Straight check
-  return (a === b);
-};
-
-jasmine.Env.prototype.contains_ = function(haystack, needle) {
-  if (jasmine.isArray_(haystack)) {
-    for (var i = 0; i < haystack.length; i++) {
-      if (this.equals_(haystack[i], needle)) return true;
-    }
-    return false;
-  }
-  return haystack.indexOf(needle) >= 0;
-};
-
-jasmine.Env.prototype.addEqualityTester = function(equalityTester) {
-  this.equalityTesters_.push(equalityTester);
-};
+	/**
+	 * Environment for Jasmine
+	 *
+	 * @constructor
+	 */
+	function _Env() {
+	  this.currentSpec = null;
+	  this.currentSuite = null;
+	  this.currentRunner_ = new jasmine.Runner(this);
+	
+	  this.reporter = new jasmine.MultiReporter();
+	
+	  this.updateInterval = jasmine.DEFAULT_UPDATE_INTERVAL;
+	  this.defaultTimeoutInterval = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+	  this.lastUpdate = 0;
+	  this.specFilter = function() {
+	    return true;
+	  };
+	
+	  this.nextSpecId_ = 0;
+	  this.nextSuiteId_ = 0;
+	  this.equalityTesters_ = [];
+	
+	  // wrap matchers
+	  this.matchersClass = function() {
+	    jasmine.Matchers.apply(this, arguments);
+	  };
+	  jasmine.util.inherit(this.matchersClass, jasmine.Matchers);
+	
+	  jasmine.Matchers.wrapInto_(jasmine.Matchers.prototype, this.matchersClass);
+	};
+	
+	
+	_Env.prototype.setTimeout = jasmine.setTimeout;
+	_Env.prototype.clearTimeout = jasmine.clearTimeout;
+	_Env.prototype.setInterval = jasmine.setInterval;
+	_Env.prototype.clearInterval = jasmine.clearInterval;
+	
+	/**
+	 * @returns an object containing jasmine version build info, if set.
+	 */
+	_Env.prototype.version = function () {
+	  if (jasmine.version_) {
+	    return jasmine.version_;
+	  } else {
+	    throw new Error('Version not set');
+	  }
+	};
+	
+	/**
+	 * @returns string containing jasmine version build info, if set.
+	 */
+	_Env.prototype.versionString = function() {
+	  if (jasmine.version_) {
+	    var version = this.version();
+	    return version.major + "." + version.minor + "." + version.build + " revision " + version.revision;
+	  } else {
+	    return "version unknown";
+	  }
+	};
+	
+	/**
+	 * @returns a sequential integer starting at 0
+	 */
+	_Env.prototype.nextSpecId = function () {
+	  return this.nextSpecId_++;
+	};
+	
+	/**
+	 * @returns a sequential integer starting at 0
+	 */
+	_Env.prototype.nextSuiteId = function () {
+	  return this.nextSuiteId_++;
+	};
+	
+	/**
+	 * Register a reporter to receive status updates from Jasmine.
+	 * @param {jasmine.Reporter} reporter An object which will receive status updates.
+	 */
+	_Env.prototype.addReporter = function(reporter) {
+	  this.reporter.addReporter(reporter);
+	};
+	
+	_Env.prototype.execute = function() {
+	  this.currentRunner_.execute();
+	};
+	
+	_Env.prototype.describe = function(description, specDefinitions) {
+	  var suite = new jasmine.Suite(this, description, specDefinitions, this.currentSuite);
+	
+	  var parentSuite = this.currentSuite;
+	  if (parentSuite) {
+	    parentSuite.add(suite);
+	  } else {
+	    this.currentRunner_.add(suite);
+	  }
+	
+	  this.currentSuite = suite;
+	
+	  var declarationError = null;
+	  try {
+	    specDefinitions.call(suite);
+	  } catch(e) {
+	    declarationError = e;
+	  }
+	
+	  this.currentSuite = parentSuite;
+	
+	  if (declarationError) {
+	    this.it("encountered a declaration exception", function() {
+	      throw declarationError;
+	    });
+	  }
+	
+	  return suite;
+	};
+	
+	_Env.prototype.beforeEach = function(beforeEachFunction) {
+	  if (this.currentSuite) {
+	    this.currentSuite.beforeEach(beforeEachFunction);
+	  } else {
+	    this.currentRunner_.beforeEach(beforeEachFunction);
+	  }
+	};
+	
+	_Env.prototype.currentRunner = function () {
+	  return this.currentRunner_;
+	};
+	
+	_Env.prototype.afterEach = function(afterEachFunction) {
+	  if (this.currentSuite) {
+	    this.currentSuite.afterEach(afterEachFunction);
+	  } else {
+	    this.currentRunner_.afterEach(afterEachFunction);
+	  }
+	
+	};
+	
+	_Env.prototype.xdescribe = function(desc, specDefinitions) {
+	  return {
+	    execute: function() {
+	    }
+	  };
+	};
+	
+	_Env.prototype.it = function(description, func) {
+	  var spec = new jasmine.Spec(this, this.currentSuite, description);
+	  this.currentSuite.add(spec);
+	  this.currentSpec = spec;
+	
+	  if (func) {
+	    spec.runs(func);
+	  }
+	
+	  return spec;
+	};
+	
+	_Env.prototype.xit = function(desc, func) {
+	  return {
+	    id: this.nextSpecId(),
+	    runs: function() {
+	    }
+	  };
+	};
+	
+	_Env.prototype.compareObjects_ = function(a, b, mismatchKeys, mismatchValues) {
+	  if (a.__Jasmine_been_here_before__ === b && b.__Jasmine_been_here_before__ === a) {
+	    return true;
+	  }
+	
+	  a.__Jasmine_been_here_before__ = b;
+	  b.__Jasmine_been_here_before__ = a;
+	
+	  var hasKey = function(obj, keyName) {
+	    return obj != null && obj[keyName] !== _undefined_ ;
+	  };
+	
+	  for (var property in b) {
+	    if (!hasKey(a, property) && hasKey(b, property)) {
+	      mismatchKeys.push("expected has key '" + property + "', but missing from actual.");
+	    }
+	  }
+	  for (property in a) {
+	    if (!hasKey(b, property) && hasKey(a, property)) {
+	      mismatchKeys.push("expected missing key '" + property + "', but present in actual.");
+	    }
+	  }
+	  for (property in b) {
+	    if (property == '__Jasmine_been_here_before__') continue;
+	    if (!this.equals_(a[property], b[property], mismatchKeys, mismatchValues)) {
+	      mismatchValues.push("'" + property + "' was '" + (b[property] ? jasmine.util.htmlEscape(b[property].toString()) : b[property]) + "' in expected, but was '" + (a[property] ? jasmine.util.htmlEscape(a[property].toString()) : a[property]) + "' in actual.");
+	    }
+	  }
+	
+	  if (jasmine.isArray_(a) && jasmine.isArray_(b) && a.length != b.length) {
+	    mismatchValues.push("arrays were not the same length");
+	  }
+	
+	  delete a.__Jasmine_been_here_before__;
+	  delete b.__Jasmine_been_here_before__;
+	  return (mismatchKeys.length == 0 && mismatchValues.length == 0);
+	};
+	
+	_Env.prototype.equals_ = function(a, b, mismatchKeys, mismatchValues) {
+	  mismatchKeys = mismatchKeys || [];
+	  mismatchValues = mismatchValues || [];
+	
+	  for (var i = 0; i < this.equalityTesters_.length; i++) {
+	    var equalityTester = this.equalityTesters_[i];
+	    var result = equalityTester(a, b, this, mismatchKeys, mismatchValues);
+	    if (result !== _undefined_ ) return result;
+	  }
+	
+	  if (a === b) return true;
+	
+	  if (a === _undefined_  || a === null || b === _undefined_  || b === null) {
+	    return (a == _undefined_  && b == _undefined_ );
+	  }
+	
+	  if (jasmine.isDomNode(a) && jasmine.isDomNode(b)) {
+	    return a === b;
+	  }
+	
+	  if (a instanceof Date && b instanceof Date) {
+	    return a.getTime() == b.getTime();
+	  }
+	
+	  if (a instanceof jasmine.Matchers.Any) {
+	    return a.matches(b);
+	  }
+	
+	  if (b instanceof jasmine.Matchers.Any) {
+	    return b.matches(a);
+	  }
+	
+	  if (jasmine.isString_(a) && jasmine.isString_(b)) {
+	    return (a == b);
+	  }
+	
+	  if (jasmine.isNumber_(a) && jasmine.isNumber_(b)) {
+	    return (a == b);
+	  }
+	
+	  if (typeof a === "object" && typeof b === "object") {
+	    return this.compareObjects_(a, b, mismatchKeys, mismatchValues);
+	  }
+	
+	  //Straight check
+	  return (a === b);
+	};
+	
+	_Env.prototype.contains_ = function(haystack, needle) {
+	  if (jasmine.isArray_(haystack)) {
+	    for (var i = 0; i < haystack.length; i++) {
+	      if (this.equals_(haystack[i], needle)) return true;
+	    }
+	    return false;
+	  }
+	  return haystack.indexOf(needle) >= 0;
+	};
+	
+	_Env.prototype.addEqualityTester = function(equalityTester) {
+	  this.equalityTesters_.push(equalityTester);
+	};
+	
+	return _Env;
+	
+})();

--- a/src/JsApiReporter.js
+++ b/src/JsApiReporter.js
@@ -1,102 +1,112 @@
-/** JavaScript API reporter.
- *
- * @constructor
- */
-jasmine.JsApiReporter = function() {
-  this.started = false;
-  this.finished = false;
-  this.suites_ = [];
-  this.results_ = {};
-};
+jasmine.JsApiReporter = (function(){ 
+	var _this = this /* @private scoped reference to "this".  (Avoids confusion/mistakes when scope of "this" changes due to events, apply, call, etc. */
+		, _undefined_  = jasmine.___undefined___ /* @private scoped reference to "undefined" */
+	;
 
-jasmine.JsApiReporter.prototype.reportRunnerStarting = function(runner) {
-  this.started = true;
-  var suites = runner.topLevelSuites();
-  for (var i = 0; i < suites.length; i++) {
-    var suite = suites[i];
-    this.suites_.push(this.summarize_(suite));
-  }
-};
+	/** JavaScript API reporter.
+	 *
+	 * @constructor
+	 */
+	
+	function _JsApiReporter() {
+	  this.started = false;
+	  this.finished = false;
+	  this.suites_ = [];
+	  this.results_ = {};
+	};
+	
+	_JsApiReporter.prototype.reportRunnerStarting = function(runner) {
+	  this.started = true;
+	  var suites = runner.topLevelSuites();
+	  for (var i = 0; i < suites.length; i++) {
+	    var suite = suites[i];
+	    this.suites_.push(this.summarize_(suite));
+	  }
+	};
+	
+	_JsApiReporter.prototype.suites = function() {
+	  return this.suites_;
+	};
+	
+	_JsApiReporter.prototype.summarize_ = function(suiteOrSpec) {
+	  var isSuite = suiteOrSpec instanceof jasmine.Suite;
+	  var summary = {
+	    id: suiteOrSpec.id,
+	    name: suiteOrSpec.description,
+	    type: isSuite ? 'suite' : 'spec',
+	    children: []
+	  };
+	  
+	  if (isSuite) {
+	    var children = suiteOrSpec.children();
+	    for (var i = 0; i < children.length; i++) {
+	      summary.children.push(this.summarize_(children[i]));
+	    }
+	  }
+	  return summary;
+	};
+	
+	_JsApiReporter.prototype.results = function() {
+	  return this.results_;
+	};
+	
+	_JsApiReporter.prototype.resultsForSpec = function(specId) {
+	  return this.results_[specId];
+	};
+	
+	//noinspection JSUnusedLocalSymbols
+	_JsApiReporter.prototype.reportRunnerResults = function(runner) {
+	  this.finished = true;
+	};
+	
+	//noinspection JSUnusedLocalSymbols
+	_JsApiReporter.prototype.reportSuiteResults = function(suite) {
+	};
+	
+	//noinspection JSUnusedLocalSymbols
+	_JsApiReporter.prototype.reportSpecResults = function(spec) {
+	  this.results_[spec.id] = {
+	    messages: spec.results().getItems(),
+	    result: spec.results().failedCount > 0 ? "failed" : "passed"
+	  };
+	};
+	
+	//noinspection JSUnusedLocalSymbols
+	_JsApiReporter.prototype.log = function(str) {
+	};
+	
+	_JsApiReporter.prototype.resultsForSpecs = function(specIds){
+	  var results = {};
+	  for (var i = 0; i < specIds.length; i++) {
+	    var specId = specIds[i];
+	    results[specId] = this.summarizeResult_(this.results_[specId]);
+	  }
+	  return results;
+	};
+	
+	_JsApiReporter.prototype.summarizeResult_ = function(result){
+	  var summaryMessages = [];
+	  var messagesLength = result.messages.length;
+	  for (var messageIndex = 0; messageIndex < messagesLength; messageIndex++) {
+	    var resultMessage = result.messages[messageIndex];
+	    summaryMessages.push({
+	      text: resultMessage.type == 'log' ? resultMessage.toString() : _undefined_,
+	      passed: resultMessage.passed ? resultMessage.passed() : true,
+	      type: resultMessage.type,
+	      message: resultMessage.message,
+	      trace: {
+	        stack: resultMessage.passed && !resultMessage.passed() ? resultMessage.trace.stack : _undefined_
+	      }
+	    });
+	  }
+	
+	  return {
+	    result : result.result,
+	    messages : summaryMessages
+	  };
+	};
+	
+	return _JsApiReporter;
 
-jasmine.JsApiReporter.prototype.suites = function() {
-  return this.suites_;
-};
-
-jasmine.JsApiReporter.prototype.summarize_ = function(suiteOrSpec) {
-  var isSuite = suiteOrSpec instanceof jasmine.Suite;
-  var summary = {
-    id: suiteOrSpec.id,
-    name: suiteOrSpec.description,
-    type: isSuite ? 'suite' : 'spec',
-    children: []
-  };
-  
-  if (isSuite) {
-    var children = suiteOrSpec.children();
-    for (var i = 0; i < children.length; i++) {
-      summary.children.push(this.summarize_(children[i]));
-    }
-  }
-  return summary;
-};
-
-jasmine.JsApiReporter.prototype.results = function() {
-  return this.results_;
-};
-
-jasmine.JsApiReporter.prototype.resultsForSpec = function(specId) {
-  return this.results_[specId];
-};
-
-//noinspection JSUnusedLocalSymbols
-jasmine.JsApiReporter.prototype.reportRunnerResults = function(runner) {
-  this.finished = true;
-};
-
-//noinspection JSUnusedLocalSymbols
-jasmine.JsApiReporter.prototype.reportSuiteResults = function(suite) {
-};
-
-//noinspection JSUnusedLocalSymbols
-jasmine.JsApiReporter.prototype.reportSpecResults = function(spec) {
-  this.results_[spec.id] = {
-    messages: spec.results().getItems(),
-    result: spec.results().failedCount > 0 ? "failed" : "passed"
-  };
-};
-
-//noinspection JSUnusedLocalSymbols
-jasmine.JsApiReporter.prototype.log = function(str) {
-};
-
-jasmine.JsApiReporter.prototype.resultsForSpecs = function(specIds){
-  var results = {};
-  for (var i = 0; i < specIds.length; i++) {
-    var specId = specIds[i];
-    results[specId] = this.summarizeResult_(this.results_[specId]);
-  }
-  return results;
-};
-
-jasmine.JsApiReporter.prototype.summarizeResult_ = function(result){
-  var summaryMessages = [];
-  var messagesLength = result.messages.length;
-  for (var messageIndex = 0; messageIndex < messagesLength; messageIndex++) {
-    var resultMessage = result.messages[messageIndex];
-    summaryMessages.push({
-      text: resultMessage.type == 'log' ? resultMessage.toString() : jasmine.undefined,
-      passed: resultMessage.passed ? resultMessage.passed() : true,
-      type: resultMessage.type,
-      message: resultMessage.message,
-      trace: {
-        stack: resultMessage.passed && !resultMessage.passed() ? resultMessage.trace.stack : jasmine.undefined
-      }
-    });
-  }
-
-  return {
-    result : result.result,
-    messages : summaryMessages
-  };
-};
+})();
 

--- a/src/Matchers.js
+++ b/src/Matchers.js
@@ -1,354 +1,361 @@
-/**
- * @constructor
- * @param {jasmine.Env} env
- * @param actual
- * @param {jasmine.Spec} spec
- */
-jasmine.Matchers = function(env, actual, spec, opt_isNot) {
-  this.env = env;
-  this.actual = actual;
-  this.spec = spec;
-  this.isNot = opt_isNot || false;
-  this.reportWasCalled_ = false;
-};
+jasmine.Matchers = (function(){ 
+	var _this = this /* @private scoped reference to "this".  (Avoids confusion/mistakes when scope of "this" changes due to events, apply, call, etc. */
+		, _undefined_  = jasmine.___undefined___ /* @private scoped reference to "undefined" */
+	;
 
-// todo: @deprecated as of Jasmine 0.11, remove soon [xw]
-jasmine.Matchers.pp = function(str) {
-  throw new Error("jasmine.Matchers.pp() is no longer supported, please use jasmine.pp() instead!");
-};
+	/**
+	 * @constructor
+	 * @param {jasmine.Env} env
+	 * @param actual
+	 * @param {jasmine.Spec} spec
+	 */
+	function _Matchers (env, actual, spec, opt_isNot) {
+	  this.env = env;
+	  this.actual = actual;
+	  this.spec = spec;
+	  this.isNot = opt_isNot || false;
+	  this.reportWasCalled_ = false;
+	};
+	
+	// todo: @deprecated as of Jasmine 0.11, remove soon [xw]
+	_Matchers.pp = function(str) {
+	  throw new Error("jasmine.Matchers.pp() is no longer supported, please use jasmine.pp() instead!");
+	};
+	
+	// todo: @deprecated Deprecated as of Jasmine 0.10. Rewrite your custom matchers to return true or false. [xw]
+	_Matchers.prototype.report = function(result, failing_message, details) {
+	  throw new Error("As of jasmine 0.11, custom matchers must be implemented differently -- please see jasmine docs");
+	};
+	
+	_Matchers.wrapInto_ = function(prototype, matchersClass) {
+	  for (var methodName in prototype) {
+	    if (methodName == 'report') continue;
+	    var orig = prototype[methodName];
+	    matchersClass.prototype[methodName] = _Matchers.matcherFn_(methodName, orig);
+	  }
+	};
+	
+	_Matchers.matcherFn_ = function(matcherName, matcherFunction) {
+	  return function() {
+	    var matcherArgs = jasmine.util.argsToArray(arguments);
+	    var result = matcherFunction.apply(this, arguments);
+	
+	    if (this.isNot) {
+	      result = !result;
+	    }
+	
+	    if (this.reportWasCalled_) return result;
+	
+	    var message;
+	    if (!result) {
+	      if (this.message) {
+	        message = this.message.apply(this, arguments);
+	        if (jasmine.isArray_(message)) {
+	          message = message[this.isNot ? 1 : 0];
+	        }
+	      } else {
+	        var englishyPredicate = matcherName.replace(/[A-Z]/g, function(s) { return ' ' + s.toLowerCase(); });
+	        message = "Expected " + jasmine.pp(this.actual) + (this.isNot ? " not " : " ") + englishyPredicate;
+	        if (matcherArgs.length > 0) {
+	          for (var i = 0; i < matcherArgs.length; i++) {
+	            if (i > 0) message += ",";
+	            message += " " + jasmine.pp(matcherArgs[i]);
+	          }
+	        }
+	        message += ".";
+	      }
+	    }
+	    var expectationResult = new jasmine.ExpectationResult({
+	      matcherName: matcherName,
+	      passed: result,
+	      expected: matcherArgs.length > 1 ? matcherArgs : matcherArgs[0],
+	      actual: this.actual,
+	      message: message
+	    });
+	    this.spec.addMatcherResult(expectationResult);
+	    return _undefined_;
+	  };
+	};
+	
+	
+	
+	
+	/**
+	 * toBe: compares the actual to the expected using ===
+	 * @param expected
+	 */
+	_Matchers.prototype.toBe = function(expected) {
+	  return this.actual === expected;
+	};
+	
+	/**
+	 * toNotBe: compares the actual to the expected using !==
+	 * @param expected
+	 * @deprecated as of 1.0. Use not.toBe() instead.
+	 */
+	_Matchers.prototype.toNotBe = function(expected) {
+	  return this.actual !== expected;
+	};
+	
+	/**
+	 * toEqual: compares the actual to the expected using common sense equality. Handles Objects, Arrays, etc.
+	 *
+	 * @param expected
+	 */
+	_Matchers.prototype.toEqual = function(expected) {
+	  return this.env.equals_(this.actual, expected);
+	};
+	
+	/**
+	 * toNotEqual: compares the actual to the expected using the ! of jasmine.Matchers.toEqual
+	 * @param expected
+	 * @deprecated as of 1.0. Use not.toNotEqual() instead.
+	 */
+	_Matchers.prototype.toNotEqual = function(expected) {
+	  return !this.env.equals_(this.actual, expected);
+	};
+	
+	/**
+	 * Matcher that compares the actual to the expected using a regular expression.  Constructs a RegExp, so takes
+	 * a pattern or a String.
+	 *
+	 * @param expected
+	 */
+	_Matchers.prototype.toMatch = function(expected) {
+	  return new RegExp(expected).test(this.actual);
+	};
+	
+	/**
+	 * Matcher that compares the actual to the expected using the boolean inverse of jasmine.Matchers.toMatch
+	 * @param expected
+	 * @deprecated as of 1.0. Use not.toMatch() instead.
+	 */
+	_Matchers.prototype.toNotMatch = function(expected) {
+	  return !(new RegExp(expected).test(this.actual));
+	};
+	
+	/**
+	 * Matcher that compares the actual to _undefined_.
+	 */
+	_Matchers.prototype.toBeDefined = function() {
+	  return (this.actual !== _undefined_);
+	};
+	
+	/**
+	 * Matcher that compares the actual to _undefined_.
+	 */
+	_Matchers.prototype.toBeUndefined = function() {
+	  return (this.actual === _undefined_);
+	};
+	
+	/**
+	 * Matcher that compares the actual to null.
+	 */
+	_Matchers.prototype.toBeNull = function() {
+	  return (this.actual === null);
+	};
+	
+	/**
+	 * Matcher that boolean not-nots the actual.
+	 */
+	_Matchers.prototype.toBeTruthy = function() {
+	  return !!this.actual;
+	};
+	
+	
+	/**
+	 * Matcher that boolean nots the actual.
+	 */
+	_Matchers.prototype.toBeFalsy = function() {
+	  return !this.actual;
+	};
+	
+	
+	/**
+	 * Matcher that checks to see if the actual, a Jasmine spy, was called.
+	 */
+	_Matchers.prototype.toHaveBeenCalled = function() {
+	  if (arguments.length > 0) {
+	    throw new Error('toHaveBeenCalled does not take arguments, use toHaveBeenCalledWith');
+	  }
+	
+	  if (!jasmine.isSpy(this.actual)) {
+	    throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
+	  }
+	
+	  this.message = function() {
+	    return [
+	      "Expected spy " + this.actual.identity + " to have been called.",
+	      "Expected spy " + this.actual.identity + " not to have been called."
+	    ];
+	  };
+	
+	  return this.actual.wasCalled;
+	};
+	
+	/** @deprecated Use expect(xxx).toHaveBeenCalled() instead */
+	_Matchers.prototype.wasCalled = _Matchers.prototype.toHaveBeenCalled;
+	
+	/**
+	 * Matcher that checks to see if the actual, a Jasmine spy, was not called.
+	 *
+	 * @deprecated Use expect(xxx).not.toHaveBeenCalled() instead
+	 */
+	_Matchers.prototype.wasNotCalled = function() {
+	  if (arguments.length > 0) {
+	    throw new Error('wasNotCalled does not take arguments');
+	  }
+	
+	  if (!jasmine.isSpy(this.actual)) {
+	    throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
+	  }
+	
+	  this.message = function() {
+	    return [
+	      "Expected spy " + this.actual.identity + " to not have been called.",
+	      "Expected spy " + this.actual.identity + " to have been called."
+	    ];
+	  };
+	
+	  return !this.actual.wasCalled;
+	};
+	
+	/**
+	 * Matcher that checks to see if the actual, a Jasmine spy, was called with a set of parameters.
+	 *
+	 * @example
+	 *
+	 */
+	_Matchers.prototype.toHaveBeenCalledWith = function() {
+	  var expectedArgs = jasmine.util.argsToArray(arguments);
+	  if (!jasmine.isSpy(this.actual)) {
+	    throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
+	  }
+	  this.message = function() {
+	    if (this.actual.callCount == 0) {
+	      // todo: what should the failure message for .not.toHaveBeenCalledWith() be? is this right? test better. [xw]
+	      return [
+	        "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but it was never called.",
+	        "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but it was."
+	      ];
+	    } else {
+	      return [
+	        "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall),
+	        "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall)
+	      ];
+	    }
+	  };
+	
+	  return this.env.contains_(this.actual.argsForCall, expectedArgs);
+	};
+	
+	/** @deprecated Use expect(xxx).toHaveBeenCalledWith() instead */
+	_Matchers.prototype.wasCalledWith = _Matchers.prototype.toHaveBeenCalledWith;
+	
+	/** @deprecated Use expect(xxx).not.toHaveBeenCalledWith() instead */
+	_Matchers.prototype.wasNotCalledWith = function() {
+	  var expectedArgs = jasmine.util.argsToArray(arguments);
+	  if (!jasmine.isSpy(this.actual)) {
+	    throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
+	  }
+	
+	  this.message = function() {
+	    return [
+	      "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but it was",
+	      "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but it was"
+	    ]
+	  };
+	
+	  return !this.env.contains_(this.actual.argsForCall, expectedArgs);
+	};
+	
+	/**
+	 * Matcher that checks that the expected item is an element in the actual Array.
+	 *
+	 * @param {Object} expected
+	 */
+	_Matchers.prototype.toContain = function(expected) {
+	  return this.env.contains_(this.actual, expected);
+	};
+	
+	/**
+	 * Matcher that checks that the expected item is NOT an element in the actual Array.
+	 *
+	 * @param {Object} expected
+	 * @deprecated as of 1.0. Use not.toNotContain() instead.
+	 */
+	_Matchers.prototype.toNotContain = function(expected) {
+	  return !this.env.contains_(this.actual, expected);
+	};
+	
+	_Matchers.prototype.toBeLessThan = function(expected) {
+	  return this.actual < expected;
+	};
+	
+	_Matchers.prototype.toBeGreaterThan = function(expected) {
+	  return this.actual > expected;
+	};
+	
+	/**
+	 * Matcher that checks that the expected exception was thrown by the actual.
+	 *
+	 * @param {String} expected
+	 */
+	_Matchers.prototype.toThrow = function(expected) {
+	  var result = false;
+	  var exception;
+	  if (typeof this.actual != 'function') {
+	    throw new Error('Actual is not a function');
+	  }
+	  try {
+	    this.actual();
+	  } catch (e) {
+	    exception = e;
+	  }
+	  if (exception) {
+	    result = (expected === _undefined_ || this.env.equals_(exception.message || exception, expected.message || expected));
+	  }
+	
+	  var not = this.isNot ? "not " : "";
+	
+	  this.message = function() {
+	    if (exception && (expected === _undefined_ || !this.env.equals_(exception.message || exception, expected.message || expected))) {
+	      return ["Expected function " + not + "to throw", expected ? expected.message || expected : " an exception", ", but it threw", exception.message || exception].join(' ');
+	    } else {
+	      return "Expected function to throw an exception.";
+	    }
+	  };
+	
+	  return result;
+	};
+	
+	_Matchers.Any = function(expectedClass) {
+	  this.expectedClass = expectedClass;
+	};
+	
+	_Matchers.Any.prototype.matches = function(other) {
+	  if (this.expectedClass == String) {
+	    return typeof other == 'string' || other instanceof String;
+	  }
+	
+	  if (this.expectedClass == Number) {
+	    return typeof other == 'number' || other instanceof Number;
+	  }
+	
+	  if (this.expectedClass == Function) {
+	    return typeof other == 'function' || other instanceof Function;
+	  }
+	
+	  if (this.expectedClass == Object) {
+	    return typeof other == 'object';
+	  }
+	
+	  return other instanceof this.expectedClass;
+	};
+	
+	_Matchers.Any.prototype.toString = function() {
+	  return '<jasmine.any(' + this.expectedClass + ')>';
+	};
 
-// todo: @deprecated Deprecated as of Jasmine 0.10. Rewrite your custom matchers to return true or false. [xw]
-jasmine.Matchers.prototype.report = function(result, failing_message, details) {
-  throw new Error("As of jasmine 0.11, custom matchers must be implemented differently -- please see jasmine docs");
-};
-
-jasmine.Matchers.wrapInto_ = function(prototype, matchersClass) {
-  for (var methodName in prototype) {
-    if (methodName == 'report') continue;
-    var orig = prototype[methodName];
-    matchersClass.prototype[methodName] = jasmine.Matchers.matcherFn_(methodName, orig);
-  }
-};
-
-jasmine.Matchers.matcherFn_ = function(matcherName, matcherFunction) {
-  return function() {
-    var matcherArgs = jasmine.util.argsToArray(arguments);
-    var result = matcherFunction.apply(this, arguments);
-
-    if (this.isNot) {
-      result = !result;
-    }
-
-    if (this.reportWasCalled_) return result;
-
-    var message;
-    if (!result) {
-      if (this.message) {
-        message = this.message.apply(this, arguments);
-        if (jasmine.isArray_(message)) {
-          message = message[this.isNot ? 1 : 0];
-        }
-      } else {
-        var englishyPredicate = matcherName.replace(/[A-Z]/g, function(s) { return ' ' + s.toLowerCase(); });
-        message = "Expected " + jasmine.pp(this.actual) + (this.isNot ? " not " : " ") + englishyPredicate;
-        if (matcherArgs.length > 0) {
-          for (var i = 0; i < matcherArgs.length; i++) {
-            if (i > 0) message += ",";
-            message += " " + jasmine.pp(matcherArgs[i]);
-          }
-        }
-        message += ".";
-      }
-    }
-    var expectationResult = new jasmine.ExpectationResult({
-      matcherName: matcherName,
-      passed: result,
-      expected: matcherArgs.length > 1 ? matcherArgs : matcherArgs[0],
-      actual: this.actual,
-      message: message
-    });
-    this.spec.addMatcherResult(expectationResult);
-    return jasmine.undefined;
-  };
-};
-
-
-
-
-/**
- * toBe: compares the actual to the expected using ===
- * @param expected
- */
-jasmine.Matchers.prototype.toBe = function(expected) {
-  return this.actual === expected;
-};
-
-/**
- * toNotBe: compares the actual to the expected using !==
- * @param expected
- * @deprecated as of 1.0. Use not.toBe() instead.
- */
-jasmine.Matchers.prototype.toNotBe = function(expected) {
-  return this.actual !== expected;
-};
-
-/**
- * toEqual: compares the actual to the expected using common sense equality. Handles Objects, Arrays, etc.
- *
- * @param expected
- */
-jasmine.Matchers.prototype.toEqual = function(expected) {
-  return this.env.equals_(this.actual, expected);
-};
-
-/**
- * toNotEqual: compares the actual to the expected using the ! of jasmine.Matchers.toEqual
- * @param expected
- * @deprecated as of 1.0. Use not.toNotEqual() instead.
- */
-jasmine.Matchers.prototype.toNotEqual = function(expected) {
-  return !this.env.equals_(this.actual, expected);
-};
-
-/**
- * Matcher that compares the actual to the expected using a regular expression.  Constructs a RegExp, so takes
- * a pattern or a String.
- *
- * @param expected
- */
-jasmine.Matchers.prototype.toMatch = function(expected) {
-  return new RegExp(expected).test(this.actual);
-};
-
-/**
- * Matcher that compares the actual to the expected using the boolean inverse of jasmine.Matchers.toMatch
- * @param expected
- * @deprecated as of 1.0. Use not.toMatch() instead.
- */
-jasmine.Matchers.prototype.toNotMatch = function(expected) {
-  return !(new RegExp(expected).test(this.actual));
-};
-
-/**
- * Matcher that compares the actual to jasmine.undefined.
- */
-jasmine.Matchers.prototype.toBeDefined = function() {
-  return (this.actual !== jasmine.undefined);
-};
-
-/**
- * Matcher that compares the actual to jasmine.undefined.
- */
-jasmine.Matchers.prototype.toBeUndefined = function() {
-  return (this.actual === jasmine.undefined);
-};
-
-/**
- * Matcher that compares the actual to null.
- */
-jasmine.Matchers.prototype.toBeNull = function() {
-  return (this.actual === null);
-};
-
-/**
- * Matcher that boolean not-nots the actual.
- */
-jasmine.Matchers.prototype.toBeTruthy = function() {
-  return !!this.actual;
-};
-
-
-/**
- * Matcher that boolean nots the actual.
- */
-jasmine.Matchers.prototype.toBeFalsy = function() {
-  return !this.actual;
-};
-
-
-/**
- * Matcher that checks to see if the actual, a Jasmine spy, was called.
- */
-jasmine.Matchers.prototype.toHaveBeenCalled = function() {
-  if (arguments.length > 0) {
-    throw new Error('toHaveBeenCalled does not take arguments, use toHaveBeenCalledWith');
-  }
-
-  if (!jasmine.isSpy(this.actual)) {
-    throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
-  }
-
-  this.message = function() {
-    return [
-      "Expected spy " + this.actual.identity + " to have been called.",
-      "Expected spy " + this.actual.identity + " not to have been called."
-    ];
-  };
-
-  return this.actual.wasCalled;
-};
-
-/** @deprecated Use expect(xxx).toHaveBeenCalled() instead */
-jasmine.Matchers.prototype.wasCalled = jasmine.Matchers.prototype.toHaveBeenCalled;
-
-/**
- * Matcher that checks to see if the actual, a Jasmine spy, was not called.
- *
- * @deprecated Use expect(xxx).not.toHaveBeenCalled() instead
- */
-jasmine.Matchers.prototype.wasNotCalled = function() {
-  if (arguments.length > 0) {
-    throw new Error('wasNotCalled does not take arguments');
-  }
-
-  if (!jasmine.isSpy(this.actual)) {
-    throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
-  }
-
-  this.message = function() {
-    return [
-      "Expected spy " + this.actual.identity + " to not have been called.",
-      "Expected spy " + this.actual.identity + " to have been called."
-    ];
-  };
-
-  return !this.actual.wasCalled;
-};
-
-/**
- * Matcher that checks to see if the actual, a Jasmine spy, was called with a set of parameters.
- *
- * @example
- *
- */
-jasmine.Matchers.prototype.toHaveBeenCalledWith = function() {
-  var expectedArgs = jasmine.util.argsToArray(arguments);
-  if (!jasmine.isSpy(this.actual)) {
-    throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
-  }
-  this.message = function() {
-    if (this.actual.callCount == 0) {
-      // todo: what should the failure message for .not.toHaveBeenCalledWith() be? is this right? test better. [xw]
-      return [
-        "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but it was never called.",
-        "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but it was."
-      ];
-    } else {
-      return [
-        "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall),
-        "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall)
-      ];
-    }
-  };
-
-  return this.env.contains_(this.actual.argsForCall, expectedArgs);
-};
-
-/** @deprecated Use expect(xxx).toHaveBeenCalledWith() instead */
-jasmine.Matchers.prototype.wasCalledWith = jasmine.Matchers.prototype.toHaveBeenCalledWith;
-
-/** @deprecated Use expect(xxx).not.toHaveBeenCalledWith() instead */
-jasmine.Matchers.prototype.wasNotCalledWith = function() {
-  var expectedArgs = jasmine.util.argsToArray(arguments);
-  if (!jasmine.isSpy(this.actual)) {
-    throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
-  }
-
-  this.message = function() {
-    return [
-      "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but it was",
-      "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but it was"
-    ]
-  };
-
-  return !this.env.contains_(this.actual.argsForCall, expectedArgs);
-};
-
-/**
- * Matcher that checks that the expected item is an element in the actual Array.
- *
- * @param {Object} expected
- */
-jasmine.Matchers.prototype.toContain = function(expected) {
-  return this.env.contains_(this.actual, expected);
-};
-
-/**
- * Matcher that checks that the expected item is NOT an element in the actual Array.
- *
- * @param {Object} expected
- * @deprecated as of 1.0. Use not.toNotContain() instead.
- */
-jasmine.Matchers.prototype.toNotContain = function(expected) {
-  return !this.env.contains_(this.actual, expected);
-};
-
-jasmine.Matchers.prototype.toBeLessThan = function(expected) {
-  return this.actual < expected;
-};
-
-jasmine.Matchers.prototype.toBeGreaterThan = function(expected) {
-  return this.actual > expected;
-};
-
-/**
- * Matcher that checks that the expected exception was thrown by the actual.
- *
- * @param {String} expected
- */
-jasmine.Matchers.prototype.toThrow = function(expected) {
-  var result = false;
-  var exception;
-  if (typeof this.actual != 'function') {
-    throw new Error('Actual is not a function');
-  }
-  try {
-    this.actual();
-  } catch (e) {
-    exception = e;
-  }
-  if (exception) {
-    result = (expected === jasmine.undefined || this.env.equals_(exception.message || exception, expected.message || expected));
-  }
-
-  var not = this.isNot ? "not " : "";
-
-  this.message = function() {
-    if (exception && (expected === jasmine.undefined || !this.env.equals_(exception.message || exception, expected.message || expected))) {
-      return ["Expected function " + not + "to throw", expected ? expected.message || expected : " an exception", ", but it threw", exception.message || exception].join(' ');
-    } else {
-      return "Expected function to throw an exception.";
-    }
-  };
-
-  return result;
-};
-
-jasmine.Matchers.Any = function(expectedClass) {
-  this.expectedClass = expectedClass;
-};
-
-jasmine.Matchers.Any.prototype.matches = function(other) {
-  if (this.expectedClass == String) {
-    return typeof other == 'string' || other instanceof String;
-  }
-
-  if (this.expectedClass == Number) {
-    return typeof other == 'number' || other instanceof Number;
-  }
-
-  if (this.expectedClass == Function) {
-    return typeof other == 'function' || other instanceof Function;
-  }
-
-  if (this.expectedClass == Object) {
-    return typeof other == 'object';
-  }
-
-  return other instanceof this.expectedClass;
-};
-
-jasmine.Matchers.Any.prototype.toString = function() {
-  return '<jasmine.any(' + this.expectedClass + ')>';
-};
-
+	return _Matchers;
+})();

--- a/src/PrettyPrinter.js
+++ b/src/PrettyPrinter.js
@@ -1,71 +1,87 @@
-/**
- * Base class for pretty printing for expectation results.
- */
-jasmine.PrettyPrinter = function() {
-  this.ppNestLevel_ = 0;
-};
+jasmine.PrettyPrinter = (function(){ 
+	var _this = this /* @private scoped reference to "this".  (Avoids confusion/mistakes when scope of "this" changes due to events, apply, call, etc. */
+		, _undefined_  = jasmine.___undefined___ /* @private scoped reference to "undefined" */
+	;
 
-/**
- * Formats a value in a nice, human-readable string.
- *
- * @param value
- */
-jasmine.PrettyPrinter.prototype.format = function(value) {
-  if (this.ppNestLevel_ > 40) {
-    throw new Error('jasmine.PrettyPrinter: format() nested too deeply!');
-  }
-
-  this.ppNestLevel_++;
-  try {
-    if (value === jasmine.undefined) {
-      this.emitScalar('undefined');
-    } else if (value === null) {
-      this.emitScalar('null');
-    } else if (value === jasmine.getGlobal()) {
-      this.emitScalar('<global>');
-    } else if (value instanceof jasmine.Matchers.Any) {
-      this.emitScalar(value.toString());
-    } else if (typeof value === 'string') {
-      this.emitString(value);
-    } else if (jasmine.isSpy(value)) {
-      this.emitScalar("spy on " + value.identity);
-    } else if (value instanceof RegExp) {
-      this.emitScalar(value.toString());
-    } else if (typeof value === 'function') {
-      this.emitScalar('Function');
-    } else if (typeof value.nodeType === 'number') {
-      this.emitScalar('HTMLNode');
-    } else if (value instanceof Date) {
-      this.emitScalar('Date(' + value + ')');
-    } else if (value.__Jasmine_been_here_before__) {
-      this.emitScalar('<circular reference: ' + (jasmine.isArray_(value) ? 'Array' : 'Object') + '>');
-    } else if (jasmine.isArray_(value) || typeof value == 'object') {
-      value.__Jasmine_been_here_before__ = true;
-      if (jasmine.isArray_(value)) {
-        this.emitArray(value);
-      } else {
-        this.emitObject(value);
-      }
-      delete value.__Jasmine_been_here_before__;
-    } else {
-      this.emitScalar(value.toString());
-    }
-  } finally {
-    this.ppNestLevel_--;
-  }
-};
-
-jasmine.PrettyPrinter.prototype.iterateObject = function(obj, fn) {
-  for (var property in obj) {
-    if (property == '__Jasmine_been_here_before__') continue;
-    fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) != null) : false);
-  }
-};
-
-jasmine.PrettyPrinter.prototype.emitArray = jasmine.unimplementedMethod_;
-jasmine.PrettyPrinter.prototype.emitObject = jasmine.unimplementedMethod_;
-jasmine.PrettyPrinter.prototype.emitScalar = jasmine.unimplementedMethod_;
-jasmine.PrettyPrinter.prototype.emitString = jasmine.unimplementedMethod_;
+	/**
+	 * @private
+	 */
+	function _unimplementedMethod_() {
+	  throw new Error("unimplemented method");
+	};
+	
+	
+	/**
+	 * Base class for pretty printing for expectation results.
+	 */
+	function _PrettyPrinter () {
+	  this.ppNestLevel_ = 0;
+	};
+	
+	/**
+	 * Formats a value in a nice, human-readable string.
+	 *
+	 * @param value
+	 */
+	_PrettyPrinter.prototype.format = function(value) {
+	  if (this.ppNestLevel_ > 40) {
+	    throw new Error('_PrettyPrinter: format() nested too deeply!');
+	  }
+	
+	  this.ppNestLevel_++;
+	  try {
+	    if (value === _undefined_) {
+	      this.emitScalar('undefined');
+	    } else if (value === null) {
+	      this.emitScalar('null');
+	    } else if (value === jasmine.getGlobal()) {
+	      this.emitScalar('<global>');
+	    } else if (value instanceof jasmine.Matchers.Any) {
+	      this.emitScalar(value.toString());
+	    } else if (typeof value === 'string') {
+	      this.emitString(value);
+	    } else if (jasmine.isSpy(value)) {
+	      this.emitScalar("spy on " + value.identity);
+	    } else if (value instanceof RegExp) {
+	      this.emitScalar(value.toString());
+	    } else if (typeof value === 'function') {
+	      this.emitScalar('Function');
+	    } else if (typeof value.nodeType === 'number') {
+	      this.emitScalar('HTMLNode');
+	    } else if (value instanceof Date) {
+	      this.emitScalar('Date(' + value + ')');
+	    } else if (value.__Jasmine_been_here_before__) {
+	      this.emitScalar('<circular reference: ' + (jasmine.isArray_(value) ? 'Array' : 'Object') + '>');
+	    } else if (jasmine.isArray_(value) || typeof value == 'object') {
+	      value.__Jasmine_been_here_before__ = true;
+	      if (jasmine.isArray_(value)) {
+	        this.emitArray(value);
+	      } else {
+	        this.emitObject(value);
+	      }
+	      delete value.__Jasmine_been_here_before__;
+	    } else {
+	      this.emitScalar(value.toString());
+	    }
+	  } finally {
+	    this.ppNestLevel_--;
+	  }
+	};
+	
+	_PrettyPrinter.prototype.iterateObject = function(obj, fn) {
+	  for (var property in obj) {
+	    if (property == '__Jasmine_been_here_before__') continue;
+	    fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) != null) : false);
+	  }
+	};
+	
+	_PrettyPrinter.prototype.emitArray = _unimplementedMethod_;
+	_PrettyPrinter.prototype.emitObject = _unimplementedMethod_;
+	_PrettyPrinter.prototype.emitScalar = _unimplementedMethod_;
+	_PrettyPrinter.prototype.emitString = _unimplementedMethod_;
+	
+	return _PrettyPrinter;
+})();
 
 jasmine.StringPrettyPrinter = function() {
   jasmine.PrettyPrinter.call(this);

--- a/src/Spec.js
+++ b/src/Spec.js
@@ -1,242 +1,250 @@
-/**
- * Internal representation of a Jasmine specification, or test.
- *
- * @constructor
- * @param {jasmine.Env} env
- * @param {jasmine.Suite} suite
- * @param {String} description
- */
-jasmine.Spec = function(env, suite, description) {
-  if (!env) {
-    throw new Error('jasmine.Env() required');
-  }
-  if (!suite) {
-    throw new Error('jasmine.Suite() required');
-  }
-  var spec = this;
-  spec.id = env.nextSpecId ? env.nextSpecId() : null;
-  spec.env = env;
-  spec.suite = suite;
-  spec.description = description;
-  spec.queue = new jasmine.Queue(env);
+jasmine.Spec = (function(){ 
+	var _this = this /* @private scoped reference to "this".  (Avoids confusion/mistakes when scope of "this" changes due to events, apply, call, etc. */
+		, _undefined_  = jasmine.___undefined___ /* @private scoped reference to "undefined" */
+	;
 
-  spec.afterCallbacks = [];
-  spec.spies_ = [];
+	/**
+	 * Internal representation of a Jasmine specification, or test.
+	 *
+	 * @constructor
+	 * @param {jasmine.Env} env
+	 * @param {jasmine.Suite} suite
+	 * @param {String} description
+	 */
+	function _Spec(env, suite, description) {
+	  if (!env) {
+	    throw new Error('jasmine.Env() required');
+	  }
+	  if (!suite) {
+	    throw new Error('jasmine.Suite() required');
+	  }
+	  var spec = this;
+	  spec.id = env.nextSpecId ? env.nextSpecId() : null;
+	  spec.env = env;
+	  spec.suite = suite;
+	  spec.description = description;
+	  spec.queue = new jasmine.Queue(env);
+	
+	  spec.afterCallbacks = [];
+	  spec.spies_ = [];
+	
+	  spec.results_ = new jasmine.NestedResults();
+	  spec.results_.description = description;
+	  spec.matchersClass = null;
+	};
+	
+	_Spec.prototype.getFullName = function() {
+	  return this.suite.getFullName() + ' ' + this.description + '.';
+	};
+	
+	
+	_Spec.prototype.results = function() {
+	  return this.results_;
+	};
+	
+	/**
+	 * All parameters are pretty-printed and concatenated together, then written to the spec's output.
+	 *
+	 * Be careful not to leave calls to <code>jasmine.log</code> in production code.
+	 */
+	_Spec.prototype.log = function() {
+	  return this.results_.log(arguments);
+	};
+	
+	_Spec.prototype.runs = function (func) {
+	  var block = new jasmine.Block(this.env, func, this);
+	  this.addToQueue(block);
+	  return this;
+	};
+	
+	_Spec.prototype.addToQueue = function (block) {
+	  if (this.queue.isRunning()) {
+	    this.queue.insertNext(block);
+	  } else {
+	    this.queue.add(block);
+	  }
+	};
+	
+	/**
+	 * @param {jasmine.ExpectationResult} result
+	 */
+	_Spec.prototype.addMatcherResult = function(result) {
+	  this.results_.addResult(result);
+	};
+	
+	_Spec.prototype.expect = function(actual) {
+	  var positive = new (this.getMatchersClass_())(this.env, actual, this);
+	  positive.not = new (this.getMatchersClass_())(this.env, actual, this, true);
+	  return positive;
+	};
+	
+	/**
+	 * Waits a fixed time period before moving to the next block.
+	 *
+	 * @deprecated Use waitsFor() instead
+	 * @param {Number} timeout milliseconds to wait
+	 */
+	_Spec.prototype.waits = function(timeout) {
+	  var waitsFunc = new jasmine.WaitsBlock(this.env, timeout, this);
+	  this.addToQueue(waitsFunc);
+	  return this;
+	};
+	
+	/**
+	 * Waits for the latchFunction to return true before proceeding to the next block.
+	 *
+	 * @param {Function} latchFunction
+	 * @param {String} optional_timeoutMessage
+	 * @param {Number} optional_timeout
+	 */
+	_Spec.prototype.waitsFor = function(latchFunction, optional_timeoutMessage, optional_timeout) {
+	  var latchFunction_ = null;
+	  var optional_timeoutMessage_ = null;
+	  var optional_timeout_ = null;
+	
+	  for (var i = 0; i < arguments.length; i++) {
+	    var arg = arguments[i];
+	    switch (typeof arg) {
+	      case 'function':
+	        latchFunction_ = arg;
+	        break;
+	      case 'string':
+	        optional_timeoutMessage_ = arg;
+	        break;
+	      case 'number':
+	        optional_timeout_ = arg;
+	        break;
+	    }
+	  }
+	
+	  var waitsForFunc = new jasmine.WaitsForBlock(this.env, optional_timeout_, latchFunction_, optional_timeoutMessage_, this);
+	  this.addToQueue(waitsForFunc);
+	  return this;
+	};
+	
+	_Spec.prototype.fail = function (e) {
+	  var expectationResult = new jasmine.ExpectationResult({
+	    passed: false,
+	    message: e ? jasmine.util.formatException(e) : 'Exception'
+	  });
+	  this.results_.addResult(expectationResult);
+	};
+	
+	_Spec.prototype.getMatchersClass_ = function() {
+	  return this.matchersClass || this.env.matchersClass;
+	};
+	
+	_Spec.prototype.addMatchers = function(matchersPrototype) {
+	  var parent = this.getMatchersClass_();
+	  var newMatchersClass = function() {
+	    parent.apply(this, arguments);
+	  };
+	  jasmine.util.inherit(newMatchersClass, parent);
+	  jasmine.Matchers.wrapInto_(matchersPrototype, newMatchersClass);
+	  this.matchersClass = newMatchersClass;
+	};
+	
+	_Spec.prototype.finishCallback = function() {
+	  this.env.reporter.reportSpecResults(this);
+	};
+	
+	_Spec.prototype.finish = function(onComplete) {
+	  this.removeAllSpies();
+	  this.finishCallback();
+	  if (onComplete) {
+	    onComplete();
+	  }
+	};
+	
+	_Spec.prototype.after = function(doAfter) {
+	  if (this.queue.isRunning()) {
+	    this.queue.add(new jasmine.Block(this.env, doAfter, this));
+	  } else {
+	    this.afterCallbacks.unshift(doAfter);
+	  }
+	};
+	
+	_Spec.prototype.execute = function(onComplete) {
+	  var spec = this;
+	  if (!spec.env.specFilter(spec)) {
+	    spec.results_.skipped = true;
+	    spec.finish(onComplete);
+	    return;
+	  }
+	
+	  this.env.reporter.reportSpecStarting(this);
+	
+	  spec.env.currentSpec = spec;
+	
+	  spec.addBeforesAndAftersToQueue();
+	
+	  spec.queue.start(function () {
+	    spec.finish(onComplete);
+	  });
+	};
+	
+	_Spec.prototype.addBeforesAndAftersToQueue = function() {
+	  var runner = this.env.currentRunner();
+	  var i;
+	
+	  for (var suite = this.suite; suite; suite = suite.parentSuite) {
+	    for (i = 0; i < suite.before_.length; i++) {
+	      this.queue.addBefore(new jasmine.Block(this.env, suite.before_[i], this));
+	    }
+	  }
+	  for (i = 0; i < runner.before_.length; i++) {
+	    this.queue.addBefore(new jasmine.Block(this.env, runner.before_[i], this));
+	  }
+	  for (i = 0; i < this.afterCallbacks.length; i++) {
+	    this.queue.add(new jasmine.Block(this.env, this.afterCallbacks[i], this));
+	  }
+	  for (suite = this.suite; suite; suite = suite.parentSuite) {
+	    for (i = 0; i < suite.after_.length; i++) {
+	      this.queue.add(new jasmine.Block(this.env, suite.after_[i], this));
+	    }
+	  }
+	  for (i = 0; i < runner.after_.length; i++) {
+	    this.queue.add(new jasmine.Block(this.env, runner.after_[i], this));
+	  }
+	};
+	
+	_Spec.prototype.explodes = function() {
+	  throw 'explodes function should not have been called';
+	};
+	
+	_Spec.prototype.spyOn = function(obj, methodName, ignoreMethodDoesntExist) {
+	  if (obj == _undefined_) {
+	    throw "spyOn could not find an object to spy upon for " + methodName + "()";
+	  }
+	
+	  if (!ignoreMethodDoesntExist && obj[methodName] === _undefined_) {
+	    throw methodName + '() method does not exist';
+	  }
+	
+	  if (!ignoreMethodDoesntExist && obj[methodName] && obj[methodName].isSpy) {
+	    throw new Error(methodName + ' has already been spied upon');
+	  }
+	
+	  var spyObj = jasmine.createSpy(methodName);
+	
+	  this.spies_.push(spyObj);
+	  spyObj.baseObj = obj;
+	  spyObj.methodName = methodName;
+	  spyObj.originalValue = obj[methodName];
+	
+	  obj[methodName] = spyObj;
+	
+	  return spyObj;
+	};
+	
+	_Spec.prototype.removeAllSpies = function() {
+	  for (var i = 0; i < this.spies_.length; i++) {
+	    var spy = this.spies_[i];
+	    spy.baseObj[spy.methodName] = spy.originalValue;
+	  }
+	  this.spies_ = [];
+	};
+	
+	return _Spec;
 
-  spec.results_ = new jasmine.NestedResults();
-  spec.results_.description = description;
-  spec.matchersClass = null;
-};
-
-jasmine.Spec.prototype.getFullName = function() {
-  return this.suite.getFullName() + ' ' + this.description + '.';
-};
-
-
-jasmine.Spec.prototype.results = function() {
-  return this.results_;
-};
-
-/**
- * All parameters are pretty-printed and concatenated together, then written to the spec's output.
- *
- * Be careful not to leave calls to <code>jasmine.log</code> in production code.
- */
-jasmine.Spec.prototype.log = function() {
-  return this.results_.log(arguments);
-};
-
-jasmine.Spec.prototype.runs = function (func) {
-  var block = new jasmine.Block(this.env, func, this);
-  this.addToQueue(block);
-  return this;
-};
-
-jasmine.Spec.prototype.addToQueue = function (block) {
-  if (this.queue.isRunning()) {
-    this.queue.insertNext(block);
-  } else {
-    this.queue.add(block);
-  }
-};
-
-/**
- * @param {jasmine.ExpectationResult} result
- */
-jasmine.Spec.prototype.addMatcherResult = function(result) {
-  this.results_.addResult(result);
-};
-
-jasmine.Spec.prototype.expect = function(actual) {
-  var positive = new (this.getMatchersClass_())(this.env, actual, this);
-  positive.not = new (this.getMatchersClass_())(this.env, actual, this, true);
-  return positive;
-};
-
-/**
- * Waits a fixed time period before moving to the next block.
- *
- * @deprecated Use waitsFor() instead
- * @param {Number} timeout milliseconds to wait
- */
-jasmine.Spec.prototype.waits = function(timeout) {
-  var waitsFunc = new jasmine.WaitsBlock(this.env, timeout, this);
-  this.addToQueue(waitsFunc);
-  return this;
-};
-
-/**
- * Waits for the latchFunction to return true before proceeding to the next block.
- *
- * @param {Function} latchFunction
- * @param {String} optional_timeoutMessage
- * @param {Number} optional_timeout
- */
-jasmine.Spec.prototype.waitsFor = function(latchFunction, optional_timeoutMessage, optional_timeout) {
-  var latchFunction_ = null;
-  var optional_timeoutMessage_ = null;
-  var optional_timeout_ = null;
-
-  for (var i = 0; i < arguments.length; i++) {
-    var arg = arguments[i];
-    switch (typeof arg) {
-      case 'function':
-        latchFunction_ = arg;
-        break;
-      case 'string':
-        optional_timeoutMessage_ = arg;
-        break;
-      case 'number':
-        optional_timeout_ = arg;
-        break;
-    }
-  }
-
-  var waitsForFunc = new jasmine.WaitsForBlock(this.env, optional_timeout_, latchFunction_, optional_timeoutMessage_, this);
-  this.addToQueue(waitsForFunc);
-  return this;
-};
-
-jasmine.Spec.prototype.fail = function (e) {
-  var expectationResult = new jasmine.ExpectationResult({
-    passed: false,
-    message: e ? jasmine.util.formatException(e) : 'Exception'
-  });
-  this.results_.addResult(expectationResult);
-};
-
-jasmine.Spec.prototype.getMatchersClass_ = function() {
-  return this.matchersClass || this.env.matchersClass;
-};
-
-jasmine.Spec.prototype.addMatchers = function(matchersPrototype) {
-  var parent = this.getMatchersClass_();
-  var newMatchersClass = function() {
-    parent.apply(this, arguments);
-  };
-  jasmine.util.inherit(newMatchersClass, parent);
-  jasmine.Matchers.wrapInto_(matchersPrototype, newMatchersClass);
-  this.matchersClass = newMatchersClass;
-};
-
-jasmine.Spec.prototype.finishCallback = function() {
-  this.env.reporter.reportSpecResults(this);
-};
-
-jasmine.Spec.prototype.finish = function(onComplete) {
-  this.removeAllSpies();
-  this.finishCallback();
-  if (onComplete) {
-    onComplete();
-  }
-};
-
-jasmine.Spec.prototype.after = function(doAfter) {
-  if (this.queue.isRunning()) {
-    this.queue.add(new jasmine.Block(this.env, doAfter, this));
-  } else {
-    this.afterCallbacks.unshift(doAfter);
-  }
-};
-
-jasmine.Spec.prototype.execute = function(onComplete) {
-  var spec = this;
-  if (!spec.env.specFilter(spec)) {
-    spec.results_.skipped = true;
-    spec.finish(onComplete);
-    return;
-  }
-
-  this.env.reporter.reportSpecStarting(this);
-
-  spec.env.currentSpec = spec;
-
-  spec.addBeforesAndAftersToQueue();
-
-  spec.queue.start(function () {
-    spec.finish(onComplete);
-  });
-};
-
-jasmine.Spec.prototype.addBeforesAndAftersToQueue = function() {
-  var runner = this.env.currentRunner();
-  var i;
-
-  for (var suite = this.suite; suite; suite = suite.parentSuite) {
-    for (i = 0; i < suite.before_.length; i++) {
-      this.queue.addBefore(new jasmine.Block(this.env, suite.before_[i], this));
-    }
-  }
-  for (i = 0; i < runner.before_.length; i++) {
-    this.queue.addBefore(new jasmine.Block(this.env, runner.before_[i], this));
-  }
-  for (i = 0; i < this.afterCallbacks.length; i++) {
-    this.queue.add(new jasmine.Block(this.env, this.afterCallbacks[i], this));
-  }
-  for (suite = this.suite; suite; suite = suite.parentSuite) {
-    for (i = 0; i < suite.after_.length; i++) {
-      this.queue.add(new jasmine.Block(this.env, suite.after_[i], this));
-    }
-  }
-  for (i = 0; i < runner.after_.length; i++) {
-    this.queue.add(new jasmine.Block(this.env, runner.after_[i], this));
-  }
-};
-
-jasmine.Spec.prototype.explodes = function() {
-  throw 'explodes function should not have been called';
-};
-
-jasmine.Spec.prototype.spyOn = function(obj, methodName, ignoreMethodDoesntExist) {
-  if (obj == jasmine.undefined) {
-    throw "spyOn could not find an object to spy upon for " + methodName + "()";
-  }
-
-  if (!ignoreMethodDoesntExist && obj[methodName] === jasmine.undefined) {
-    throw methodName + '() method does not exist';
-  }
-
-  if (!ignoreMethodDoesntExist && obj[methodName] && obj[methodName].isSpy) {
-    throw new Error(methodName + ' has already been spied upon');
-  }
-
-  var spyObj = jasmine.createSpy(methodName);
-
-  this.spies_.push(spyObj);
-  spyObj.baseObj = obj;
-  spyObj.methodName = methodName;
-  spyObj.originalValue = obj[methodName];
-
-  obj[methodName] = spyObj;
-
-  return spyObj;
-};
-
-jasmine.Spec.prototype.removeAllSpies = function() {
-  for (var i = 0; i < this.spies_.length; i++) {
-    var spy = this.spies_[i];
-    spy.baseObj[spy.methodName] = spy.originalValue;
-  }
-  this.spies_ = [];
-};
-
+})();

--- a/src/base.js
+++ b/src/base.js
@@ -3,587 +3,577 @@
  *
  * @namespace
  */
-var jasmine = {};
+var jasmine = (function(){
+	var _this = this;
 
-/**
- * @private
- */
-jasmine.unimplementedMethod_ = function() {
-  throw new Error("unimplemented method");
-};
-
-/**
- * Use <code>jasmine.undefined</code> instead of <code>undefined</code>, since <code>undefined</code> is just
- * a plain old variable and may be redefined by somebody else.
- *
- * @private
- */
-jasmine.undefined = jasmine.___undefined___;
-
-/**
- * Default interval in milliseconds for event loop yields (e.g. to allow network activity or to refresh the screen with the HTML-based runner). Small values here may result in slow test running. Zero means no updates until all tests have completed.
- *
- */
-jasmine.DEFAULT_UPDATE_INTERVAL = 250;
-
-/**
- * Default timeout interval in milliseconds for waitsFor() blocks.
- */
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
-
-jasmine.getGlobal = function() {
-  function getGlobal() {
-    return this;
-  }
-
-  return getGlobal();
-};
-
-/**
- * Allows for bound functions to be compared.  Internal use only.
- *
- * @ignore
- * @private
- * @param base {Object} bound 'this' for the function
- * @param name {Function} function to find
- */
-jasmine.bindOriginal_ = function(base, name) {
-  var original = base[name];
-  if (original.apply) {
-    return function() {
-      return original.apply(base, arguments);
-    };
-  } else {
-    // IE support
-    return jasmine.getGlobal()[name];
-  }
-};
-
-jasmine.setTimeout = jasmine.bindOriginal_(jasmine.getGlobal(), 'setTimeout');
-jasmine.clearTimeout = jasmine.bindOriginal_(jasmine.getGlobal(), 'clearTimeout');
-jasmine.setInterval = jasmine.bindOriginal_(jasmine.getGlobal(), 'setInterval');
-jasmine.clearInterval = jasmine.bindOriginal_(jasmine.getGlobal(), 'clearInterval');
-
-jasmine.MessageResult = function(values) {
-  this.type = 'log';
-  this.values = values;
-  this.trace = new Error(); // todo: test better
-};
-
-jasmine.MessageResult.prototype.toString = function() {
-  var text = "";
-  for(var i = 0; i < this.values.length; i++) {
-    if (i > 0) text += " ";
-    if (jasmine.isString_(this.values[i])) {
-      text += this.values[i];
-    } else {
-      text += jasmine.pp(this.values[i]);
-    }
-  }
-  return text;
-};
-
-jasmine.ExpectationResult = function(params) {
-  this.type = 'expect';
-  this.matcherName = params.matcherName;
-  this.passed_ = params.passed;
-  this.expected = params.expected;
-  this.actual = params.actual;
-
-  this.message = this.passed_ ? 'Passed.' : params.message;
-  this.trace = this.passed_ ? '' : new Error(this.message);
-};
-
-jasmine.ExpectationResult.prototype.toString = function () {
-  return this.message;
-};
-
-jasmine.ExpectationResult.prototype.passed = function () {
-  return this.passed_;
-};
-
-/**
- * Getter for the Jasmine environment. Ensures one gets created
- */
-jasmine.getEnv = function() {
-  return jasmine.currentEnv_ = jasmine.currentEnv_ || new jasmine.Env();
-};
-
-/**
- * @ignore
- * @private
- * @param value
- * @returns {Boolean}
- */
-jasmine.isArray_ = function(value) {
-  return jasmine.isA_("Array", value);  
-};
-
-/**
- * @ignore
- * @private
- * @param value
- * @returns {Boolean}
- */
-jasmine.isString_ = function(value) {
-  return jasmine.isA_("String", value);
-};
-
-/**
- * @ignore
- * @private
- * @param value
- * @returns {Boolean}
- */
-jasmine.isNumber_ = function(value) {
-  return jasmine.isA_("Number", value);
-};
-
-/**
- * @ignore
- * @private
- * @param {String} typeName
- * @param value
- * @returns {Boolean}
- */
-jasmine.isA_ = function(typeName, value) {
-  return Object.prototype.toString.apply(value) === '[object ' + typeName + ']';
-};
-
-/**
- * Pretty printer for expecations.  Takes any object and turns it into a human-readable string.
- *
- * @param value {Object} an object to be outputted
- * @returns {String}
- */
-jasmine.pp = function(value) {
-  var stringPrettyPrinter = new jasmine.StringPrettyPrinter();
-  stringPrettyPrinter.format(value);
-  return stringPrettyPrinter.string;
-};
-
-/**
- * Returns true if the object is a DOM Node.
- *
- * @param {Object} obj object to check
- * @returns {Boolean}
- */
-jasmine.isDomNode = function(obj) {
-  return obj['nodeType'] > 0;
-};
-
-/**
- * Returns a matchable 'generic' object of the class type.  For use in expecations of type when values don't matter.
- *
- * @example
- * // don't care about which function is passed in, as long as it's a function
- * expect(mySpy).toHaveBeenCalledWith(jasmine.any(Function));
- *
- * @param {Class} clazz
- * @returns matchable object of the type clazz
- */
-jasmine.any = function(clazz) {
-  return new jasmine.Matchers.Any(clazz);
-};
-
-/**
- * Jasmine Spies are test doubles that can act as stubs, spies, fakes or when used in an expecation, mocks.
- *
- * Spies should be created in test setup, before expectations.  They can then be checked, using the standard Jasmine
- * expectation syntax. Spies can be checked if they were called or not and what the calling params were.
- *
- * A Spy has the following fields: wasCalled, callCount, mostRecentCall, and argsForCall (see docs).
- *
- * Spies are torn down at the end of every spec.
- *
- * Note: Do <b>not</b> call new jasmine.Spy() directly - a spy must be created using spyOn, jasmine.createSpy or jasmine.createSpyObj.
- *
- * @example
- * // a stub
- * var myStub = jasmine.createSpy('myStub');  // can be used anywhere
- *
- * // spy example
- * var foo = {
- *   not: function(bool) { return !bool; }
- * }
- *
- * // actual foo.not will not be called, execution stops
- * spyOn(foo, 'not');
-
- // foo.not spied upon, execution will continue to implementation
- * spyOn(foo, 'not').andCallThrough();
- *
- * // fake example
- * var foo = {
- *   not: function(bool) { return !bool; }
- * }
- *
- * // foo.not(val) will return val
- * spyOn(foo, 'not').andCallFake(function(value) {return value;});
- *
- * // mock example
- * foo.not(7 == 7);
- * expect(foo.not).toHaveBeenCalled();
- * expect(foo.not).toHaveBeenCalledWith(true);
- *
- * @constructor
- * @see spyOn, jasmine.createSpy, jasmine.createSpyObj
- * @param {String} name
- */
-jasmine.Spy = function(name) {
-  /**
-   * The name of the spy, if provided.
-   */
-  this.identity = name || 'unknown';
-  /**
-   *  Is this Object a spy?
-   */
-  this.isSpy = true;
-  /**
-   * The actual function this spy stubs.
-   */
-  this.plan = function() {
-  };
-  /**
-   * Tracking of the most recent call to the spy.
-   * @example
-   * var mySpy = jasmine.createSpy('foo');
-   * mySpy(1, 2);
-   * mySpy.mostRecentCall.args = [1, 2];
-   */
-  this.mostRecentCall = {};
-
-  /**
-   * Holds arguments for each call to the spy, indexed by call count
-   * @example
-   * var mySpy = jasmine.createSpy('foo');
-   * mySpy(1, 2);
-   * mySpy(7, 8);
-   * mySpy.mostRecentCall.args = [7, 8];
-   * mySpy.argsForCall[0] = [1, 2];
-   * mySpy.argsForCall[1] = [7, 8];
-   */
-  this.argsForCall = [];
-  this.calls = [];
-};
-
-/**
- * Tells a spy to call through to the actual implemenatation.
- *
- * @example
- * var foo = {
- *   bar: function() { // do some stuff }
- * }
- *
- * // defining a spy on an existing property: foo.bar
- * spyOn(foo, 'bar').andCallThrough();
- */
-jasmine.Spy.prototype.andCallThrough = function() {
-  this.plan = this.originalValue;
-  return this;
-};
-
-/**
- * For setting the return value of a spy.
- *
- * @example
- * // defining a spy from scratch: foo() returns 'baz'
- * var foo = jasmine.createSpy('spy on foo').andReturn('baz');
- *
- * // defining a spy on an existing property: foo.bar() returns 'baz'
- * spyOn(foo, 'bar').andReturn('baz');
- *
- * @param {Object} value
- */
-jasmine.Spy.prototype.andReturn = function(value) {
-  this.plan = function() {
-    return value;
-  };
-  return this;
-};
-
-/**
- * For throwing an exception when a spy is called.
- *
- * @example
- * // defining a spy from scratch: foo() throws an exception w/ message 'ouch'
- * var foo = jasmine.createSpy('spy on foo').andThrow('baz');
- *
- * // defining a spy on an existing property: foo.bar() throws an exception w/ message 'ouch'
- * spyOn(foo, 'bar').andThrow('baz');
- *
- * @param {String} exceptionMsg
- */
-jasmine.Spy.prototype.andThrow = function(exceptionMsg) {
-  this.plan = function() {
-    throw exceptionMsg;
-  };
-  return this;
-};
-
-/**
- * Calls an alternate implementation when a spy is called.
- *
- * @example
- * var baz = function() {
- *   // do some stuff, return something
- * }
- * // defining a spy from scratch: foo() calls the function baz
- * var foo = jasmine.createSpy('spy on foo').andCall(baz);
- *
- * // defining a spy on an existing property: foo.bar() calls an anonymnous function
- * spyOn(foo, 'bar').andCall(function() { return 'baz';} );
- *
- * @param {Function} fakeFunc
- */
-jasmine.Spy.prototype.andCallFake = function(fakeFunc) {
-  this.plan = fakeFunc;
-  return this;
-};
-
-/**
- * Resets all of a spy's the tracking variables so that it can be used again.
- *
- * @example
- * spyOn(foo, 'bar');
- *
- * foo.bar();
- *
- * expect(foo.bar.callCount).toEqual(1);
- *
- * foo.bar.reset();
- *
- * expect(foo.bar.callCount).toEqual(0);
- */
-jasmine.Spy.prototype.reset = function() {
-  this.wasCalled = false;
-  this.callCount = 0;
-  this.argsForCall = [];
-  this.calls = [];
-  this.mostRecentCall = {};
-};
-
-jasmine.createSpy = function(name) {
-
-  var spyObj = function() {
-    spyObj.wasCalled = true;
-    spyObj.callCount++;
-    var args = jasmine.util.argsToArray(arguments);
-    spyObj.mostRecentCall.object = this;
-    spyObj.mostRecentCall.args = args;
-    spyObj.argsForCall.push(args);
-    spyObj.calls.push({object: this, args: args});
-    return spyObj.plan.apply(this, arguments);
-  };
-
-  var spy = new jasmine.Spy(name);
-
-  for (var prop in spy) {
-    spyObj[prop] = spy[prop];
-  }
-
-  spyObj.reset();
-
-  return spyObj;
-};
-
-/**
- * Determines whether an object is a spy.
- *
- * @param {jasmine.Spy|Object} putativeSpy
- * @returns {Boolean}
- */
-jasmine.isSpy = function(putativeSpy) {
-  return putativeSpy && putativeSpy.isSpy;
-};
-
-/**
- * Creates a more complicated spy: an Object that has every property a function that is a spy.  Used for stubbing something
- * large in one call.
- *
- * @param {String} baseName name of spy class
- * @param {Array} methodNames array of names of methods to make spies
- */
-jasmine.createSpyObj = function(baseName, methodNames) {
-  if (!jasmine.isArray_(methodNames) || methodNames.length == 0) {
-    throw new Error('createSpyObj requires a non-empty array of method names to create spies for');
-  }
-  var obj = {};
-  for (var i = 0; i < methodNames.length; i++) {
-    obj[methodNames[i]] = jasmine.createSpy(baseName + '.' + methodNames[i]);
-  }
-  return obj;
-};
-
-/**
- * All parameters are pretty-printed and concatenated together, then written to the current spec's output.
- *
- * Be careful not to leave calls to <code>jasmine.log</code> in production code.
- */
-jasmine.log = function() {
-  var spec = jasmine.getEnv().currentSpec;
-  spec.log.apply(spec, arguments);
-};
-
-/**
- * Function that installs a spy on an existing object's method name.  Used within a Spec to create a spy.
- *
- * @example
- * // spy example
- * var foo = {
- *   not: function(bool) { return !bool; }
- * }
- * spyOn(foo, 'not'); // actual foo.not will not be called, execution stops
- *
- * @see jasmine.createSpy
- * @param obj
- * @param methodName
- * @returns a Jasmine spy that can be chained with all spy methods
- */
-var spyOn = function(obj, methodName) {
-  return jasmine.getEnv().currentSpec.spyOn(obj, methodName);
-};
-
-/**
- * Creates a Jasmine spec that will be added to the current suite.
- *
- * // TODO: pending tests
- *
- * @example
- * it('should be true', function() {
- *   expect(true).toEqual(true);
- * });
- *
- * @param {String} desc description of this specification
- * @param {Function} func defines the preconditions and expectations of the spec
- */
-var it = function(desc, func) {
-  return jasmine.getEnv().it(desc, func);
-};
-
-/**
- * Creates a <em>disabled</em> Jasmine spec.
- *
- * A convenience method that allows existing specs to be disabled temporarily during development.
- *
- * @param {String} desc description of this specification
- * @param {Function} func defines the preconditions and expectations of the spec
- */
-var xit = function(desc, func) {
-  return jasmine.getEnv().xit(desc, func);
-};
-
-/**
- * Starts a chain for a Jasmine expectation.
- *
- * It is passed an Object that is the actual value and should chain to one of the many
- * jasmine.Matchers functions.
- *
- * @param {Object} actual Actual value to test against and expected value
- */
-var expect = function(actual) {
-  return jasmine.getEnv().currentSpec.expect(actual);
-};
-
-/**
- * Defines part of a jasmine spec.  Used in cominbination with waits or waitsFor in asynchrnous specs.
- *
- * @param {Function} func Function that defines part of a jasmine spec.
- */
-var runs = function(func) {
-  jasmine.getEnv().currentSpec.runs(func);
-};
-
-/**
- * Waits a fixed time period before moving to the next block.
- *
- * @deprecated Use waitsFor() instead
- * @param {Number} timeout milliseconds to wait
- */
-var waits = function(timeout) {
-  jasmine.getEnv().currentSpec.waits(timeout);
-};
-
-/**
- * Waits for the latchFunction to return true before proceeding to the next block.
- *
- * @param {Function} latchFunction
- * @param {String} optional_timeoutMessage
- * @param {Number} optional_timeout
- */
-var waitsFor = function(latchFunction, optional_timeoutMessage, optional_timeout) {
-  jasmine.getEnv().currentSpec.waitsFor.apply(jasmine.getEnv().currentSpec, arguments);
-};
-
-/**
- * A function that is called before each spec in a suite.
- *
- * Used for spec setup, including validating assumptions.
- *
- * @param {Function} beforeEachFunction
- */
-var beforeEach = function(beforeEachFunction) {
-  jasmine.getEnv().beforeEach(beforeEachFunction);
-};
-
-/**
- * A function that is called after each spec in a suite.
- *
- * Used for restoring any state that is hijacked during spec execution.
- *
- * @param {Function} afterEachFunction
- */
-var afterEach = function(afterEachFunction) {
-  jasmine.getEnv().afterEach(afterEachFunction);
-};
-
-/**
- * Defines a suite of specifications.
- *
- * Stores the description and all defined specs in the Jasmine environment as one suite of specs. Variables declared
- * are accessible by calls to beforeEach, it, and afterEach. Describe blocks can be nested, allowing for specialization
- * of setup in some tests.
- *
- * @example
- * // TODO: a simple suite
- *
- * // TODO: a simple suite with a nested describe block
- *
- * @param {String} description A string, usually the class under test.
- * @param {Function} specDefinitions function that defines several specs.
- */
-var describe = function(description, specDefinitions) {
-  return jasmine.getEnv().describe(description, specDefinitions);
-};
-
-/**
- * Disables a suite of specifications.  Used to disable some suites in a file, or files, temporarily during development.
- *
- * @param {String} description A string, usually the class under test.
- * @param {Function} specDefinitions function that defines several specs.
- */
-var xdescribe = function(description, specDefinitions) {
-  return jasmine.getEnv().xdescribe(description, specDefinitions);
-};
-
-
-// Provide the XMLHttpRequest class for IE 5.x-6.x:
-jasmine.XmlHttpRequest = (typeof XMLHttpRequest == "undefined") ? function() {
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP.6.0");
-  } catch(e) {
-  }
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP.3.0");
-  } catch(e) {
-  }
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP");
-  } catch(e) {
-  }
-  try {
-    return new ActiveXObject("Microsoft.XMLHTTP");
-  } catch(e) {
-  }
-  throw new Error("This browser does not support XMLHttpRequest.");
-} : XMLHttpRequest;
+	/**
+	 * Allows for bound functions to be compared.  Internal use only.
+	 *
+	 * @ignore
+	 * @private
+	 * @param base {Object} bound 'this' for the function
+	 * @param name {Function} function to find
+	 */
+	function _bindOriginal_ (base, name) {
+	  var original = base[name];
+	  if (original.apply) {
+	    return function() {
+	      return original.apply(base, arguments);
+	    };
+	  } else {
+	    // IE support
+	    return _this.getGlobal()[name];
+	  }
+	};
+	
+	/**
+	 * Default interval in milliseconds for event loop yields (e.g. to allow network activity or to refresh the screen with the HTML-based runner). Small values here may result in slow test running. Zero means no updates until all tests have completed.
+	 *
+	 */
+	_this.DEFAULT_UPDATE_INTERVAL = 250;
+	
+	/**
+	 * Default timeout interval in milliseconds for waitsFor() blocks.
+	 */
+	_this.DEFAULT_TIMEOUT_INTERVAL = 5000;
+	
+	_this.getGlobal = function() {
+	  function getGlobal() {
+	    return this;
+	  }
+	
+	  return getGlobal();
+	};
+	
+	
+	_this.setTimeout = _bindOriginal_(_this.getGlobal(), 'setTimeout');
+	_this.clearTimeout = _bindOriginal_(_this.getGlobal(), 'clearTimeout');
+	_this.setInterval = _bindOriginal_(_this.getGlobal(), 'setInterval');
+	_this.clearInterval = _bindOriginal_(_this.getGlobal(), 'clearInterval');
+	
+	_this.MessageResult = function(values) {
+	  this.type = 'log';
+	  this.values = values;
+	  this.trace = new Error(); // todo: test better
+	};
+	
+	_this.MessageResult.prototype.toString = function() {
+	  var text = "";
+	  for(var i = 0; i < this.values.length; i++) {
+	    if (i > 0) text += " ";
+	    if (_this.isString_(this.values[i])) {
+	      text += this.values[i];
+	    } else {
+	      text += _this.pp(this.values[i]);
+	    }
+	  }
+	  return text;
+	};
+	
+	_this.ExpectationResult = function(params) {
+	  this.type = 'expect';
+	  this.matcherName = params.matcherName;
+	  this.passed_ = params.passed;
+	  this.expected = params.expected;
+	  this.actual = params.actual;
+	
+	  this.message = this.passed_ ? 'Passed.' : params.message;
+	  this.trace = this.passed_ ? '' : new Error(this.message);
+	};
+	
+	_this.ExpectationResult.prototype.toString = function () {
+	  return this.message;
+	};
+	
+	_this.ExpectationResult.prototype.passed = function () {
+	  return this.passed_;
+	};
+	
+	/**
+	 * Getter for the Jasmine environment. Ensures one gets created
+	 */
+	_this.getEnv = function() {
+	  return _this.currentEnv_ = _this.currentEnv_ || new _this.Env();
+	};
+	
+	/**
+	 * @ignore
+	 * @private
+	 * @param value
+	 * @returns {Boolean}
+	 */
+	_this.isArray_ = function(value) {
+	  return _this.isA_("Array", value);  
+	};
+	
+	/**
+	 * @ignore
+	 * @private
+	 * @param value
+	 * @returns {Boolean}
+	 */
+	_this.isString_ = function(value) {
+	  return _this.isA_("String", value);
+	};
+	
+	/**
+	 * @ignore
+	 * @private
+	 * @param value
+	 * @returns {Boolean}
+	 */
+	_this.isNumber_ = function(value) {
+	  return _this.isA_("Number", value);
+	};
+	
+	/**
+	 * @ignore
+	 * @private
+	 * @param {String} typeName
+	 * @param value
+	 * @returns {Boolean}
+	 */
+	_this.isA_ = function(typeName, value) {
+	  return Object.prototype.toString.apply(value) === '[object ' + typeName + ']';
+	};
+	
+	/**
+	 * Pretty printer for expecations.  Takes any object and turns it into a human-readable string.
+	 *
+	 * @param value {Object} an object to be outputted
+	 * @returns {String}
+	 */
+	_this.pp = function(value) {
+	  var stringPrettyPrinter = new _this.StringPrettyPrinter();
+	  stringPrettyPrinter.format(value);
+	  return stringPrettyPrinter.string;
+	};
+	
+	/**
+	 * Returns true if the object is a DOM Node.
+	 *
+	 * @param {Object} obj object to check
+	 * @returns {Boolean}
+	 */
+	_this.isDomNode = function(obj) {
+	  return obj['nodeType'] > 0;
+	};
+	
+	/**
+	 * Returns a matchable 'generic' object of the class type.  For use in expecations of type when values don't matter.
+	 *
+	 * @example
+	 * // don't care about which function is passed in, as long as it's a function
+	 * expect(mySpy).toHaveBeenCalledWith(jasmine.any(Function));
+	 *
+	 * @param {Class} clazz
+	 * @returns matchable object of the type clazz
+	 */
+	_this.any = function(clazz) {
+	  return new _this.Matchers.Any(clazz);
+	};
+	
+	/**
+	 * Jasmine Spies are test doubles that can act as stubs, spies, fakes or when used in an expecation, mocks.
+	 *
+	 * Spies should be created in test setup, before expectations.  They can then be checked, using the standard Jasmine
+	 * expectation syntax. Spies can be checked if they were called or not and what the calling params were.
+	 *
+	 * A Spy has the following fields: wasCalled, callCount, mostRecentCall, and argsForCall (see docs).
+	 *
+	 * Spies are torn down at the end of every spec.
+	 *
+	 * Note: Do <b>not</b> call new jasmine.Spy() directly - a spy must be created using spyOn, jasmine.createSpy or jasmine.createSpyObj.
+	 *
+	 * @example
+	 * // a stub
+	 * var myStub = jasmine.createSpy('myStub');  // can be used anywhere
+	 *
+	 * // spy example
+	 * var foo = {
+	 *   not: function(bool) { return !bool; }
+	 * }
+	 *
+	 * // actual foo.not will not be called, execution stops
+	 * spyOn(foo, 'not');
+	
+	 // foo.not spied upon, execution will continue to implementation
+	 * spyOn(foo, 'not').andCallThrough();
+	 *
+	 * // fake example
+	 * var foo = {
+	 *   not: function(bool) { return !bool; }
+	 * }
+	 *
+	 * // foo.not(val) will return val
+	 * spyOn(foo, 'not').andCallFake(function(value) {return value;});
+	 *
+	 * // mock example
+	 * foo.not(7 == 7);
+	 * expect(foo.not).toHaveBeenCalled();
+	 * expect(foo.not).toHaveBeenCalledWith(true);
+	 *
+	 * @constructor
+	 * @see spyOn, jasmine.createSpy, jasmine.createSpyObj
+	 * @param {String} name
+	 */
+	_this.Spy = function(name) {
+	  /**
+	   * The name of the spy, if provided.
+	   */
+	  this.identity = name || 'unknown';
+	  /**
+	   *  Is this Object a spy?
+	   */
+	  this.isSpy = true;
+	  /**
+	   * The actual function this spy stubs.
+	   */
+	  this.plan = function() {
+	  };
+	  /**
+	   * Tracking of the most recent call to the spy.
+	   * @example
+	   * var mySpy = jasmine.createSpy('foo');
+	   * mySpy(1, 2);
+	   * mySpy.mostRecentCall.args = [1, 2];
+	   */
+	  this.mostRecentCall = {};
+	
+	  /**
+	   * Holds arguments for each call to the spy, indexed by call count
+	   * @example
+	   * var mySpy = jasmine.createSpy('foo');
+	   * mySpy(1, 2);
+	   * mySpy(7, 8);
+	   * mySpy.mostRecentCall.args = [7, 8];
+	   * mySpy.argsForCall[0] = [1, 2];
+	   * mySpy.argsForCall[1] = [7, 8];
+	   */
+	  this.argsForCall = [];
+	  this.calls = [];
+	};
+	
+	/**
+	 * Tells a spy to call through to the actual implemenatation.
+	 *
+	 * @example
+	 * var foo = {
+	 *   bar: function() { // do some stuff }
+	 * }
+	 *
+	 * // defining a spy on an existing property: foo.bar
+	 * spyOn(foo, 'bar').andCallThrough();
+	 */
+	_this.Spy.prototype.andCallThrough = function() {
+	  this.plan = this.originalValue;
+	  return this;
+	};
+	
+	/**
+	 * For setting the return value of a spy.
+	 *
+	 * @example
+	 * // defining a spy from scratch: foo() returns 'baz'
+	 * var foo = jasmine.createSpy('spy on foo').andReturn('baz');
+	 *
+	 * // defining a spy on an existing property: foo.bar() returns 'baz'
+	 * spyOn(foo, 'bar').andReturn('baz');
+	 *
+	 * @param {Object} value
+	 */
+	_this.Spy.prototype.andReturn = function(value) {
+	  this.plan = function() {
+	    return value;
+	  };
+	  return this;
+	};
+	
+	/**
+	 * For throwing an exception when a spy is called.
+	 *
+	 * @example
+	 * // defining a spy from scratch: foo() throws an exception w/ message 'ouch'
+	 * var foo = jasmine.createSpy('spy on foo').andThrow('baz');
+	 *
+	 * // defining a spy on an existing property: foo.bar() throws an exception w/ message 'ouch'
+	 * spyOn(foo, 'bar').andThrow('baz');
+	 *
+	 * @param {String} exceptionMsg
+	 */
+	_this.Spy.prototype.andThrow = function(exceptionMsg) {
+	  this.plan = function() {
+	    throw exceptionMsg;
+	  };
+	  return this;
+	};
+	
+	/**
+	 * Calls an alternate implementation when a spy is called.
+	 *
+	 * @example
+	 * var baz = function() {
+	 *   // do some stuff, return something
+	 * }
+	 * // defining a spy from scratch: foo() calls the function baz
+	 * var foo = jasmine.createSpy('spy on foo').andCall(baz);
+	 *
+	 * // defining a spy on an existing property: foo.bar() calls an anonymnous function
+	 * spyOn(foo, 'bar').andCall(function() { return 'baz';} );
+	 *
+	 * @param {Function} fakeFunc
+	 */
+	_this.Spy.prototype.andCallFake = function(fakeFunc) {
+	  this.plan = fakeFunc;
+	  return this;
+	};
+	
+	/**
+	 * Resets all of a spy's the tracking variables so that it can be used again.
+	 *
+	 * @example
+	 * spyOn(foo, 'bar');
+	 *
+	 * foo.bar();
+	 *
+	 * expect(foo.bar.callCount).toEqual(1);
+	 *
+	 * foo.bar.reset();
+	 *
+	 * expect(foo.bar.callCount).toEqual(0);
+	 */
+	_this.Spy.prototype.reset = function() {
+	  this.wasCalled = false;
+	  this.callCount = 0;
+	  this.argsForCall = [];
+	  this.calls = [];
+	  this.mostRecentCall = {};
+	};
+	
+	_this.createSpy = function(name) {
+	
+	  var spyObj = function() {
+	    spyObj.wasCalled = true;
+	    spyObj.callCount++;
+	    var args = _this.util.argsToArray(arguments);
+	    spyObj.mostRecentCall.object = this;
+	    spyObj.mostRecentCall.args = args;
+	    spyObj.argsForCall.push(args);
+	    spyObj.calls.push({object: this, args: args});
+	    return spyObj.plan.apply(this, arguments);
+	  };
+	
+	  var spy = new _this.Spy(name);
+	
+	  for (var prop in spy) {
+	    spyObj[prop] = spy[prop];
+	  }
+	
+	  spyObj.reset();
+	
+	  return spyObj;
+	};
+	
+	/**
+	 * Determines whether an object is a spy.
+	 *
+	 * @param {jasmine.Spy|Object} putativeSpy
+	 * @returns {Boolean}
+	 */
+	_this.isSpy = function(putativeSpy) {
+	  return putativeSpy && putativeSpy.isSpy;
+	};
+	
+	/**
+	 * Creates a more complicated spy: an Object that has every property a function that is a spy.  Used for stubbing something
+	 * large in one call.
+	 *
+	 * @param {String} baseName name of spy class
+	 * @param {Array} methodNames array of names of methods to make spies
+	 */
+	_this.createSpyObj = function(baseName, methodNames) {
+	  if (!_this.isArray_(methodNames) || methodNames.length == 0) {
+	    throw new Error('createSpyObj requires a non-empty array of method names to create spies for');
+	  }
+	  var obj = {};
+	  for (var i = 0; i < methodNames.length; i++) {
+	    obj[methodNames[i]] = _this.createSpy(baseName + '.' + methodNames[i]);
+	  }
+	  return obj;
+	};
+	
+	/**
+	 * All parameters are pretty-printed and concatenated together, then written to the current spec's output.
+	 *
+	 * Be careful not to leave calls to <code>jasmine.log</code> in production code.
+	 */
+	_this.log = function() {
+	  var spec = _this.getEnv().currentSpec;
+	  spec.log.apply(spec, arguments);
+	};
+	
+	/**
+	 * Function that installs a spy on an existing object's method name.  Used within a Spec to create a spy.
+	 *
+	 * @example
+	 * // spy example
+	 * var foo = {
+	 *   not: function(bool) { return !bool; }
+	 * }
+	 * spyOn(foo, 'not'); // actual foo.not will not be called, execution stops
+	 *
+	 * @see jasmine.createSpy
+	 * @param obj
+	 * @param methodName
+	 * @returns a Jasmine spy that can be chained with all spy methods
+	 */
+	_this.spyOn = function(obj, methodName) {
+	  return _this.getEnv().currentSpec.spyOn(obj, methodName);
+	};
+	
+	/**
+	 * Creates a Jasmine spec that will be added to the current suite.
+	 *
+	 * // TODO: pending tests
+	 *
+	 * @example
+	 * it('should be true', function() {
+	 *   expect(true).toEqual(true);
+	 * });
+	 *
+	 * @param {String} desc description of this specification
+	 * @param {Function} func defines the preconditions and expectations of the spec
+	 */
+	_this.it = function(desc, func) {
+	  return _this.getEnv().it(desc, func);
+	};
+	
+	/**
+	 * Creates a <em>disabled</em> Jasmine spec.
+	 *
+	 * A convenience method that allows existing specs to be disabled temporarily during development.
+	 *
+	 * @param {String} desc description of this specification
+	 * @param {Function} func defines the preconditions and expectations of the spec
+	 */
+	_this.xit = function(desc, func) {
+	  return _this.getEnv().xit(desc, func);
+	};
+	
+	/**
+	 * Starts a chain for a Jasmine expectation.
+	 *
+	 * It is passed an Object that is the actual value and should chain to one of the many
+	 * _this.Matchers functions.
+	 *
+	 * @param {Object} actual Actual value to test against and expected value
+	 */
+	_this.expect = function(actual) {
+	  return _this.getEnv().currentSpec.expect(actual);
+	};
+	
+	/**
+	 * Defines part of a jasmine spec.  Used in cominbination with waits or waitsFor in asynchrnous specs.
+	 *
+	 * @param {Function} func Function that defines part of a jasmine spec.
+	 */
+	_this.runs = function(func) {
+	  _this.getEnv().currentSpec.runs(func);
+	};
+	
+	/**
+	 * Waits a fixed time period before moving to the next block.
+	 *
+	 * @deprecated Use waitsFor() instead
+	 * @param {Number} timeout milliseconds to wait
+	 */
+	_this.waits = function(timeout) {
+	  _this.getEnv().currentSpec.waits(timeout);
+	};
+	
+	/**
+	 * Waits for the latchFunction to return true before proceeding to the next block.
+	 *
+	 * @param {Function} latchFunction
+	 * @param {String} optional_timeoutMessage
+	 * @param {Number} optional_timeout
+	 */
+	_this.waitsFor = function(latchFunction, optional_timeoutMessage, optional_timeout) {
+	  _this.getEnv().currentSpec.waitsFor.apply(_this.getEnv().currentSpec, arguments);
+	};
+	
+	/**
+	 * A function that is called before each spec in a suite.
+	 *
+	 * Used for spec setup, including validating assumptions.
+	 *
+	 * @param {Function} beforeEachFunction
+	 */
+	_this.beforeEach = function(beforeEachFunction) {
+	  _this.getEnv().beforeEach(beforeEachFunction);
+	};
+	
+	/**
+	 * A function that is called after each spec in a suite.
+	 *
+	 * Used for restoring any state that is hijacked during spec execution.
+	 *
+	 * @param {Function} afterEachFunction
+	 */
+	_this.afterEach = function(afterEachFunction) {
+	  _this.getEnv().afterEach(afterEachFunction);
+	};
+	
+	/**
+	 * Defines a suite of specifications.
+	 *
+	 * Stores the description and all defined specs in the Jasmine environment as one suite of specs. Variables declared
+	 * are accessible by calls to beforeEach, it, and afterEach. Describe blocks can be nested, allowing for specialization
+	 * of setup in some tests.
+	 *
+	 * @example
+	 * // TODO: a simple suite
+	 *
+	 * // TODO: a simple suite with a nested describe block
+	 *
+	 * @param {String} description A string, usually the class under test.
+	 * @param {Function} specDefinitions function that defines several specs.
+	 */
+	_this.describe = function(description, specDefinitions) {
+	  return _this.getEnv().describe(description, specDefinitions);
+	};
+	
+	/**
+	 * Disables a suite of specifications.  Used to disable some suites in a file, or files, temporarily during development.
+	 *
+	 * @param {String} description A string, usually the class under test.
+	 * @param {Function} specDefinitions function that defines several specs.
+	 */
+	_this.xdescribe = function(description, specDefinitions) {
+	  return _this.getEnv().xdescribe(description, specDefinitions);
+	};
+	
+	
+	// Provide the XMLHttpRequest class for IE 5.x-6.x:
+	_this.XmlHttpRequest = (typeof XMLHttpRequest == "undefined") ? function() {
+	  try {
+	    return new ActiveXObject("Msxml2.XMLHTTP.6.0");
+	  } catch(e) {
+	  }
+	  try {
+	    return new ActiveXObject("Msxml2.XMLHTTP.3.0");
+	  } catch(e) {
+	  }
+	  try {
+	    return new ActiveXObject("Msxml2.XMLHTTP");
+	  } catch(e) {
+	  }
+	  try {
+	    return new ActiveXObject("Microsoft.XMLHTTP");
+	  } catch(e) {
+	  }
+	  throw new Error("This browser does not support XMLHttpRequest.");
+	} : XMLHttpRequest;
+	
+	return _this;
+})();

--- a/src/mock-timeout.js
+++ b/src/mock-timeout.js
@@ -1,89 +1,98 @@
-// Mock setTimeout, clearTimeout
-// Contributed by Pivotal Computer Systems, www.pivotalsf.com
+jasmine.FakeTimer = (function(){ 
+	var _this = this /* @private scoped reference to "this".  (Avoids confusion/mistakes when scope of "this" changes due to events, apply, call, etc. */
+		, _undefined_  = jasmine.___undefined___ /* @private scoped reference to "undefined" */
+	;
 
-jasmine.FakeTimer = function() {
-  this.reset();
+	// Mock setTimeout, clearTimeout
+	// Contributed by Pivotal Computer Systems, www.pivotalsf.com
+	
+	function _FakeTimer() {
+	  this.reset();
+	
+	  var self = this;
+	  self.setTimeout = function(funcToCall, millis) {
+	    self.timeoutsMade++;
+	    self.scheduleFunction(self.timeoutsMade, funcToCall, millis, false);
+	    return self.timeoutsMade;
+	  };
+	
+	  self.setInterval = function(funcToCall, millis) {
+	    self.timeoutsMade++;
+	    self.scheduleFunction(self.timeoutsMade, funcToCall, millis, true);
+	    return self.timeoutsMade;
+	  };
+	
+	  self.clearTimeout = function(timeoutKey) {
+	    self.scheduledFunctions[timeoutKey] = _undefined_;
+	  };
+	
+	  self.clearInterval = function(timeoutKey) {
+	    self.scheduledFunctions[timeoutKey] = _undefined_;
+	  };
+	
+	};
+	
+	_FakeTimer.prototype.reset = function() {
+	  this.timeoutsMade = 0;
+	  this.scheduledFunctions = {};
+	  this.nowMillis = 0;
+	};
+	
+	_FakeTimer.prototype.tick = function(millis) {
+	  var oldMillis = this.nowMillis;
+	  var newMillis = oldMillis + millis;
+	  this.runFunctionsWithinRange(oldMillis, newMillis);
+	  this.nowMillis = newMillis;
+	};
+	
+	_FakeTimer.prototype.runFunctionsWithinRange = function(oldMillis, nowMillis) {
+	  var scheduledFunc;
+	  var funcsToRun = [];
+	  for (var timeoutKey in this.scheduledFunctions) {
+	    scheduledFunc = this.scheduledFunctions[timeoutKey];
+	    if (scheduledFunc != _undefined_ &&
+	        scheduledFunc.runAtMillis >= oldMillis &&
+	        scheduledFunc.runAtMillis <= nowMillis) {
+	      funcsToRun.push(scheduledFunc);
+	      this.scheduledFunctions[timeoutKey] = _undefined_;
+	    }
+	  }
+	
+	  if (funcsToRun.length > 0) {
+	    funcsToRun.sort(function(a, b) {
+	      return a.runAtMillis - b.runAtMillis;
+	    });
+	    for (var i = 0; i < funcsToRun.length; ++i) {
+	      try {
+	        var funcToRun = funcsToRun[i];
+	        this.nowMillis = funcToRun.runAtMillis;
+	        funcToRun.funcToCall();
+	        if (funcToRun.recurring) {
+	          this.scheduleFunction(funcToRun.timeoutKey,
+	              funcToRun.funcToCall,
+	              funcToRun.millis,
+	              true);
+	        }
+	      } catch(e) {
+	      }
+	    }
+	    this.runFunctionsWithinRange(oldMillis, nowMillis);
+	  }
+	};
+	
+	_FakeTimer.prototype.scheduleFunction = function(timeoutKey, funcToCall, millis, recurring) {
+	  this.scheduledFunctions[timeoutKey] = {
+	    runAtMillis: this.nowMillis + millis,
+	    funcToCall: funcToCall,
+	    recurring: recurring,
+	    timeoutKey: timeoutKey,
+	    millis: millis
+	  };
+	};
+	
+	return _FakeTimer;
 
-  var self = this;
-  self.setTimeout = function(funcToCall, millis) {
-    self.timeoutsMade++;
-    self.scheduleFunction(self.timeoutsMade, funcToCall, millis, false);
-    return self.timeoutsMade;
-  };
-
-  self.setInterval = function(funcToCall, millis) {
-    self.timeoutsMade++;
-    self.scheduleFunction(self.timeoutsMade, funcToCall, millis, true);
-    return self.timeoutsMade;
-  };
-
-  self.clearTimeout = function(timeoutKey) {
-    self.scheduledFunctions[timeoutKey] = jasmine.undefined;
-  };
-
-  self.clearInterval = function(timeoutKey) {
-    self.scheduledFunctions[timeoutKey] = jasmine.undefined;
-  };
-
-};
-
-jasmine.FakeTimer.prototype.reset = function() {
-  this.timeoutsMade = 0;
-  this.scheduledFunctions = {};
-  this.nowMillis = 0;
-};
-
-jasmine.FakeTimer.prototype.tick = function(millis) {
-  var oldMillis = this.nowMillis;
-  var newMillis = oldMillis + millis;
-  this.runFunctionsWithinRange(oldMillis, newMillis);
-  this.nowMillis = newMillis;
-};
-
-jasmine.FakeTimer.prototype.runFunctionsWithinRange = function(oldMillis, nowMillis) {
-  var scheduledFunc;
-  var funcsToRun = [];
-  for (var timeoutKey in this.scheduledFunctions) {
-    scheduledFunc = this.scheduledFunctions[timeoutKey];
-    if (scheduledFunc != jasmine.undefined &&
-        scheduledFunc.runAtMillis >= oldMillis &&
-        scheduledFunc.runAtMillis <= nowMillis) {
-      funcsToRun.push(scheduledFunc);
-      this.scheduledFunctions[timeoutKey] = jasmine.undefined;
-    }
-  }
-
-  if (funcsToRun.length > 0) {
-    funcsToRun.sort(function(a, b) {
-      return a.runAtMillis - b.runAtMillis;
-    });
-    for (var i = 0; i < funcsToRun.length; ++i) {
-      try {
-        var funcToRun = funcsToRun[i];
-        this.nowMillis = funcToRun.runAtMillis;
-        funcToRun.funcToCall();
-        if (funcToRun.recurring) {
-          this.scheduleFunction(funcToRun.timeoutKey,
-              funcToRun.funcToCall,
-              funcToRun.millis,
-              true);
-        }
-      } catch(e) {
-      }
-    }
-    this.runFunctionsWithinRange(oldMillis, nowMillis);
-  }
-};
-
-jasmine.FakeTimer.prototype.scheduleFunction = function(timeoutKey, funcToCall, millis, recurring) {
-  this.scheduledFunctions[timeoutKey] = {
-    runAtMillis: this.nowMillis + millis,
-    funcToCall: funcToCall,
-    recurring: recurring,
-    timeoutKey: timeoutKey,
-    millis: millis
-  };
-};
+})();
 
 /**
  * @namespace


### PR DESCRIPTION
I was going to give jasmine a try and noticed that it wasn't fully namespaced, so felt the overwhelming OCD need to wrap it.  I was working with the built download files, so it was a cakewalk to just wrap it in a closure, attach everything to a scoped var and return it.  Talked to Davis Frank, and they asked for/about a pull request of the mods, so I checked out your source.  Due to the code separation, wrapping the entire base in a closure is not the easiest (or best) route, so I did a little effort towards namespacing/scoping.

Mainly wrapped every major player who needed any privately scoped variables in a closure, and scoped those vars/functions so as to really be private.  Made for duplicated private "_undefined_" vars, but that's how it has to be when you're compartmentalizing code.  In base.js I made all the global vars properties of jasmine to avoid muddying the global namespace.  example of how to make it still readable in your specs:

```
jasmine.describe("foo", function () {
    var _ = jasmine;
    _.it("should still be easy to read", function () {
        //some code
    });
});
```

If this is a route you'd like to take your code base, there's a good bit of continued work that could be done to improve, though this seems to work just fine as is.

Hope it's useful for you.  If you're interested in further strategies on how to JS namespace within a complex build system, let me know.  I've spent a lot of time thinking on the matter and have some pretty decent ideas. 
