### PR TITLE
Nicer error messages for toHaveBeenCalledWith

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -2429,7 +2429,7 @@ jasmine.getGlobal().clearInterval = function(timeoutKey) {
 
 jasmine.version_= {
   "major": 1,
-  "minor": 0,
-  "build": 2,
-  "revision": 1299565706
+  "minor": 1,
+  "build": 0,
+  "revision": 1299963843
 };


### PR DESCRIPTION
Now includes the name of the spy in the error message just like toHaveBeenCalled
