### PR TITLE
Refactor browser spec helpers to use the `SourcesList.json` file.

### DIFF
--- a/src/SourcesList.json
+++ b/src/SourcesList.json
@@ -1,7 +1,51 @@
-[
-  "base.js",
-  "util.js",
-  "Env.js",
-  "Reporter.js",
-  "Block.js"
-]
+{
+  "core_sources": [
+    "base.js",
+    "util.js",
+    "Env.js",
+    "Reporter.js",
+    "Block.js"
+  ],
+  "html_sources": [
+    "HtmlReporterHelpers.js",
+    "HtmlReporter.js",
+    "ReporterView.js",
+    "SpecView.js",
+    "SuiteView.js",
+    "TrivialReporter.js"
+  ],
+  "console_sources": [
+    "ConsoleReporter.js"
+  ],
+  "core_specfiles": [
+    "BaseSpec.js",
+    "CustomMatchersSpec.js",
+    "EnvSpec.js",
+    "ExceptionsSpec.js",
+    "JsApiReporterSpec.js",
+    "MatchersSpec.js",
+    "MockClockSpec.js",
+    "MultiReporterSpec.js",
+    "NestedResultsSpec.js",
+    "PrettyPrintSpec.js",
+    "QueueSpec.js",
+    "ReporterSpec.js",
+    "RunnerSpec.js",
+    "SpecRunningSpec.js",
+    "SpecSpec.js",
+    "SpySpec.js",
+    "SuiteSpec.js",
+    "UtilSpec.js",
+    "WaitsForBlockSpec.js"
+  ],
+  "html_specfiles": [
+    "HTMLReporterSpec.js",
+    "MatchersHtmlSpec.js",
+    "PrettyPrintHtmlSpec.js",
+    "TrivialReporterSpec.js"
+  ],
+  "console_specfiles": [
+    "ConsoleReporterSpec.js"
+  ]
+}
+

--- a/tasks/helpers.rb
+++ b/tasks/helpers.rb
@@ -1,31 +1,49 @@
 require 'json'
 
-def core_sources
-  first_sources = JSON.parse(File.read('./src/SourcesList.json')).collect { |f| "./src/core/#{f}" }
+def get_sources(namespace)
+  JSON.parse(File.read('./src/SourcesList.json'))[namespace]
+end
 
-  remaining_sources = Dir.glob('./src/core/*.js').reject { |f| first_sources.include?(f) }.sort
+def core_sources
+  first_sources = get_sources('core_sources').collect {
+    |f| "./src/core/#{f}" 
+  }
+
+  remaining_sources = Dir.glob('./src/core/*.js').reject {
+    |f| first_sources.include?(f)
+  }.sort
 
   first_sources + remaining_sources
 end
 
 def html_sources
-  ['./src/html/HtmlReporterHelpers.js'] + Dir.glob('./src/html/*.js')
+  get_sources('html_sources').collect {
+    |f| "./src/html/#{f}"
+  }
 end
 
 def console_sources
-  Dir.glob('./src/console/*.js')
+  get_sources('console_sources').collect {
+    |f| "./src/console/#{f}" 
+  }
 end
 
 def core_specfiles
-  Dir.glob('./spec/core/*.js')
+  get_sources('core_specfiles').collect {
+    |f| "./spec/core/#{f}" 
+  }
 end
 
 def html_specfiles
-   Dir.glob('./spec/html/*.js')
+  get_sources('html_specfiles').collect {
+    |f| "./spec/html/#{f}" 
+  }
 end
 
 def console_specfiles
-  Dir.glob('./spec/console/*.js')
+  get_sources('console_specfiles').collect {
+    |f| "./spec/console/#{f}" 
+  }
 end
 
 def version_string


### PR DESCRIPTION
This should exclude errors generated by wrong order inclusions and allow some 
controle over what files get tested.

Right now, master branch `runner.html` generator, breaks inclusion order and deps.
