### PR TITLE
less confusing messages for toHaveBeenCalledWith

### DIFF
--- a/spec/core/MatchersSpec.js
+++ b/spec/core/MatchersSpec.js
@@ -771,7 +771,13 @@ describe("jasmine.Matchers", function() {
         TestClass.spyFunction('d', 'e', 'f');
         var expected = match(TestClass.spyFunction);
         expect(expected.toHaveBeenCalledWith('a', 'b')).toFail();
-        expect(lastResult().message).toEqual("Expected spy My spy to have been called with [ 'a', 'b' ] but was called with [ [ 'a', 'b', 'c' ], [ 'd', 'e', 'f' ] ]");
+        expect(lastResult().message).toEqual("Expected spy My spy to have been called with [ 'a', 'b' ] but actual calls were [ 'a', 'b', 'c' ], [ 'd', 'e', 'f' ]");
+      });
+
+      it("should return a decent message when it hasn't been called", function() {
+        var expected = match(TestClass.spyFunction);
+        expect(expected.toHaveBeenCalledWith('a', 'b')).toFail();
+        expect(lastResult().message).toEqual("Expected spy My spy to have been called with [ 'a', 'b' ] but it was never called.");
       });
 
       it("should return a decent message when inverted", function() {
@@ -779,7 +785,7 @@ describe("jasmine.Matchers", function() {
         TestClass.spyFunction('d', 'e', 'f');
         var expected = match(TestClass.spyFunction);
         expect(expected.not.toHaveBeenCalledWith('a', 'b', 'c')).toFail();
-        expect(lastResult().message).toEqual("Expected spy My spy not to have been called with [ 'a', 'b', 'c' ] but was called with [ [ 'a', 'b', 'c' ], [ 'd', 'e', 'f' ] ]");
+        expect(lastResult().message).toEqual("Expected spy My spy not to have been called with [ 'a', 'b', 'c' ] but it was.");
       });
 
       it('should throw an exception when invoked on a non-spy', shouldThrowAnExceptionWhenInvokedOnANonSpy('toHaveBeenCalledWith'));

--- a/src/core/Matchers.js
+++ b/src/core/Matchers.js
@@ -227,18 +227,14 @@ jasmine.Matchers.prototype.toHaveBeenCalledWith = function() {
     throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
   }
   this.message = function() {
+    var invertedMessage = "Expected spy " + this.actual.identity + " not to have been called with " + jasmine.pp(expectedArgs) + " but it was.";
+    var positiveMessage = "";
     if (this.actual.callCount === 0) {
-      // todo: what should the failure message for .not.toHaveBeenCalledWith() be? is this right? test better. [xw]
-      return [
-        "Expected spy " + this.actual.identity + " to have been called with " + jasmine.pp(expectedArgs) + " but it was never called.",
-        "Expected spy " + this.actual.identity + " not to have been called with " + jasmine.pp(expectedArgs) + " but it was."
-      ];
+      positiveMessage = "Expected spy " + this.actual.identity + " to have been called with " + jasmine.pp(expectedArgs) + " but it was never called.";
     } else {
-      return [
-        "Expected spy " + this.actual.identity + " to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall),
-        "Expected spy " + this.actual.identity + " not to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall)
-      ];
+      positiveMessage = "Expected spy " + this.actual.identity + " to have been called with " + jasmine.pp(expectedArgs) + " but actual calls were " + jasmine.pp(this.actual.argsForCall).replace(/^\[ | \]$/g, '')
     }
+    return [positiveMessage, invertedMessage];
   };
 
   return this.env.contains_(this.actual.argsForCall, expectedArgs);


### PR DESCRIPTION
I've run into this a couple of times where the failure message for toHaveBeenCalledWith looks like you've passed in an array of arrays, when really it's just printing out the array of arguments arrays, so I fixed it to make it a bit more obvious what the heck was going on
