### PR TITLE
toEqualWithPrecision matcher function

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1420,6 +1420,7 @@ jasmine.Matchers.prototype.toBeGreaterThan = function(expected) {
  * @deprecated  
  */
 jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
+  if(!precision) precision = 2;
   this.toEqualWithPrecision(expected, precision);
 };
 
@@ -1433,6 +1434,11 @@ jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
  * @param {Number} precision
  */
 jasmine.Matchers.prototype.toEqualWithPrecision = function(expected, precision) {
+	if (!precision || precision < 1 || precision > 100) {
+		this.message = function(){return ['Precision is out of range 1-100.']}
+		return false;
+	}
+
 	var toEqualWithPrecision = function(a, b, env, mismatchKeys, mismatchValues) {
 		if (+a === +a && +b === +b) {
 			return (+a).toPrecision(precision) === (+b).toPrecision(precision);


### PR DESCRIPTION
We added matcher toEqualWithPrecision() which is more suitable than original toBeCloseTo(). 

Internet Explorer has an issue that its rounds of floats differently than other browers and we recently discovered that Firefox 5 provides more digits than previous versions making our tests fail. The usual way how to resolve this problem is to round a number down to predefined precision e.g.

precision = 1e6;
num = Math.round(num \* precision) / precision;

We are introducing matcher which is using Javascript 1.5  toPrecision(). We decided to use this method due to the fact that Math.round() doesn't work properly with big integers.  We need to work with number of significant digits as provided by the toPrecision method e.g. 

(12345).toPrecision(2) -> "1.2e+4" 
(1.23456789123456789).toPrecision(10) -> "1.234567891"

(See also: https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Number/toPrecision)

Our new toEqualWithPrecision method can also compare arrays of numbers with given precision. We are reusing Jasmine current code, so we register own equality tester and then we use normal Jasmine equals_ function. Furthermore we also have implemented removeEqualityTester() since we needed a way to properly deregister an equality tester at the end of our match function since on registration we lock precision in closure for current test case.
