### PR TITLE
Method "should" to create specs the same way we do with "it"

### DIFF
--- a/src/core/base.js
+++ b/src/core/base.js
@@ -473,6 +473,20 @@ var it = function(desc, func) {
 };
 if (isCommonJS) exports.it = it;
 
+
+/**
+ * Creates a  Jasmine spec that will be added to the current suite. This is the same as <code>it</code>,
+ * but it's easier to read through the tests.
+ *
+ * @param {String} desc description of this specification
+ * @param {Function} func defines the preconditions and expectations of the spec
+ */
+var should = function(desc, func) {
+    desc = 'should ' + desc;
+    return jasmine.getEnv().it(desc, func);
+}
+if (isCommonJS) exports.should = should;
+
 /**
  * Creates a <em>disabled</em> Jasmine spec.
  *


### PR DESCRIPTION
So I was using jasmine to create tests and I found very repetitive to add every time it('should ...', function () {}) in every test.

This commit will simple add the method "should" to jasmine, so I can create specs like:

should('do something', function () {});

also by using should it will append the word 'should' to the description of the spec.
