### PR TITLE
Jshint (i.e. jslint-forked-in-anger) support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ namespace :jasmine do
           passed = false
         end
 
-        if line.scan(/window/).length > 0
+        if line.scan(/window/).length > 0 && !line.include?("typeof")
           puts "Dangerous window at #{src}:#{i}:\n > #{line}"
           passed = false
         end
@@ -55,6 +55,8 @@ namespace :jasmine do
       puts "Lint failed!"
       exit 1
     end
+    
+    system("node jshint/run.js") || exit(1)
   end
 
   desc 'Builds lib/jasmine from source'

--- a/example/spec/SpecHelper.js
+++ b/example/spec/SpecHelper.js
@@ -2,8 +2,8 @@ beforeEach(function() {
   this.addMatchers({
     toBePlaying: function(expectedSong) {
       var player = this.actual;
-      return player.currentlyPlayingSong === expectedSong
-          && player.isPlaying;
+      return player.currentlyPlayingSong === expectedSong && 
+             player.isPlaying;
     }
-  })
+  });
 });

--- a/jshint/jshint.js
+++ b/jshint/jshint.js
@@ -221,7 +221,7 @@
  lightseagreen, lightskyblue, lightslategray, lightsteelblue,
  lightyellow, lime, limegreen, line, "line-height", linen, link,
  "list-style", "list-style-image", "list-style-position",
- "list-style-type", load, loadClass, localStorage, location, log, m, magenta,
+ "list-style-type", load, loadClass, localStorage, location, log, loopfunc, m, magenta,
  map, margin, "margin-bottom", "margin-left", "margin-right", "margin-top",
  mark, "marker-offset", maroon, match, "max-height", "max-width", maxerr,
  maxlen, md5, mediumaquamarine, mediumblue, mediumorchid, mediumpurple,
