### PR TITLE
A useful stack trace for Node etc -- a stab at issue #5

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -91,7 +91,7 @@ jasmine.ExpectationResult = function(params) {
   this.actual = params.actual;
 
   this.message = this.passed_ ? 'Passed.' : params.message;
-  if (params.trace) {
+  if (typeof params.trace == 'object') {
     this.trace = params.trace
   } else {
     this.trace = this.passed_ ? '' : new Error(this.message);
@@ -2051,16 +2051,16 @@ jasmine.Spec.prototype.addBeforesAndAftersToQueue = function() {
 };
 
 jasmine.Spec.prototype.explodes = function() {
-  throw 'explodes function should not have been called';
+  throw new Error('explodes function should not have been called');
 };
 
 jasmine.Spec.prototype.spyOn = function(obj, methodName, ignoreMethodDoesntExist) {
   if (obj == jasmine.undefined) {
-    throw "spyOn could not find an object to spy upon for " + methodName + "()";
+    throw new Error("spyOn could not find an object to spy upon for " + methodName + "()");
   }
 
   if (!ignoreMethodDoesntExist && obj[methodName] === jasmine.undefined) {
-    throw methodName + '() method does not exist';
+    throw new Error(methodName + '() method does not exist');
   }
 
   if (!ignoreMethodDoesntExist && obj[methodName] && obj[methodName].isSpy) {
@@ -2422,5 +2422,5 @@ jasmine.version_= {
   "major": 1,
   "minor": 0,
   "build": 1,
-  "revision": 1293464019
+  "revision": 1295632154
 };

--- a/src/Spec.js
+++ b/src/Spec.js
@@ -205,16 +205,16 @@ jasmine.Spec.prototype.addBeforesAndAftersToQueue = function() {
 };
 
 jasmine.Spec.prototype.explodes = function() {
-  throw 'explodes function should not have been called';
+  throw new Error('explodes function should not have been called');
 };
 
 jasmine.Spec.prototype.spyOn = function(obj, methodName, ignoreMethodDoesntExist) {
   if (obj == jasmine.undefined) {
-    throw "spyOn could not find an object to spy upon for " + methodName + "()";
+    throw new Error("spyOn could not find an object to spy upon for " + methodName + "()");
   }
 
   if (!ignoreMethodDoesntExist && obj[methodName] === jasmine.undefined) {
-    throw methodName + '() method does not exist';
+    throw new Error(methodName + '() method does not exist');
   }
 
   if (!ignoreMethodDoesntExist && obj[methodName] && obj[methodName].isSpy) {

--- a/src/base.js
+++ b/src/base.js
@@ -91,7 +91,7 @@ jasmine.ExpectationResult = function(params) {
   this.actual = params.actual;
 
   this.message = this.passed_ ? 'Passed.' : params.message;
-  if (params.trace) {
+  if (typeof params.trace == 'object') {
     this.trace = params.trace
   } else {
     this.trace = this.passed_ ? '' : new Error(this.message);


### PR DESCRIPTION
I've been using Jasmine with Node and CoffeeScript, and I've really wanted to see where my errors are.

With this change, any error raised by a Spec is kept and attached to the ExpectationResult. This changes the output dramatically. Compare the following two stack traces:
## With this change:

```
  TypeError: number is not a function
    at Number.CALL_NON_FUNCTION (native)
    at Simulation.begin (lib/queuing-simulation.coffee:22:25)
    at [object Object].<anonymous> (spec/simulation_integration_spec.coffee:18:22)
    at [object Object].execute (vendor/jasmine/jasmine.js:972:15)
    at [object Object].next_ (vendor/jasmine/jasmine.js:1743:31)
    at [object Object].start (vendor/jasmine/jasmine.js:1696:8)
    at [object Object].execute (vendor/jasmine/jasmine.js:2023:14)
    at [object Object].next_ (vendor/jasmine/jasmine.js:1743:31)
    at [object Object].start (vendor/jasmine/jasmine.js:1696:8)
    at [object Object].execute (vendor/jasmine/jasmine.js:2168:14)
```
## Before this change

```
  Error: TypeError: number is not a function
    at new <anonymous> (vendor/jasmine/jasmine.js:94:36)
    at [object Object].fail (vendor/jasmine/jasmine.js:1963:27)
    at [object Object].execute (vendor/jasmine/jasmine.js:970:15)
    at [object Object].next_ (vendor/jasmine/jasmine.js:1739:31)
    at [object Object].start (vendor/jasmine/jasmine.js:1692:8)
    at [object Object].execute (vendor/jasmine/jasmine.js:2018:14)
    at [object Object].next_ (vendor/jasmine/jasmine.js:1739:31)
    at [object Object].start (vendor/jasmine/jasmine.js:1692:8)
    at [object Object].execute (vendor/jasmine/jasmine.js:2163:14)
    at [object Object].next_ (vendor/jasmine/jasmine.js:1739:31)
```

(Apologies to anyone who gets this unnecessarily -- the README asked for pull requests to be sent only to the three maintainers, but I can't figure out how to change the recipient list.)
