### PR TITLE
Added specLink method and changed href: "?" to href: window.location.search in reporter

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -301,14 +301,14 @@ jasmine.HtmlReporter.ReporterView = function(dom) {
 
     // currently running UI
     if (isUndefined(this.runningAlert)) {
-      this.runningAlert = this.createDom('a', {href: "?", className: "runningAlert bar"});
+      this.runningAlert = this.createDom('a', {href: window.location.search, className: "runningAlert bar"});
       dom.alert.appendChild(this.runningAlert);
     }
     this.runningAlert.innerHTML = "Running " + this.completeSpecCount + " of " + specPluralizedFor(this.totalSpecCount);
 
     // skipped specs UI
     if (isUndefined(this.skippedAlert)) {
-      this.skippedAlert = this.createDom('a', {href: "?", className: "skippedAlert bar"});
+      this.skippedAlert = this.createDom('a', {href: window.location.search, className: "skippedAlert bar"});
     }
 
     this.skippedAlert.innerHTML = "Skipping " + this.skippedCount + " of " + specPluralizedFor(this.totalSpecCount) + " - run all";
@@ -319,13 +319,13 @@ jasmine.HtmlReporter.ReporterView = function(dom) {
 
     // passing specs UI
     if (isUndefined(this.passedAlert)) {
-      this.passedAlert = this.createDom('span', {href: "?", className: "passingAlert bar"});
+      this.passedAlert = this.createDom('span', {href: window.location.search, className: "passingAlert bar"});
     }
     this.passedAlert.innerHTML = "Passing " + specPluralizedFor(this.passedCount);
 
     // failing specs UI
     if (isUndefined(this.failedAlert)) {
-      this.failedAlert = this.createDom('span', {href: "?", className: "failingAlert bar"});
+      this.failedAlert = this.createDom('span', {href: window.location.search, className: "failingAlert bar"});
     }
     this.failedAlert.innerHTML = "Failing " + specPluralizedFor(this.failedCount);
 
@@ -393,7 +393,7 @@ jasmine.HtmlReporter.SpecView = function(spec, dom, views) {
   this.summary = this.createDom('div', { className: 'specSummary' },
       this.createDom('a', {
         className: 'description',
-        href: '?spec=' + encodeURIComponent(this.spec.getFullName()),
+        href: this.specLink(this.spec),
         title: this.spec.getFullName()
       }, this.spec.description)
   );
@@ -401,7 +401,7 @@ jasmine.HtmlReporter.SpecView = function(spec, dom, views) {
   this.detail = this.createDom('div', { className: 'specDetail' },
       this.createDom('a', {
         className: 'description',
-        href: '?spec=' + encodeURIComponent(this.spec.getFullName()),
+        href: this.specLink(this.spec),
         title: this.spec.getFullName()
       }, this.spec.getFullName())
   );
@@ -466,7 +466,7 @@ jasmine.HtmlReporterHelpers.addHelpers(jasmine.HtmlReporter.SpecView);jasmine.Ht
   this.views = views;
 
   this.element = this.createDom('div', { className: 'suite' },
-      this.createDom('a', { className: 'description', href: '?spec=' + encodeURIComponent(this.suite.getFullName()) }, this.suite.description)
+      this.createDom('a', { className: 'description', href: this.specLink(this.suite) }, this.suite.description)
   );
 
   this.appendToSummary(this.suite, this.element);
@@ -481,6 +481,22 @@ jasmine.HtmlReporter.SuiteView.prototype.refresh = function() {
 };
 
 jasmine.HtmlReporterHelpers.addHelpers(jasmine.HtmlReporter.SuiteView);
+
+jasmine.HtmlReporter.prototype.specLink = function (spec) {
+  var query = window.location.search;
+	if(query) {
+		if (query.match(new RegExp("([\?&])spec="))) {
+			query = query.replace(new RegExp("([\?&]spec=)[^&]+"), function ($0, $1) {
+				return $1 + encodeURIComponent(spec.getFullName());
+			});
+		} else {
+			query += "&spec=" + encodeURIComponent(spec.getFullName());
+		}
+	} else {
+		query = "?spec=" + encodeURIComponent(spec.getFullName());
+	}
+	return query;
+}
 
 /* @deprecated Use jasmine.HtmlReporter instead
  */
@@ -532,7 +548,7 @@ jasmine.TrivialReporter.prototype.reportRunnerStarting = function(runner) {
           ),
 
       this.runnerDiv = this.createDom('div', { className: 'runner running' },
-          this.createDom('a', { className: 'run_spec', href: '?' }, "run all"),
+          this.createDom('a', { className: 'run_spec', href: window.location.search }, "run all"),
           this.runnerMessageSpan = this.createDom('span', {}, "Running..."),
           this.finishedAtSpan = this.createDom('span', { className: 'finished-at' }, ""))
       );
@@ -543,8 +559,8 @@ jasmine.TrivialReporter.prototype.reportRunnerStarting = function(runner) {
   for (var i = 0; i < suites.length; i++) {
     var suite = suites[i];
     var suiteDiv = this.createDom('div', { className: 'suite' },
-        this.createDom('a', { className: 'run_spec', href: '?spec=' + encodeURIComponent(suite.getFullName()) }, "run"),
-        this.createDom('a', { className: 'description', href: '?spec=' + encodeURIComponent(suite.getFullName()) }, suite.description));
+        this.createDom('a', { className: 'run_spec', href: this.specLink(suite) }, "run"),
+        this.createDom('a', { className: 'description', href: this.specLink(suite) }, suite.description));
     this.suiteDivs[suite.id] = suiteDiv;
     var parentDiv = this.outerDiv;
     if (suite.parentSuite) {
@@ -588,9 +604,10 @@ jasmine.TrivialReporter.prototype.reportRunnerResults = function(runner) {
   }
   var message = "" + specCount + " spec" + (specCount == 1 ? "" : "s" ) + ", " + results.failedCount + " failure" + ((results.failedCount == 1) ? "" : "s");
   message += " in " + ((new Date().getTime() - this.startedAt.getTime()) / 1000) + "s";
-  this.runnerMessageSpan.replaceChild(this.createDom('a', { className: 'description', href: '?'}, message), this.runnerMessageSpan.firstChild);
+  this.runnerMessageSpan.replaceChild(this.createDom('a', { className: 'description', href: window.location.search}, message), this.runnerMessageSpan.firstChild);
 
   this.finishedAtSpan.appendChild(document.createTextNode("Finished at " + new Date().toString()));
+
 };
 
 jasmine.TrivialReporter.prototype.reportSuiteResults = function(suite) {
@@ -608,6 +625,22 @@ jasmine.TrivialReporter.prototype.reportSpecStarting = function(spec) {
   }
 };
 
+jasmine.TrivialReporter.prototype.specLink = function (spec) {
+	var query = window.location.search;
+	if(query) {
+		if (query.match(new RegExp("([\?&])spec="))) {
+			query = query.replace(new RegExp("([\?&]spec=)[^&]+"), function ($0, $1) {
+				return $1 + encodeURIComponent(spec.getFullName());
+			});
+		} else {
+			query += "&spec=" + encodeURIComponent(spec.getFullName());
+		}
+	} else {
+		query = "?spec=" + encodeURIComponent(spec.getFullName());
+	}
+	return query;
+}
+
 jasmine.TrivialReporter.prototype.reportSpecResults = function(spec) {
   var results = spec.results();
   var status = results.passed() ? 'passed' : 'failed';
@@ -618,7 +651,8 @@ jasmine.TrivialReporter.prototype.reportSpecResults = function(spec) {
       this.createDom('a', { className: 'run_spec', href: '?spec=' + encodeURIComponent(spec.getFullName()) }, "run"),
       this.createDom('a', {
         className: 'description',
-        href: '?spec=' + encodeURIComponent(spec.getFullName()),
+        href: this.specLink(spec),
+
         title: spec.getFullName()
       }, spec.description));
 


### PR DESCRIPTION
Fixes bug where any query strings specified by the user (Example use case: specifying a jQuery version to include using a url query string) are overwritten when clicking on links.
