### PR TITLE
If the first description throws an exception (syntax error or whatever) then the test suite breaks

### DIFF
--- a/lib/jasmine.js
+++ b/lib/jasmine.js
@@ -779,7 +779,7 @@ jasmine.Env.prototype.describe = function(description, specDefinitions) {
     declarationError = e;
   }
 
-  this.currentSuite = parentSuite;
+  this.currentSuite = parentSuite || suite;
 
   if (declarationError) {
     this.it("encountered a declaration exception", function() {


### PR DESCRIPTION
Exceptions thrown by description functions are caught and are used to create a failed test report, but jasmine actually fails to set the current test suite properly and so this also fails.
