### PR TITLE
added async tests using callback pattern. runsAsync.

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1053,7 +1053,7 @@ jasmine.BlockAsync.prototype.execute = function(onComplete) {
     }, this.timeout);
 
     var that = this
-    this.func.apply(this.spec, [null, function(err) {
+    this.func.apply(this.spec, [function(err) {
       that.env.clearTimeout(failTimer);
       if (err) {
         that.spec.fail(err);

--- a/spec/core/SpecRunningSpec.js
+++ b/spec/core/SpecRunningSpec.js
@@ -264,14 +264,14 @@ describe("jasmine spec running", function () {
     foo = 0;
     env.describe('test async spec', function() {
       a_spec = env.it('spec w/ queued statments', function () {
-        this.runsAsync(function (err, callback) {
+        this.runsAsync(function (callback) {
           fakeTimer.setTimeout(function() {
             foo++;
             callback()
           }, 500);
         });
         var that = this
-        this.runsAsync(function(err, callback) {
+        this.runsAsync(function(callback) {
           fakeTimer.setTimeout(function(){
             that.expect(foo).toEqual(1);
             callback()
@@ -299,14 +299,14 @@ describe("jasmine spec running", function () {
     var yet_another_spec;
     env.describe('test async spec', function() {
       yet_another_spec = env.it('spec w/ async fail on a callback', function () {
-        this.runsAsync(function (err, callback) {
+        this.runsAsync(function (callback) {
           fakeTimer.setTimeout(function() {
             baz++;
             callback("not null") //("first arg not null")
           }, 250);
         });
         var that = this
-        this.runsAsync(function(err, callback) {
+        this.runsAsync(function(callback) {
           fakeTimer.setTimeout(function() {
             that.expect(baz).toEqual(1);
             callback()
@@ -331,7 +331,7 @@ describe("jasmine spec running", function () {
     var even_more_spec;
     env.describe('test async spec', function() {
       even_more_spec = env.it('spec w/ async fail on last callback', function () {
-        this.runsAsync(function (err, callback) {
+        this.runsAsync(function (callback) {
           fakeTimer.setTimeout(function() {
             that.expect(bazzy).toEqual(0)
             bazzy++;
@@ -339,7 +339,7 @@ describe("jasmine spec running", function () {
           }, 250);
         });
         var that = this
-        this.runsAsync(function(err, callback) {
+        this.runsAsync(function(callback) {
           fakeTimer.setTimeout(function() {
             that.expect(bazzy).toEqual(1);
             callback("error")
@@ -364,7 +364,7 @@ describe("jasmine spec running", function () {
     env.describe('test async spec', function() {
       mas_spec = env.it('spec w/ async fail by timeout', function () {
         var that = this
-        this.runsAsync(function (err, callback) {
+        this.runsAsync(function (callback) {
           fakeTimer.setTimeout(function() {
             that.expect(foozy).toEqual(0)
             foozy++;


### PR DESCRIPTION
I think callback-style tests would be a good addition to Jasmine. Jasmine already has async tests but they are based either on waiting a specified time, or continuously polling for a condition to be true.

This change adds a `runsAsync` method that is modeled after node.js style async functions. You pass `runsAsync` a function just like `runs`, but this time it takes a `callback` parameter. You call `callback()` when your async function is all done. If the first parameter you call `callback` with is not null, then the test will fail. 

Tests included in commit.
