### PR TITLE
toBeCloseTo

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -1367,6 +1367,24 @@ jasmine.Matchers.prototype.toBeGreaterThan = function(expected) {
 };
 
 /**
+ * Matcher that checks that the expected item is equal to the actual item
+ * up to a given level of decimal precision (default 2).
+ *
+ * @param {Number} expected
+ * @param {Number} precision
+ */
+jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
+  if (!(precision === 0)) {
+    precision = precision || 2;
+  }
+  var multiplier = Math.pow(10, precision);
+  var actual = Math.round(this.actual * multiplier);
+  expected = Math.round(expected * multiplier);
+  return expected == actual;
+};
+
+
+/**
  * Matcher that checks that the expected exception was thrown by the actual.
  *
  * @param {String} expected
@@ -2417,5 +2435,5 @@ jasmine.version_= {
   "major": 1,
   "minor": 0,
   "build": 2,
-  "revision": 1298837858
+  "revision": 1299266181
 };

--- a/spec/suites/MatchersSpec.js
+++ b/spec/suites/MatchersSpec.js
@@ -471,6 +471,47 @@ describe("jasmine.Matchers", function() {
     expect(result.expected).toEqual(expected);
   });
 
+  describe("toBeCloseTo", function() {
+    it("returns 'true' iff actual and expected are equal within 2 decimal points of precision", function() {
+      expect(0).toBeCloseTo(0);
+      expect(1).toBeCloseTo(1);
+      expect(1).not.toBeCloseTo(1.1);
+      expect(1).not.toBeCloseTo(1.01);
+      expect(1).toBeCloseTo(1.001);
+
+      expect(1.23).toBeCloseTo(1.234);
+      expect(1.23).toBeCloseTo(1.233);
+      expect(1.23).toBeCloseTo(1.232);
+      expect(1.23).not.toBeCloseTo(1.24);
+
+      expect(-1.23).toBeCloseTo(-1.234);
+      expect(-1.23).not.toBeCloseTo(-1.24);
+    });
+
+    it("accepts an optional precision argument", function() {
+      expect(1).toBeCloseTo(1.1, 0);
+      expect(1.2).toBeCloseTo(1.23, 1);
+
+      expect(1.234).toBeCloseTo(1.2343, 3);
+      expect(1.234).not.toBeCloseTo(1.233, 3);
+    });
+
+    it("rounds", function() {
+      expect(1.23).toBeCloseTo(1.229);
+      expect(1.23).toBeCloseTo(1.226);
+      expect(1.23).toBeCloseTo(1.225);
+      expect(1.23).not.toBeCloseTo(1.2249999);
+
+      expect(1.23).toBeCloseTo(1.234);
+      expect(1.23).toBeCloseTo(1.2349999);
+      expect(1.23).not.toBeCloseTo(1.235);
+
+      expect(-1.23).toBeCloseTo(-1.234);
+      expect(-1.23).not.toBeCloseTo(-1.235);
+      expect(-1.23).not.toBeCloseTo(-1.236);
+    });
+  });
+
   describe("toThrow", function() {
     describe("when code block throws an exception", function() {
       var throwingFn;

--- a/src/Matchers.js
+++ b/src/Matchers.js
@@ -292,6 +292,24 @@ jasmine.Matchers.prototype.toBeGreaterThan = function(expected) {
 };
 
 /**
+ * Matcher that checks that the expected item is equal to the actual item
+ * up to a given level of decimal precision (default 2).
+ *
+ * @param {Number} expected
+ * @param {Number} precision
+ */
+jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
+  if (!(precision === 0)) {
+    precision = precision || 2;
+  }
+  var multiplier = Math.pow(10, precision);
+  var actual = Math.round(this.actual * multiplier);
+  expected = Math.round(expected * multiplier);
+  return expected == actual;
+};
+
+
+/**
  * Matcher that checks that the expected exception was thrown by the actual.
  *
  * @param {String} expected


### PR DESCRIPTION
A matcher for floating-point number comparison. Useful for testing that Fahrenheit-to-Celcius converter you've always dreamed of... :-)
