### PR TITLE
Match anything that isn't undefined with .any

### DIFF
--- a/spec/core/MatchersSpec.js
+++ b/spec/core/MatchersSpec.js
@@ -982,6 +982,36 @@ describe("jasmine.Matchers", function() {
     });
 
     describe(".jasmineMatches", function () {
+      describe("with no argument", function() {
+        beforeEach(function () {
+          any = jasmine.any();
+        });
+
+        it("matches an empty object", function () {
+          expect(any.jasmineMatches({})).toEqual(true);
+        });
+
+        it("matches a newed up object", function () {
+          expect(any.jasmineMatches(new Object())).toEqual(true);
+        });
+
+        it("matches a string", function () {
+          expect(any.jasmineMatches("")).toEqual(true);
+        });
+
+        it("matches a number", function () {
+          expect(any.jasmineMatches(123)).toEqual(true);
+        });
+
+        it("matches a function", function () {
+          expect(any.jasmineMatches(function () {})).toEqual(true);
+        });
+
+        it("does not match undefined", function () {
+          expect(any.jasmineMatches()).toEqual(false);
+        });
+      });
+
       describe("with Object", function () {
         beforeEach(function () {
           any = jasmine.any(Object);

--- a/src/core/Matchers.js
+++ b/src/core/Matchers.js
@@ -346,6 +346,10 @@ jasmine.Matchers.Any = function(expectedClass) {
 };
 
 jasmine.Matchers.Any.prototype.jasmineMatches = function(other) {
+  if (!this.expectedClass) {
+    return typeof other !== 'undefined';
+  }
+
   if (this.expectedClass == String) {
     return typeof other == 'string' || other instanceof String;
   }


### PR DESCRIPTION
This change modifies the jasmine.any argument matcher to allow it to match any object regardless of type. For example:

```
var fn = jasmine.createSpy();
fn("Chai", [1,2,3]);
expect(fn).toHaveBeenCalledWith(jasmine.any(String), jasmine.any()); // passes

var fn = jasmine.createSpy();
fn("Earl Grey");
expect(fn).toHaveBeenCalledWith(jasmine.any(String), jasmine.any()); // fails
```

I'd also be open to changing `jasmine.any()` (no args) to `jasmine.anything()`. I thought it was preferable not to introduce more terminology, but I see that `.anything()` may be more descriptive for readers than `.any()`.
