### PR TITLE
Use stack property to format exception if available.

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -2476,6 +2476,6 @@ jasmine.version_= {
   "major": 1,
   "minor": 1,
   "build": 0,
-  "revision": 1308618948,
+  "revision": 1308796784,
   "release_candidate": 1
 };

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -21,6 +21,10 @@ jasmine.util.inherit = function(childClass, parentClass) {
 };
 
 jasmine.util.formatException = function(e) {
+  if (e.stack) {
+    return e.stack;
+  }
+
   var lineNumber;
   if (e.line) {
     lineNumber = e.line;

--- a/src/version.js
+++ b/src/version.js
@@ -2,6 +2,6 @@ jasmine.version_= {
   "major": 1,
   "minor": 1,
   "build": 0,
-  "revision": 1308618948,
+  "revision": 1308796784,
   "release_candidate": 1
 };


### PR DESCRIPTION
Running jasmine via jasmine-node, the last portion of the stack trace is cut off because v8 implements different error properties.

Using error.stack fixes the issue.
