### PR TITLE
Add ddescribe, iit for exclusive suites,specs

### DIFF
--- a/spec/core/RunnerSpec.js
+++ b/spec/core/RunnerSpec.js
@@ -264,4 +264,62 @@ describe('RunnerTest', function() {
       expect(suiteNames(suites)).toEqual([suite1.getFullName(), suite3.getFullName()]);
     });
   });
+
+  describe('ddescribe', function() {
+    it('should run only ddescribe suites when at least one registered', function() {
+      var normal = jasmine.createSpy('normal spec');
+      var exclusive = jasmine.createSpy('exclusive spec');
+
+      env.describe('normal', function() {
+        env.it('not executed 1', normal);
+        env.it('not executed 2', normal);
+      });
+
+      env.ddescribe('exclusive', function() {
+        env.it('executed 1', exclusive);
+        env.it('executed 2', exclusive);
+        env.describe('nested exclusive', function() {
+          env.it('executed 3', exclusive);
+        });
+      });
+
+      env.describe('normal 2', function() {
+        env.it('not executed 3', normal);
+      });
+
+      env.execute();
+      expect(normal).not.toHaveBeenCalled();
+      expect(exclusive).toHaveBeenCalled();
+      expect(exclusive.callCount).toBe(3);
+    });
+  });
+
+  describe('iit', function() {
+    it('should run only iit specs when at least one registered', function() {
+      var normal = jasmine.createSpy('normal spec');
+      var exclusive = jasmine.createSpy('exclusive spec');
+
+      env.describe('normal', function() {
+        env.it('not executed 1', normal);
+        env.iit('executed 1', exclusive);
+      });
+
+      env.ddescribe('exclusive', function() {
+        env.it('not executed 2', normal);
+        env.iit('executed 2', exclusive);
+        env.describe('nested exclusive', function() {
+          env.iit('executed 3', exclusive);
+        });
+      });
+
+      env.ddescribe('normal 2', function() {
+        env.it('not executed 3', normal);
+      });
+
+      env.execute();
+      expect(normal).not.toHaveBeenCalled();
+      expect(exclusive).toHaveBeenCalled();
+      expect(exclusive.callCount).toBe(3);
+    })
+  })
 });

--- a/src/core/Spec.js
+++ b/src/core/Spec.js
@@ -26,6 +26,7 @@ jasmine.Spec = function(env, suite, description) {
   spec.results_ = new jasmine.NestedResults();
   spec.results_.description = description;
   spec.matchersClass = null;
+  spec.exclusive_ = suite.exclusive_;
 };
 
 jasmine.Spec.prototype.getFullName = function() {

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -19,6 +19,7 @@ jasmine.Suite = function(env, description, specDefinitions, parentSuite) {
   self.children_ = [];
   self.suites_ = [];
   self.specs_ = [];
+  self.exclusive_ = parentSuite && parentSuite.exclusive_ || 0;
 };
 
 jasmine.Suite.prototype.getFullName = function() {

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -489,6 +489,32 @@ var it = function(desc, func) {
 if (isCommonJS) exports.it = it;
 
 /**
+ * Creates an exclusive Jasmine spec that will be added to the current suite.
+ *
+ * If at least one exclusive (iit) spec is registered, only these exclusive specs are run.
+ * Note, that this behavior works only with the default specFilter.
+ * Note, that iit has higher priority over ddescribe
+ *
+ * @example
+ * describe('suite', function() {
+ *   iit('should be true', function() {
+ *     // only this spec will be run
+ *   });
+ *
+ *   it('should be false', function() {
+ *     // this won't be run
+ *   });
+ * });
+ *
+ * @param {String} desc description of this specification
+ * @param {Function} func defines the preconditions and expectations of the spec
+ */
+var iit = function(desc, func) {
+  return jasmine.getEnv().iit(desc, func);
+};
+if (isCommonJS) exports.iit = iit;
+
+/**
  * Creates a <em>disabled</em> Jasmine spec.
  *
  * A convenience method that allows existing specs to be disabled temporarily during development.
@@ -590,6 +616,37 @@ var describe = function(description, specDefinitions) {
   return jasmine.getEnv().describe(description, specDefinitions);
 };
 if (isCommonJS) exports.describe = describe;
+
+
+/**
+ * Defines an exclusive suite of specifications.
+ *
+ * If at least one exclusive (ddescribe) suite is registered, only these exclusive suites are run.
+ * Note, that this behavior works only with the default specFilter.
+ *
+ * @example
+ * ddescribe('exclusive suite', function() {
+ *   it('should be true', function() {
+ *     // this spec will be run
+ *   });
+ *
+ *   it('should be false', function() {
+ *     // this spec will be run as well
+ *   });
+ * });
+ *
+ * describe('normal suite', function() {
+ *   // no spec from this suite will be run
+ * });
+ *
+ *
+ * @param {String} description A string, usually the class under test.
+ * @param {Function} specDefinitions function that defines several specs.
+ */
+var ddescribe = function(description, specDefinitions) {
+  return jasmine.getEnv().ddescribe(description, specDefinitions);
+};
+if (isCommonJS) exports.ddescribe = ddescribe;
 
 /**
  * Disables a suite of specifications.  Used to disable some suites in a file, or files, temporarily during development.


### PR DESCRIPTION
When any ddescribe is registered, only specs withing these exclusive suites will be run

``` javascript
describe('normal', function() {
  ddescribe('exclusive', function() {
    // all specs here will be run
  });

  // nothing here will run
  it('should not run', function() {});
});
```

When any iit is registered, only these exclusive specs will be run (precedence over ddescribe)

``` javascript
it('should not run', function() {});
iit('should run', function() {});
it('should not run 2', function() {});
iit('should run as well', function() {});
```

We've been using this feature for quit a while during development of [AngularJS](http://angularjs.org).

It's part of [Jasmine - JsTD adapter](https://github.com/mhevery/jasmine-jstd-adapter), I think it was originally an idea of @IgorMinar.

I really miss this feature when using [jasmine-node](https://github.com/mhevery/jasmine-node) or when using [SlimJim](https://github.com/vojtajina/slim-jim).

I think, it really should be part of the core, so I did implement it.
