### PR TITLE
Fixed negative message when use not.toThrow matcher

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1442,7 +1442,7 @@ jasmine.Matchers.prototype.toThrow = function(expected) {
     if (exception && (expected === jasmine.undefined || !this.env.equals_(exception.message || exception, expected.message || expected))) {
       return ["Expected function " + not + "to throw", expected ? expected.message || expected : "an exception", ", but it threw", exception.message || exception].join(' ');
     } else {
-      return "Expected function to throw an exception.";
+      return "Expected function " + not + "to throw an exception.";
     }
   };
 
@@ -2472,5 +2472,5 @@ jasmine.version_= {
   "major": 1,
   "minor": 1,
   "build": 0,
-  "revision": 1315677058
+  "revision": 1319128960
 };

--- a/spec/core/MatchersSpec.js
+++ b/spec/core/MatchersSpec.js
@@ -542,11 +542,13 @@ describe("jasmine.Matchers", function() {
         it("should match exceptions specified by message", function() {
           expect(match(throwingFn).not.toThrow("Fake Error")).toFail();
 //          expect(lastResult().message).toMatch(/Expected function not to throw Fake Error./);
+          expect(lastResult().message).toMatch(/Expected function not to throw an exception/);
           expect(match(throwingFn).not.toThrow("Other Error")).toPass();
         });
 
         it("should match exceptions specified by Error", function() {
           expect(match(throwingFn).not.toThrow(new Error("Fake Error"))).toFail();
+          expect(lastResult().message).toMatch(/Expected function not to throw an exception/);
 //          expect(lastResult().message).toMatch("Other Error");
           expect(match(throwingFn).not.toThrow(new Error("Other Error"))).toPass();
         });

--- a/src/core/Matchers.js
+++ b/src/core/Matchers.js
@@ -334,7 +334,7 @@ jasmine.Matchers.prototype.toThrow = function(expected) {
     if (exception && (expected === jasmine.undefined || !this.env.equals_(exception.message || exception, expected.message || expected))) {
       return ["Expected function " + not + "to throw", expected ? expected.message || expected : "an exception", ", but it threw", exception.message || exception].join(' ');
     } else {
-      return "Expected function to throw an exception.";
+      return "Expected function " + not + "to throw an exception.";
     }
   };
 

--- a/src/version.js
+++ b/src/version.js
@@ -2,5 +2,5 @@ jasmine.version_= {
   "major": 1,
   "minor": 1,
   "build": 0,
-  "revision": 1315677058
+  "revision": 1319128960
 };


### PR DESCRIPTION
Adding negative message when use matcher not.toThrow with an expected error
