### PR TITLE
clearInterval should work with mock clock

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -2336,7 +2336,6 @@ jasmine.FakeTimer.prototype.runFunctionsWithinRange = function(oldMillis, nowMil
         scheduledFunc.runAtMillis >= oldMillis &&
         scheduledFunc.runAtMillis <= nowMillis) {
       funcsToRun.push(scheduledFunc);
-      this.scheduledFunctions[timeoutKey] = jasmine.undefined;
     }
   }
 
@@ -2349,11 +2348,13 @@ jasmine.FakeTimer.prototype.runFunctionsWithinRange = function(oldMillis, nowMil
         var funcToRun = funcsToRun[i];
         this.nowMillis = funcToRun.runAtMillis;
         funcToRun.funcToCall();
-        if (funcToRun.recurring) {
+        if (funcToRun.recurring && this.scheduledFunctions[funcToRun.timeoutKey] != jasmine.undefined) {
           this.scheduleFunction(funcToRun.timeoutKey,
               funcToRun.funcToCall,
               funcToRun.millis,
               true);
+        } else {
+          this.scheduledFunctions[funcToRun.timeoutKey] = jasmine.undefined;
         }
       } catch(e) {
       }
@@ -2472,5 +2473,5 @@ jasmine.version_= {
   "major": 1,
   "minor": 1,
   "build": 0,
-  "revision": 1315677058
+  "revision": 1317399768
 };

--- a/spec/core/MockClockSpec.js
+++ b/spec/core/MockClockSpec.js
@@ -30,6 +30,27 @@ describe("MockClock", function () {
       jasmine.Clock.tick(1);
       expect(interval).toEqual(2);
     });
+
+    describe("#clearInterval", function () {
+      var callCount, intervalId;
+      beforeEach(function() {
+        callCount = 0;
+        intervalId = setInterval(function() {
+          callCount++;
+          if (callCount > 1) { clearInterval(intervalId); }
+        }, 30000);
+      });
+
+      it("should prevent the interval function from being called", function() {
+        expect(callCount).toEqual(0);
+        jasmine.Clock.tick(30000);
+        expect(callCount).toEqual(1);
+        jasmine.Clock.tick(30000);
+        expect(callCount).toEqual(2);
+        jasmine.Clock.tick(30000);
+        expect(callCount).toEqual(2);
+      });
+    });
   });
 
   it("shouldn't complain if you call jasmine.Clock.useMock() more than once", function() {

--- a/src/core/mock-timeout.js
+++ b/src/core/mock-timeout.js
@@ -49,7 +49,6 @@ jasmine.FakeTimer.prototype.runFunctionsWithinRange = function(oldMillis, nowMil
         scheduledFunc.runAtMillis >= oldMillis &&
         scheduledFunc.runAtMillis <= nowMillis) {
       funcsToRun.push(scheduledFunc);
-      this.scheduledFunctions[timeoutKey] = jasmine.undefined;
     }
   }
 
@@ -62,11 +61,13 @@ jasmine.FakeTimer.prototype.runFunctionsWithinRange = function(oldMillis, nowMil
         var funcToRun = funcsToRun[i];
         this.nowMillis = funcToRun.runAtMillis;
         funcToRun.funcToCall();
-        if (funcToRun.recurring) {
+        if (funcToRun.recurring && this.scheduledFunctions[funcToRun.timeoutKey] != jasmine.undefined) {
           this.scheduleFunction(funcToRun.timeoutKey,
               funcToRun.funcToCall,
               funcToRun.millis,
               true);
+        } else {
+          this.scheduledFunctions[funcToRun.timeoutKey] = jasmine.undefined;
         }
       } catch(e) {
       }

--- a/src/version.js
+++ b/src/version.js
@@ -2,5 +2,5 @@ jasmine.version_= {
   "major": 1,
   "minor": 1,
   "build": 0,
-  "revision": 1315677058
+  "revision": 1317399768
 };


### PR DESCRIPTION
When using the mock clock, a function should actually stop if it is started by setInterval and then calls clearInterval for itself.  This is not true currently, but this patch fixes the problem.
