### PR TITLE
Patch for better stack traces

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -91,7 +91,10 @@ jasmine.ExpectationResult = function(params) {
   this.actual = params.actual;
 
   this.message = this.passed_ ? 'Passed.' : params.message;
-  this.trace = this.passed_ ? '' : new Error(this.message);
+  this.trace = this.passed_ ? '' : params.trace;
+  if (!this.trace) {
+    this.trace = this.passed_ ? '' : new Error(this.message);
+  }
 };
 
 jasmine.ExpectationResult.prototype.toString = function () {
@@ -1962,7 +1965,8 @@ jasmine.Spec.prototype.waitsFor = function(latchFunction, optional_timeoutMessag
 jasmine.Spec.prototype.fail = function (e) {
   var expectationResult = new jasmine.ExpectationResult({
     passed: false,
-    message: e ? jasmine.util.formatException(e) : 'Exception'
+    message: e ? jasmine.util.formatException(e) : 'Exception',
+    trace: {stack : e.stack}
   });
   this.results_.addResult(expectationResult);
 };


### PR DESCRIPTION
No longer rewriting the stack trace from jasmine.ExpectationResult which results in much more detailed stack traces.
