### PR TITLE
Reintroducing toBeCloseTo matcher function

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1401,19 +1401,36 @@ jasmine.Matchers.prototype.toBeGreaterThan = function(expected) {
 
 /**
  * Matcher that checks that the expected item is equal to the actual item
- * up to a given level of decimal precision (default 2).
+ * +/- the given error margin. Default value is +/- 0. Method can also compare 
+ *  arrays of numbers with given error margin.  
  *
  * @param {Number} expected
- * @param {Number} precision
+ * @param {Number} errorMargin
  */
-jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
-  if (!(precision === 0)) {
-    precision = precision || 2;
-  }
-  var multiplier = Math.pow(10, precision);
-  var actual = Math.round(this.actual * multiplier);
-  expected = Math.round(expected * multiplier);
-  return expected == actual;
+toBeCloseTo = function (expected, errorMargin) {
+	if (arguments.length < 2) errorMargin = 0;
+	var toBeCloseTo = function (a, b, env, mismatchKeys, mismatchValues) {
+		if (a !== b && a !== null && b !== null && +a === a && +b === b) {
+			return Math.abs(a - b) <= errorMargin;
+		}   
+	};
+	
+	this.env.addEqualityTester(toBeCloseTo);
+	
+	var notPassTrue =  "Expected " + jasmine.pp(this.actual) + " to be close to " +
+			jasmine.pp(expected) + " +/- " + jasmine.pp(errorMargin) + ".";
+	var notPassFalse = "Expected " + jasmine.pp(this.actual) + " to be not close to " +
+			jasmine.pp(expected) + " +/- " + jasmine.pp(errorMargin) + ".";
+	
+	this.message = function() {
+		return [
+			notPassTrue,
+			notPassFalse
+		];
+	};
+	var result = this.env.equals_(this.actual, expected);
+	this.env.removeEqualityTester(toBeCloseTo);
+	return result;
 };
 
 /**


### PR DESCRIPTION
As I mentioned in pull request http://github.com/pivotal/jasmine/pull/104 this is replacement of previous pull request. We introduced toEqualWithPrecision() matcher but it doesn't work for all cases so we decided to improve toBeCloseTo matcher to match two numbers with given error margin. It is of course possible to use this matcher to match arrays.