@@ -314,9 +314,9 @@ var JSHINT = (function () {
         },
 
 
-// These are the JSHint options.
+// These are the JSHint boolean options.
 
-        options = {
+        boolOptions = {
             adsafe     : true, // if ADsafe should be enforced
             asi        : true, // if automatic semicolon insertion should be tolerated
             bitwise    : true, // if bitwise operators should not be allowed
@@ -336,6 +336,7 @@ var JSHINT = (function () {
             immed      : true, // if immediate invocations must be wrapped in parens
             jquery     : true, // if jQuery globals should be predefined
             laxbreak   : true, // if line breaks should not be checked
+            loopfunc   : true, // if functions should be allowed to be defined within loops
             newcap     : true, // if constructor names must be capitalized
             noarg      : true, // if arguments.caller and arguments.callee should be disallowed
             node       : true, // if the Node.js environment globals should be predefined
@@ -356,7 +357,7 @@ var JSHINT = (function () {
             white      : true, // if strict whitespace rules apply
             widget     : true  // if the Yahoo Widgets globals should be predefined
         },
-        
+
 // browser contains a set of global names which are commonly provided by a
 // web browser environment.
 
@@ -2017,7 +2018,7 @@ klass:                                  do {
                 warning("ADsafe restriction.");
             }
             obj = option;
-            filter = options;
+            filter = boolOptions;
             break;
         case '/*global':
             if (option.safe) {
@@ -4896,7 +4897,7 @@ loop:   for (;;) {
                     t = nexttoken;
                     adjacent(token, nexttoken);
                     f = doFunction(i);
-                    if (funct['(loopage)']) {
+                    if (!option.loopfunc && funct['(loopage)']) {
                         warning("Don't make functions within a loop.", t);
                     }
                     p = f['(params)'];
@@ -5032,7 +5033,7 @@ loop:   for (;;) {
             nonadjacent(token, nexttoken);
         }
         doFunction(i);
-        if (funct['(loopage)']) {
+        if (!option.loopfunc && funct['(loopage)']) {
             warning("Don't make functions within a loop.");
         }
         return this;
@@ -5529,11 +5530,10 @@ loop:   for (;;) {
 
 // The actual JSHINT function itself.
 
-    var itself = function (s, o, g) {
+    var itself = function (s, o) {
         var a, i, k;
         JSHINT.errors = [];
         predefined = Object.create(standard);
-        combine(predefined, g || {});
         if (o) {
             a = o.predef;
             if (a) {
@@ -5552,22 +5552,23 @@ loop:   for (;;) {
                 o.safe = true;
             }
             if (o.safe) {
-                o.browser =
-                o.css     =
-                o.debug   =
-                o.devel   =
-                o.evil    =
-                o.forin   =
-                o.on      =
-                o.rhino   =
-                o.windows =
-                o.sub     =
-                o.widget  = false;
+                o.browser  =
+                o.css      =
+                o.debug    =
+                o.devel    =
+                o.evil     =
+                o.forin    =
+                o.loopfunc =
+                o.on       =
+                o.rhino    =
+                o.windows  =
+                o.sub      =
+                o.widget   = false;
 
-                o.eqeqeq  =
-                o.nomen   =
-                o.safe    =
-                o.undef   = true;
+                o.eqeqeq   =
+                o.nomen    =
+                o.safe     =
+                o.undef    = true;
 
                 predefined.Date =
                 predefined['eval'] =

--- a/jshint/run.js
+++ b/jshint/run.js
@@ -1,42 +1,70 @@
-var fs = require("fs")
-var sys = require("sys")
-var path = require("path")
+var fs = require("fs");
+var sys = require("sys");
+var path = require("path");
 var JSHINT = require("./jshint").JSHINT;
 
-function isVendorFile(fullPath) {
-  var fileName = path.basename(fullPath)
-  var vendorFiles = ["json2.js", "jshint.js", "publish.js"]
-  for (var i=0; i<vendorFiles.length; i++) if (fileName==vendorFiles[i]) return true
-  return false
+function isExcluded(fullPath) {
+  var fileName = path.basename(fullPath);
+  var excludeFiles = ["json2.js", "jshint.js", "publish.js", "node_suite.js", "jasmine.js", "jasmine-html.js"];
+  for (var i=0; i<excludeFiles.length; i++) if (fileName==excludeFiles[i]) return true;
+  return false;
 }
 
 function allJasmineJsFiles(rootDir) {
-  var files = []
-  var things = fs.readdirSync(rootDir)
+  var files = [];
+  var things = fs.readdirSync(rootDir);
   for (var i=0; i<things.length; i++) {
-    var thing = things[i]
-    var fullPath = rootDir + "/" + thing
+    var thing = things[i];
+    var fullPath = rootDir + "/" + thing;
     if (fs.statSync(fullPath).isDirectory()) {
-      files = files.concat(allJasmineJsFiles(fullPath))
+      files = files.concat(allJasmineJsFiles(fullPath));
     } else {
-      if (fullPath.match(/\.js$/) && !isVendorFile(fullPath)) files.push(fullPath)
+      if (fullPath.match(/\.js$/) && !isExcluded(fullPath)) files.push(fullPath);
     }
   }
-  return files
+  return files;
 }
 
-var jasmineJsFiles = allJasmineJsFiles(".")
+var jasmineJsFiles = allJasmineJsFiles(".");
+jasmineJsFiles.reverse(); //cheap way to do the stuff in src stuff first
 
-var jasmineJsHintConfig = {}
-var jasmineGlobals = {}
+var jasmineJsHintConfig = {
 
+  forin:true,             //while it's possible that we could be
+                          //considering unwanted prototype methods, mostly
+                          //we're doing this because the jsobjects are being
+                          //used as maps.
+  
+  loopfunc:true           //we're fine with functions defined inside loops (setTimeout functions, etc)
+
+};
+
+var jasmineGlobals = {};
+
+
+//jasmine.undefined is a jasmine-ism, let's let it go...
+function removeJasmineUndefinedErrors(errors) {
+  var keepErrors = [];
+  for(var i=0; i<errors.length; i++) {
+    if (!(errors[i] &&
+          errors[i].raw && 
+          errors[i].evidence &&
+          ( errors[i].evidence.match(/jasmine\.undefined/) ||
+            errors[i].evidence.match(/diz be undefined yo/) )
+       )) keepErrors.push(errors[i]);
+  }
+  return keepErrors;  
+}
 
 for(var i=0; i<jasmineJsFiles.length; i++) {
-  var file = jasmineJsFiles[i]
-  var result = JSHINT(fs.readFileSync(file, "utf8"))
-  if (!result) {
-    console.log("JSHINT failure: ", file)
-    console.log(JSHINT.data().errors)
-    process.exit(1)
+  var file = jasmineJsFiles[i];
+  JSHINT(fs.readFileSync(file, "utf8"), jasmineJsHintConfig);
+  var errors = JSHINT.data().errors || [];
+  errors = removeJasmineUndefinedErrors(errors);
+  
+  if (errors.length>=1) {
+    console.log("JSHINT failure: ", file);
+    console.log(errors);
+    process.exit(1);
   }  
 }

--- a/lib/jasmine-html.js
+++ b/lib/jasmine-html.js
@@ -110,7 +110,7 @@ jasmine.TrivialReporter.prototype.reportRunnerResults = function(runner) {
 jasmine.TrivialReporter.prototype.reportSuiteResults = function(suite) {
   var results = suite.results();
   var status = results.passed() ? 'passed' : 'failed';
-  if (results.totalCount == 0) { // todo: change this to check results.skipped
+  if (results.totalCount === 0) { // todo: change this to check results.skipped
     status = 'skipped';
   }
   this.suiteDivs[suite.id].className += " " + status;
@@ -183,6 +183,6 @@ jasmine.TrivialReporter.prototype.specFilter = function(spec) {
     paramMap[decodeURIComponent(p[0])] = decodeURIComponent(p[1]);
   }
 
-  if (!paramMap["spec"]) return true;
-  return spec.getFullName().indexOf(paramMap["spec"]) == 0;
+  if (!paramMap.spec) return true;
+  return spec.getFullName().indexOf(paramMap.spec) === 0;
 };

--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -1,10 +1,12 @@
+var isCommonJS = typeof window == "undefined";
+
 /**
  * Top level namespace for Jasmine, a lightweight JavaScript BDD/spec/testing framework.
  *
  * @namespace
  */
 var jasmine = {};
-
+if (isCommonJS) exports.jasmine = jasmine;
 /**
  * @private
  */
@@ -106,7 +108,8 @@ jasmine.ExpectationResult.prototype.passed = function () {
  * Getter for the Jasmine environment. Ensures one gets created
  */
 jasmine.getEnv = function() {
-  return jasmine.currentEnv_ = jasmine.currentEnv_ || new jasmine.Env();
+  var env = jasmine.currentEnv_ = jasmine.currentEnv_ || new jasmine.Env();
+  return env;
 };
 
 /**
@@ -169,7 +172,7 @@ jasmine.pp = function(value) {
  * @returns {Boolean}
  */
 jasmine.isDomNode = function(obj) {
-  return obj['nodeType'] > 0;
+  return obj.nodeType > 0;
 };
 
 /**
@@ -405,7 +408,7 @@ jasmine.isSpy = function(putativeSpy) {
  * @param {Array} methodNames array of names of methods to make spies
  */
 jasmine.createSpyObj = function(baseName, methodNames) {
-  if (!jasmine.isArray_(methodNames) || methodNames.length == 0) {
+  if (!jasmine.isArray_(methodNames) || methodNames.length === 0) {
     throw new Error('createSpyObj requires a non-empty array of method names to create spies for');
   }
   var obj = {};
@@ -443,6 +446,7 @@ jasmine.log = function() {
 var spyOn = function(obj, methodName) {
   return jasmine.getEnv().currentSpec.spyOn(obj, methodName);
 };
+if (isCommonJS) exports.spyOn = spyOn;
 
 /**
  * Creates a Jasmine spec that will be added to the current suite.
@@ -460,6 +464,7 @@ var spyOn = function(obj, methodName) {
 var it = function(desc, func) {
   return jasmine.getEnv().it(desc, func);
 };
+if (isCommonJS) exports.it = it;
 
 /**
  * Creates a <em>disabled</em> Jasmine spec.
@@ -472,6 +477,7 @@ var it = function(desc, func) {
 var xit = function(desc, func) {
   return jasmine.getEnv().xit(desc, func);
 };
+if (isCommonJS) exports.xit = xit;
 
 /**
  * Starts a chain for a Jasmine expectation.
@@ -484,6 +490,7 @@ var xit = function(desc, func) {
 var expect = function(actual) {
   return jasmine.getEnv().currentSpec.expect(actual);
 };
+if (isCommonJS) exports.expect = expect;
 
 /**
  * Defines part of a jasmine spec.  Used in cominbination with waits or waitsFor in asynchrnous specs.
@@ -493,6 +500,7 @@ var expect = function(actual) {
 var runs = function(func) {
   jasmine.getEnv().currentSpec.runs(func);
 };
+if (isCommonJS) exports.runs = runs;
 
 /**
  * Waits a fixed time period before moving to the next block.
@@ -503,6 +511,7 @@ var runs = function(func) {
 var waits = function(timeout) {
   jasmine.getEnv().currentSpec.waits(timeout);
 };
+if (isCommonJS) exports.waits = waits;
 
 /**
  * Waits for the latchFunction to return true before proceeding to the next block.
@@ -514,6 +523,7 @@ var waits = function(timeout) {
 var waitsFor = function(latchFunction, optional_timeoutMessage, optional_timeout) {
   jasmine.getEnv().currentSpec.waitsFor.apply(jasmine.getEnv().currentSpec, arguments);
 };
+if (isCommonJS) exports.waitsFor = waitsFor;
 
 /**
  * A function that is called before each spec in a suite.
@@ -525,6 +535,7 @@ var waitsFor = function(latchFunction, optional_timeoutMessage, optional_timeout
 var beforeEach = function(beforeEachFunction) {
   jasmine.getEnv().beforeEach(beforeEachFunction);
 };
+if (isCommonJS) exports.beforeEach = beforeEach;
 
 /**
  * A function that is called after each spec in a suite.
@@ -536,6 +547,7 @@ var beforeEach = function(beforeEachFunction) {
 var afterEach = function(afterEachFunction) {
   jasmine.getEnv().afterEach(afterEachFunction);
 };
+if (isCommonJS) exports.afterEach = afterEach;
 
 /**
  * Defines a suite of specifications.
@@ -555,6 +567,7 @@ var afterEach = function(afterEachFunction) {
 var describe = function(description, specDefinitions) {
   return jasmine.getEnv().describe(description, specDefinitions);
 };
+if (isCommonJS) exports.describe = describe;
 
 /**
  * Disables a suite of specifications.  Used to disable some suites in a file, or files, temporarily during development.
@@ -565,27 +578,27 @@ var describe = function(description, specDefinitions) {
 var xdescribe = function(description, specDefinitions) {
   return jasmine.getEnv().xdescribe(description, specDefinitions);
 };
+if (isCommonJS) exports.xdescribe = xdescribe;
 
 
 // Provide the XMLHttpRequest class for IE 5.x-6.x:
 jasmine.XmlHttpRequest = (typeof XMLHttpRequest == "undefined") ? function() {
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP.6.0");
-  } catch(e) {
+  function tryIt(f) {
+    try {
+      return f();
+    } catch(e) {
+    }    
+    return null;
   }
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP.3.0");
-  } catch(e) {
-  }
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP");
-  } catch(e) {
-  }
-  try {
-    return new ActiveXObject("Microsoft.XMLHTTP");
-  } catch(e) {
-  }
-  throw new Error("This browser does not support XMLHttpRequest.");
+  
+  var xhr = tryIt(function(){return new ActiveXObject("Msxml2.XMLHTTP.6.0");}) ||
+            tryIt(function(){return new ActiveXObject("Msxml2.XMLHTTP.3.0");}) ||
+            tryIt(function(){return new ActiveXObject("Msxml2.XMLHTTP");}) ||
+            tryIt(function(){return new ActiveXObject("Microsoft.XMLHTTP");});
+
+  if (!xhr) throw new Error("This browser does not support XMLHttpRequest.");
+  
+  return xhr;
 } : XMLHttpRequest;
 /**
  * @namespace
@@ -606,7 +619,7 @@ jasmine.util.inherit = function(childClass, parentClass) {
   var subclass = function() {
   };
   subclass.prototype = parentClass.prototype;
-  childClass.prototype = new subclass;
+  childClass.prototype = new subclass();
 };
 
 jasmine.util.formatException = function(e) {
@@ -828,7 +841,7 @@ jasmine.Env.prototype.compareObjects_ = function(a, b, mismatchKeys, mismatchVal
   b.__Jasmine_been_here_before__ = a;
 
   var hasKey = function(obj, keyName) {
-    return obj != null && obj[keyName] !== jasmine.undefined;
+    return obj !== null && obj[keyName] !== jasmine.undefined;
   };
 
   for (var property in b) {
@@ -854,7 +867,7 @@ jasmine.Env.prototype.compareObjects_ = function(a, b, mismatchKeys, mismatchVal
 
   delete a.__Jasmine_been_here_before__;
   delete b.__Jasmine_been_here_before__;
-  return (mismatchKeys.length == 0 && mismatchValues.length == 0);
+  return (mismatchKeys.length === 0 && mismatchValues.length === 0);
 };
 
 jasmine.Env.prototype.equals_ = function(a, b, mismatchKeys, mismatchValues) {
@@ -1302,7 +1315,7 @@ jasmine.Matchers.prototype.toHaveBeenCalledWith = function() {
     throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
   }
   this.message = function() {
-    if (this.actual.callCount == 0) {
+    if (this.actual.callCount === 0) {
       // todo: what should the failure message for .not.toHaveBeenCalledWith() be? is this right? test better. [xw]
       return [
         "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but it was never called.",
@@ -1333,7 +1346,7 @@ jasmine.Matchers.prototype.wasNotCalledWith = function() {
     return [
       "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but it was",
       "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but it was"
-    ]
+    ];
   };
 
   return !this.env.contains_(this.actual.argsForCall, expectedArgs);
@@ -1390,7 +1403,7 @@ jasmine.Matchers.prototype.toThrow = function(expected) {
 
   this.message = function() {
     if (exception && (expected === jasmine.undefined || !this.env.equals_(exception.message || exception, expected.message || expected))) {
-      return ["Expected function " + not + "to throw", expected ? expected.message || expected : " an exception", ", but it threw", exception.message || exception].join(' ');
+      return ["Expected function " + not + "to throw", expected ? expected.message || expected : "an exception", ", but it threw", exception.message || exception].join(' ');
     } else {
       return "Expected function to throw an exception.";
     }
@@ -1602,7 +1615,8 @@ jasmine.PrettyPrinter.prototype.format = function(value) {
 jasmine.PrettyPrinter.prototype.iterateObject = function(obj, fn) {
   for (var property in obj) {
     if (property == '__Jasmine_been_here_before__') continue;
-    fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) != null) : false);
+    fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) !== jasmine.undefined && 
+                                         obj.__lookupGetter__(property) !== null) : false);
   }
 };
 
@@ -2417,5 +2431,5 @@ jasmine.version_= {
   "major": 1,
   "minor": 0,
   "build": 1,
-  "revision": 1286311016
+  "revision": 1298761339
 };

--- a/spec/node_suite.js
+++ b/spec/node_suite.js
@@ -3,10 +3,10 @@ var sys = require('sys');
 var path = require('path');
 
 // yes, really keep this here to keep us honest, but only for jasmine's own runner! [xw]
-undefined = "diz be undefined yo";
+// undefined = "diz be undefined yo";
 
 var jasmineGlobals = require("../src/base");
-for(var k in jasmineGlobals) {global[k] = jasmineGlobals[k]};
+for(var k in jasmineGlobals) {global[k] = jasmineGlobals[k];}
 
 //load jasmine src files based on the order in runner.html
 var srcFilesInProperRequireOrder = [];
@@ -15,7 +15,7 @@ var srcFileLines = [];
 for (var i=0; i<runnerHtmlLines.length; i++) 
   if (runnerHtmlLines[i].match(/script(.*?)\/src\//)) 
     srcFileLines.push(runnerHtmlLines[i]);
-for (i=0; i<srcFileLines.length; i++) srcFilesInProperRequireOrder.push(/src=\"(.*?)\"/(srcFileLines[i])[1]);
+for (i=0; i<srcFileLines.length; i++) srcFilesInProperRequireOrder.push(srcFileLines[i].match(/src=\"(.*?)\"/)[1]);
 for (i=0; i<srcFilesInProperRequireOrder.length; i++) require(srcFilesInProperRequireOrder[i]);
 
 
@@ -66,7 +66,7 @@ jasmine.executeSpecs = function(specs, done, isVerbose, showColors){
     
     reportRunnerStarting: function(runner) {
       sys.puts('Started');
-      start = Number(new Date);
+      start = new Date().getTime();
     },
 
     reportSuiteResults: function(suite) {
@@ -112,7 +112,7 @@ jasmine.executeSpecs = function(specs, done, isVerbose, showColors){
 
 
     reportRunnerResults: function(runner) {
-      elapsed = (Number(new Date) - start) / 1000;
+      elapsed = (new Date().getTime() - start) / 1000;
       sys.puts('\n');
       log.forEach(function(log){
         sys.puts(log);
@@ -216,16 +216,16 @@ process.argv.forEach(function(arg){
   }
 });
 
-var specs = jasmine.getAllSpecFiles(__dirname + '/suites', new RegExp("^.+\.(js|coffee)$"));
+var specs = jasmine.getAllSpecFiles(__dirname + '/suites', new RegExp(".js$"));
 var domIndependentSpecs = [];
 for(var i=0; i<specs.length; i++) { 
   if (fs.readFileSync(specs[i], "utf8").indexOf("document.createElement")<0) {
     domIndependentSpecs.push(specs[i]);
-  }; 
-};
+  }
+}
 
 jasmine.executeSpecs(domIndependentSpecs, function(runner, log){
-  if (runner.results().failedCount == 0) {
+  if (runner.results().failedCount === 0) {
     process.exit(0);
   } else {
     process.exit(1);

--- a/spec/suites/EnvSpec.js
+++ b/spec/suites/EnvSpec.js
@@ -108,7 +108,7 @@ describe("jasmine.Env", function() {
 
         it("should give custom equality testers precedence", function() {
           expect(env.equals_('abc', 'abc')).toBeFalsy();
-          var o = new Object();
+          var o = {};
           expect(env.equals_(o, o)).toBeFalsy();
         });
       });

--- a/spec/suites/ExceptionsSpec.js
+++ b/spec/suites/ExceptionsSpec.js
@@ -89,9 +89,9 @@ describe('Exceptions:', function() {
     expect(blockResults[0].message).toMatch(/fake error 1/);
 
     expect(specResults[1].passed()).toEqual(false);
-    var blockResults = specResults[1].getItems();
+    blockResults = specResults[1].getItems();
     expect(blockResults[0].passed()).toEqual(false);
-    expect(blockResults[0].message).toMatch(/fake error 2/),
+    expect(blockResults[0].message).toMatch(/fake error 2/);
     expect(blockResults[1].passed()).toEqual(true);
 
     expect(specResults[2].passed()).toEqual(true);

--- a/spec/suites/JsApiReporterSpec.js
+++ b/spec/suites/JsApiReporterSpec.js
@@ -21,7 +21,7 @@ describe('jasmine.jsApiReporter', function() {
         nestedSuite = env.describe("nested suite", function() {
           nestedSpec = env.it("nested spec", function() {
             expect(true).toEqual(true);
-          })
+          });
         });
 
         spec3 = env.it("spec 3", function() {

--- a/spec/suites/MatchersSpec.js
+++ b/spec/suites/MatchersSpec.js
@@ -18,7 +18,7 @@ describe("jasmine.Matchers", function() {
       toFail: function() {
         return !lastResult().passed();
       }
-    })
+    });
   });
 
   function match(value) {
@@ -68,15 +68,15 @@ describe("jasmine.Matchers", function() {
     expect((match(['a', 'b']).toEqual(['a', jasmine.undefined]))).toFail();
     expect((match(['a', 'b']).toEqual(['a', 'b', jasmine.undefined]))).toFail();
 
-    expect((match(new String("cat")).toEqual("cat"))).toPass();
-    expect((match(new String("cat")).toNotEqual("cat"))).toFail();
+    expect((match("cat").toEqual("cat"))).toPass();
+    expect((match("cat").toNotEqual("cat"))).toFail();
 
-    expect((match(new Number(5)).toEqual(5))).toPass();
-    expect((match(new Number('5')).toEqual(5))).toPass();
-    expect((match(new Number(5)).toNotEqual(5))).toFail();
-    expect((match(new Number('5')).toNotEqual(5))).toFail();
+    expect((match(5).toEqual(5))).toPass();
+    expect((match(parseInt('5', 10)).toEqual(5))).toPass();
+    expect((match(5).toNotEqual(5))).toFail();
+    expect((match(parseInt('5', 10)).toNotEqual(5))).toFail();
   });
-
+  
   it("toEqual with DOM nodes", function() {
     var nodeA = document.createElement('div');
     var nodeB = document.createElement('div');
@@ -500,7 +500,7 @@ describe("jasmine.Matchers", function() {
       describe("and matcher is inverted with .not", function() {
         it("should match any exception", function() {
           expect(match(throwingFn).not.toThrow()).toFail();
-          expect(lastResult().message).toMatch(/Expected function not to throw  an exception/);
+          expect(lastResult().message).toMatch(/Expected function not to throw an exception/);
         });
 
         it("should match exceptions specified by message", function() {

--- a/spec/suites/MultiReporterSpec.js
+++ b/spec/suites/MultiReporterSpec.js
@@ -18,9 +18,9 @@ describe("jasmine.MultiReporter", function() {
         delegate[methodName] = jasmine.createSpy(methodName);
         this.actual[methodName]("whatever argument");
 
-        return delegate[methodName].wasCalled
-            && delegate[methodName].mostRecentCall.args.length == 1
-            && delegate[methodName].mostRecentCall.args[0] == "whatever argument";
+        return delegate[methodName].wasCalled && 
+               delegate[methodName].mostRecentCall.args.length == 1 && 
+               delegate[methodName].mostRecentCall.args[0] == "whatever argument";
       }
     });
 

--- a/spec/suites/SpecSpec.js
+++ b/spec/suites/SpecSpec.js
@@ -38,7 +38,7 @@ describe('Spec', function () {
 
   it('getFullName returns suite & spec description', function () {
     var spec = new jasmine.Spec(env, suite, 'spec 1');
-    expect(spec.getFullName()).toEqual('suite 1 spec 1.')
+    expect(spec.getFullName()).toEqual('suite 1 spec 1.');
   });
 
   describe('results', function () {

--- a/spec/suites/UtilSpec.js
+++ b/spec/suites/UtilSpec.js
@@ -25,7 +25,6 @@ describe("jasmine.util", function() {
     it("should return true if the argument is an array", function() {
       expect(jasmine.isArray_([])).toBe(true);
       expect(jasmine.isArray_(['a'])).toBe(true);
-      expect(jasmine.isArray_(new Array())).toBe(true);
     });
 
     it("should return false if the argument is not an array", function() {

--- a/src/Env.js
+++ b/src/Env.js
@@ -172,7 +172,7 @@ jasmine.Env.prototype.compareObjects_ = function(a, b, mismatchKeys, mismatchVal
   b.__Jasmine_been_here_before__ = a;
 
   var hasKey = function(obj, keyName) {
-    return obj != null && obj[keyName] !== jasmine.undefined;
+    return obj !== null && obj[keyName] !== jasmine.undefined;
   };
 
   for (var property in b) {
@@ -198,7 +198,7 @@ jasmine.Env.prototype.compareObjects_ = function(a, b, mismatchKeys, mismatchVal
 
   delete a.__Jasmine_been_here_before__;
   delete b.__Jasmine_been_here_before__;
-  return (mismatchKeys.length == 0 && mismatchValues.length == 0);
+  return (mismatchKeys.length === 0 && mismatchValues.length === 0);
 };
 
 jasmine.Env.prototype.equals_ = function(a, b, mismatchKeys, mismatchValues) {

--- a/src/Matchers.js
+++ b/src/Matchers.js
@@ -227,7 +227,7 @@ jasmine.Matchers.prototype.toHaveBeenCalledWith = function() {
     throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
   }
   this.message = function() {
-    if (this.actual.callCount == 0) {
+    if (this.actual.callCount === 0) {
       // todo: what should the failure message for .not.toHaveBeenCalledWith() be? is this right? test better. [xw]
       return [
         "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but it was never called.",
@@ -258,7 +258,7 @@ jasmine.Matchers.prototype.wasNotCalledWith = function() {
     return [
       "Expected spy not to have been called with " + jasmine.pp(expectedArgs) + " but it was",
       "Expected spy to have been called with " + jasmine.pp(expectedArgs) + " but it was"
-    ]
+    ];
   };
 
   return !this.env.contains_(this.actual.argsForCall, expectedArgs);
@@ -315,7 +315,7 @@ jasmine.Matchers.prototype.toThrow = function(expected) {
 
   this.message = function() {
     if (exception && (expected === jasmine.undefined || !this.env.equals_(exception.message || exception, expected.message || expected))) {
-      return ["Expected function " + not + "to throw", expected ? expected.message || expected : " an exception", ", but it threw", exception.message || exception].join(' ');
+      return ["Expected function " + not + "to throw", expected ? expected.message || expected : "an exception", ", but it threw", exception.message || exception].join(' ');
     } else {
       return "Expected function to throw an exception.";
     }

--- a/src/PrettyPrinter.js
+++ b/src/PrettyPrinter.js
@@ -58,7 +58,8 @@ jasmine.PrettyPrinter.prototype.format = function(value) {
 jasmine.PrettyPrinter.prototype.iterateObject = function(obj, fn) {
   for (var property in obj) {
     if (property == '__Jasmine_been_here_before__') continue;
-    fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) != null) : false);
+    fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) !== jasmine.undefined && 
+                                         obj.__lookupGetter__(property) !== null) : false);
   }
 };
 

--- a/src/base.js
+++ b/src/base.js
@@ -108,7 +108,8 @@ jasmine.ExpectationResult.prototype.passed = function () {
  * Getter for the Jasmine environment. Ensures one gets created
  */
 jasmine.getEnv = function() {
-  return jasmine.currentEnv_ = jasmine.currentEnv_ || new jasmine.Env();
+  var env = jasmine.currentEnv_ = jasmine.currentEnv_ || new jasmine.Env();
+  return env;
 };
 
 /**
@@ -171,7 +172,7 @@ jasmine.pp = function(value) {
  * @returns {Boolean}
  */
 jasmine.isDomNode = function(obj) {
-  return obj['nodeType'] > 0;
+  return obj.nodeType > 0;
 };
 
 /**
@@ -407,7 +408,7 @@ jasmine.isSpy = function(putativeSpy) {
  * @param {Array} methodNames array of names of methods to make spies
  */
 jasmine.createSpyObj = function(baseName, methodNames) {
-  if (!jasmine.isArray_(methodNames) || methodNames.length == 0) {
+  if (!jasmine.isArray_(methodNames) || methodNames.length === 0) {
     throw new Error('createSpyObj requires a non-empty array of method names to create spies for');
   }
   var obj = {};
@@ -582,21 +583,20 @@ if (isCommonJS) exports.xdescribe = xdescribe;
 
 // Provide the XMLHttpRequest class for IE 5.x-6.x:
 jasmine.XmlHttpRequest = (typeof XMLHttpRequest == "undefined") ? function() {
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP.6.0");
-  } catch(e) {
+  function tryIt(f) {
+    try {
+      return f();
+    } catch(e) {
+    }    
+    return null;
   }
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP.3.0");
-  } catch(e) {
-  }
-  try {
-    return new ActiveXObject("Msxml2.XMLHTTP");
-  } catch(e) {
-  }
-  try {
-    return new ActiveXObject("Microsoft.XMLHTTP");
-  } catch(e) {
-  }
-  throw new Error("This browser does not support XMLHttpRequest.");
+  
+  var xhr = tryIt(function(){return new ActiveXObject("Msxml2.XMLHTTP.6.0");}) ||
+            tryIt(function(){return new ActiveXObject("Msxml2.XMLHTTP.3.0");}) ||
+            tryIt(function(){return new ActiveXObject("Msxml2.XMLHTTP");}) ||
+            tryIt(function(){return new ActiveXObject("Microsoft.XMLHTTP");});
+
+  if (!xhr) throw new Error("This browser does not support XMLHttpRequest.");
+  
+  return xhr;
 } : XMLHttpRequest;

--- a/src/html/TrivialReporter.js
+++ b/src/html/TrivialReporter.js
@@ -110,7 +110,7 @@ jasmine.TrivialReporter.prototype.reportRunnerResults = function(runner) {
 jasmine.TrivialReporter.prototype.reportSuiteResults = function(suite) {
   var results = suite.results();
   var status = results.passed() ? 'passed' : 'failed';
-  if (results.totalCount == 0) { // todo: change this to check results.skipped
+  if (results.totalCount === 0) { // todo: change this to check results.skipped
     status = 'skipped';
   }
   this.suiteDivs[suite.id].className += " " + status;
@@ -183,6 +183,6 @@ jasmine.TrivialReporter.prototype.specFilter = function(spec) {
     paramMap[decodeURIComponent(p[0])] = decodeURIComponent(p[1]);
   }
 
-  if (!paramMap["spec"]) return true;
-  return spec.getFullName().indexOf(paramMap["spec"]) == 0;
+  if (!paramMap.spec) return true;
+  return spec.getFullName().indexOf(paramMap.spec) === 0;
 };

--- a/src/util.js
+++ b/src/util.js
@@ -17,7 +17,7 @@ jasmine.util.inherit = function(childClass, parentClass) {
   var subclass = function() {
   };
   subclass.prototype = parentClass.prototype;
-  childClass.prototype = new subclass;
+  childClass.prototype = new subclass();
 };
 
 jasmine.util.formatException = function(e) {


### PR DESCRIPTION
- Jshint added to the project.
- To run jshint evaluation:
  node jshint/run.js
- Jasmine passes jshint with the following options / modifications from the jslint defaults:
  - forin:true - we don't care about the risk of copying prototype methods in a for(var k in obj) scenario
  - loopfunc:true - it's ok to create functions within loops (such as setTimeout...func)
  - I wrote custom code to exclude errors having to do with jasmine.undefined.  Jshint isn't happy about the use of a reserved word, but obviously there are good reasons to be using this in jasmine.
    (you'll see all this stuff at the bottom of jshint/run.js)
- I added the following to rake jasmine:lint
  system("node jshint/run.js") || exit(1)
- Also it seems to me that this project probably ought to move away from using ruby and toward node and node libraries.  Just my opinion.
