### PR TITLE
smaller, more configurable pretty-printing of objects

### DIFF
--- a/spec/core/PrettyPrintSpec.js
+++ b/spec/core/PrettyPrintSpec.js
@@ -40,6 +40,28 @@ describe("jasmine.pp", function () {
     expect(jasmine.pp(instance)).toEqual("{ bar : 'my own bar' }");
   });
 
+  it("should not recurse objects and arrays more deeply than jasmine.MAX_PRETTY_PRINT_DEPTH", function() {
+    var originalMaxDepth = jasmine.MAX_PRETTY_PRINT_DEPTH;
+    var nestedObject = { level1: { level2: { level3: { level4: "leaf" } } } };
+    var nestedArray  = [1, [2, [3, [4, "leaf"]]]];
+
+    try {
+      jasmine.MAX_PRETTY_PRINT_DEPTH = 2;
+      expect(jasmine.pp(nestedObject)).toEqual("{ level1 : { level2 : Object } }");
+      expect(jasmine.pp(nestedArray)).toEqual("[ 1, [ 2, Array ] ]");
+
+      jasmine.MAX_PRETTY_PRINT_DEPTH = 3;
+      expect(jasmine.pp(nestedObject)).toEqual("{ level1 : { level2 : { level3 : Object } } }");
+      expect(jasmine.pp(nestedArray)).toEqual("[ 1, [ 2, [ 3, Array ] ] ]");
+
+      jasmine.MAX_PRETTY_PRINT_DEPTH = 4;
+      expect(jasmine.pp(nestedObject)).toEqual("{ level1 : { level2 : { level3 : { level4 : 'leaf' } } } }");
+      expect(jasmine.pp(nestedArray)).toEqual("[ 1, [ 2, [ 3, [ 4, 'leaf' ] ] ] ]");
+    } finally {
+      jasmine.MAX_PRETTY_PRINT_DEPTH = originalMaxDepth;
+    }
+  });
+
   it("should stringify RegExp objects properly", function() {
     expect(jasmine.pp(/x|y|z/)).toEqual("/x|y|z/");
   });

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -11,10 +11,6 @@ jasmine.PrettyPrinter = function() {
  * @param value
  */
 jasmine.PrettyPrinter.prototype.format = function(value) {
-  if (this.ppNestLevel_ > 40) {
-    throw new Error('jasmine.PrettyPrinter: format() nested too deeply!');
-  }
-
   this.ppNestLevel_++;
   try {
     if (value === jasmine.undefined) {
@@ -85,6 +81,11 @@ jasmine.StringPrettyPrinter.prototype.emitString = function(value) {
 };
 
 jasmine.StringPrettyPrinter.prototype.emitArray = function(array) {
+  if (this.ppNestLevel_ > jasmine.MAX_PRETTY_PRINT_DEPTH) {
+    this.append("Array");
+    return;
+  }
+
   this.append('[ ');
   for (var i = 0; i < array.length; i++) {
     if (i > 0) {
@@ -96,6 +97,11 @@ jasmine.StringPrettyPrinter.prototype.emitArray = function(array) {
 };
 
 jasmine.StringPrettyPrinter.prototype.emitObject = function(obj) {
+  if (this.ppNestLevel_ > jasmine.MAX_PRETTY_PRINT_DEPTH) {
+    this.append("Object");
+    return;
+  }
+
   var self = this;
   this.append('{ ');
   var first = true;

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -35,6 +35,11 @@ jasmine.VERBOSE = false;
 jasmine.DEFAULT_UPDATE_INTERVAL = 250;
 
 /**
+ * Maximum levels of nesting that will be included when an object is pretty-printed
+ */
+jasmine.MAX_PRETTY_PRINT_DEPTH = 40;
+
+/**
  * Default timeout interval in milliseconds for waitsFor() blocks.
  */
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;


### PR DESCRIPTION
This includes two changes to the pretty printer:
1. There's a new constant `jasmine.MAX_PRETTY_PRINT_DEPTH`, which controls how deeply the pretty-printer will recurse when stringifying an object. The depth was previously hard-coded to 40. When the limit is reached, rather than throwing an exception, the pretty printer will simply emit `Object` or `Array`. This allows you to set the recursion depth lower without breaking your tests. Personally I find that after a few levels of depth, the readability of the output decreases, so I would set MAX_PRETTY_PRINT_DEPTH to 4 or 5. Other people might want to leave it at 40 to see the entire structure.
2. When stringifying an object, the pretty-printer will now skip over its inherited properties. This one might be controversial. We hacked it in on our project because when one of our Backbone-derived model objects got printed out, the number of prototypal methods that was included made it hard to discern much about the actual object. I think the fact that the pretty-printer currently _includes_ these properties is responsible for most of the too-long-to-read messages that jasmine produces. 

Curious what you guys think of number 2.
