### PR TITLE
Passing through ignoreMethodDoesntExist parameter from spyOn() to jasmine.Spec.prototype.spyOn

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -443,8 +443,8 @@ jasmine.log = function() {
  * @param methodName
  * @returns a Jasmine spy that can be chained with all spy methods
  */
-var spyOn = function(obj, methodName) {
-  return jasmine.getEnv().currentSpec.spyOn(obj, methodName);
+var spyOn = function(obj, methodName, ignoreMethodDoesntExist) {
+  return jasmine.getEnv().currentSpec.spyOn(obj, methodName, ignoreMethodDoesntExist);
 };
 if (isCommonJS) exports.spyOn = spyOn;
 


### PR DESCRIPTION
The specific case which I need to fix is running jasmine-ajax in JSTestDriver (via the jasmine-jstd-adapter). At the moment, running more than one test case will re-add the spy - passing through the ignore parameter fixes this.
