### PR TITLE
Show test results in console in case browser supports it.

### DIFF
--- a/lib/jasmine-html.js
+++ b/lib/jasmine-html.js
@@ -89,7 +89,7 @@ jasmine.TrivialReporter.prototype.reportRunnerStarting = function(runner) {
 
 jasmine.TrivialReporter.prototype.reportRunnerResults = function(runner) {
   var results = runner.results();
-  if(jasmine.TrivialReporter.hasConsole()) {
+  if (jasmine.TrivialReporter.hasConsole()) {
     jasmine.TrivialReporter.reportToConsole(runner.suites());
   }
   var className = (results.failedCount > 0) ? "runner failed" : "runner passed";
@@ -111,39 +111,36 @@ jasmine.TrivialReporter.prototype.reportRunnerResults = function(runner) {
 };
 
 jasmine.TrivialReporter.hasConsole = function() {
-  return window['console'] && console.info && console.warn && console.group && console.groupEnd && console.groupCollapsed
+  return window['console'] && console.info && console.warn && console.group && console.groupEnd && console.groupCollapsed;
 };
 
 jasmine.TrivialReporter.reportToConsole = function (suites) {
   for (var i in suites) {
-	var suite = suites[i]
-    console.group(suite.description)
-	var specs = suite.specs();
+    var suite = suites[i];
+    console.group(suite.description);
+    var specs = suite.specs();
     for (var j in specs) {
-      var spec = specs[j]
+      var spec = specs[j];
       var results = spec.results();
-      res = results
-      var passedSpecs = results.passed()
-      var groupFunc = results.passed() ? console.groupCollapsed : console.group
-      if(results.passed() && console.groupCollapsed) {
-	    console.groupCollapsed(spec.description)
+      if (results.passed() && console.groupCollapsed) {
+        console.groupCollapsed(spec.description);
       } else {
-	    console.group(spec.description)
+        console.group(spec.description);
       }
       var items = results.getItems()
       for (var k in items) {
-	    var item = items[k]
-        if(item.passed && !item.passed()) {
+        var item = items[k];
+        if (item.passed && !item.passed()) {
           console.warn({actual:item.actual,expected: item.expected});
-          item.trace.message = item.matcherName
-          console.error(item.trace)
+          item.trace.message = item.matcherName;
+          console.error(item.trace);
         } else {
-          console.info('Passed')
+          console.info('Passed');
         }
       }
-      console.groupEnd()
+      console.groupEnd();
     }
-    console.groupEnd()
+    console.groupEnd();
   }
 };
 

--- a/src/html/TrivialReporter.js
+++ b/src/html/TrivialReporter.js
@@ -89,7 +89,7 @@ jasmine.TrivialReporter.prototype.reportRunnerStarting = function(runner) {
 
 jasmine.TrivialReporter.prototype.reportRunnerResults = function(runner) {
   var results = runner.results();
-  if(jasmine.TrivialReporter.hasConsole()) {
+  if (jasmine.TrivialReporter.hasConsole()) {
     jasmine.TrivialReporter.reportToConsole(runner.suites());
   }
   var className = (results.failedCount > 0) ? "runner failed" : "runner passed";
@@ -111,39 +111,36 @@ jasmine.TrivialReporter.prototype.reportRunnerResults = function(runner) {
 };
 
 jasmine.TrivialReporter.hasConsole = function() {
-  return window['console'] && console.info && console.warn && console.group && console.groupEnd && console.groupCollapsed
+  return window['console'] && console.info && console.warn && console.group && console.groupEnd && console.groupCollapsed;
 };
 
 jasmine.TrivialReporter.reportToConsole = function (suites) {
   for (var i in suites) {
-	var suite = suites[i]
-    console.group(suite.description)
-	var specs = suite.specs();
+    var suite = suites[i];
+    console.group(suite.description);
+    var specs = suite.specs();
     for (var j in specs) {
-      var spec = specs[j]
+      var spec = specs[j];
       var results = spec.results();
-      res = results
-      var passedSpecs = results.passed()
-      var groupFunc = results.passed() ? console.groupCollapsed : console.group
-      if(results.passed() && console.groupCollapsed) {
-	    console.groupCollapsed(spec.description)
+      if (results.passed() && console.groupCollapsed) {
+        console.groupCollapsed(spec.description);
       } else {
-	    console.group(spec.description)
+        console.group(spec.description);
       }
       var items = results.getItems()
       for (var k in items) {
-	    var item = items[k]
-        if(item.passed && !item.passed()) {
+        var item = items[k];
+        if (item.passed && !item.passed()) {
           console.warn({actual:item.actual,expected: item.expected});
-          item.trace.message = item.matcherName
-          console.error(item.trace)
+          item.trace.message = item.matcherName;
+          console.error(item.trace);
         } else {
-          console.info('Passed')
+          console.info('Passed');
         }
       }
-      console.groupEnd()
+      console.groupEnd();
     }
-    console.groupEnd()
+    console.groupEnd();
   }
 };
 


### PR DESCRIPTION
Benefits
- Printing actual and expected values to console helps comparing them because of DOM browser. 
- Line breaks and multiple white spaces can be spotted more easily when the results are unformatted. 
- Console stack trace shows the line number of the failing test and production code, wich is also navigable.
- Nothing will fail in case browser doesn't support console.
