### PR TITLE
Ensure order of globbed files in task helpers

### DIFF
--- a/tasks/helpers.rb
+++ b/tasks/helpers.rb
@@ -3,29 +3,29 @@ require 'json'
 def core_sources
   first_sources = JSON.parse(File.read('./src/SourcesList.json')).collect { |f| "./src/core/#{f}" }
 
-  remaining_sources = Dir.glob('./src/core/*.js').reject { |f| first_sources.include?(f) }.sort
+  remaining_sources = Dir.glob('./src/core/*.js').sort.reject { |f| first_sources.include?(f) }.sort
 
   first_sources + remaining_sources
 end
 
 def html_sources
-  ['./src/html/HtmlReporterHelpers.js'] + Dir.glob('./src/html/*.js')
+  ['./src/html/HtmlReporterHelpers.js'] + Dir.glob('./src/html/*.js').sort
 end
 
 def console_sources
-  Dir.glob('./src/console/*.js')
+  Dir.glob('./src/console/*.js').sort
 end
 
 def core_specfiles
-  Dir.glob('./spec/core/*.js')
+  Dir.glob('./spec/core/*.js').sort
 end
 
 def html_specfiles
-   Dir.glob('./spec/html/*.js')
+   Dir.glob('./spec/html/*.js').sort
 end
 
 def console_specfiles
-  Dir.glob('./spec/console/*.js')
+  Dir.glob('./spec/console/*.js').sort
 end
 
 def version_string


### PR DESCRIPTION
The [docs for `Dir.glob` state](http://ruby-doc.org/core-1.9.3/Dir.html#method-c-glob):

> Note that case sensitivity depends on your system (so File::FNM_CASEFOLD is ignored), as does the order in which the results are returned.

So when I ran `rake:spec` on Ubuntu 11.10 with an ext3 filesystem, the source files in my `runner.html` were in a seemingly arbitrary order:

```
<!-- include source files here... -->
<script type="text/javascript" src=".././src/html/HtmlReporterHelpers.js"></script>
<script type="text/javascript" src=".././src/html/TrivialReporter.js"></script>
<script type="text/javascript" src=".././src/html/SuiteView.js"></script>
<script type="text/javascript" src=".././src/html/HtmlReporterHelpers.js"></script>
<script type="text/javascript" src=".././src/html/ReporterView.js"></script>
<script type="text/javascript" src=".././src/html/HtmlReporter.js"></script>
<script type="text/javascript" src=".././src/html/SpecView.js"></script>
<script type="text/javascript" src=".././src/console/ConsoleReporter.js"></script>
<!-- include spec files here... -->
```

This resulted in the following runtime errors:  

```
SuiteView.js:1 Uncaught TypeError: Cannot set property 'SuiteView' of undefined
ReporterView.js:1 Uncaught TypeError: Cannot set property 'ReporterView' of undefined
HtmlReporter.js:22 Uncaught TypeError: undefined is not a function
```

After applying this fix, my script sources were the same as the runner.html that is currently checked in to the upstream master branch:

```
<!-- include source files here... -->
<script type="text/javascript" src=".././src/html/HtmlReporterHelpers.js"></script>
<script type="text/javascript" src=".././src/html/HtmlReporter.js"></script>
<script type="text/javascript" src=".././src/html/HtmlReporterHelpers.js"></script>
<script type="text/javascript" src=".././src/html/ReporterView.js"></script>
<script type="text/javascript" src=".././src/html/SpecView.js"></script>
<script type="text/javascript" src=".././src/html/SuiteView.js"></script>
<script type="text/javascript" src=".././src/html/TrivialReporter.js"></script>
<script type="text/javascript" src=".././src/console/ConsoleReporter.js"></script>
<!-- include spec files here... -->
```

And of course the browser tests now pass in Chromium on my machine.  The node tests pass as well.

There are still several places where I didn't sort Dir.glob:
- `jasmine-core.gemspec` and `lib/jasmine-core.rb` because I didn't have a way to test either of them
- `tasks/build_dist.rb` which globbed a single file without wildcards:  `Dir.glob('src/version.js')`
- `tasks/spec.rb` which was just globbing files for the purpose of counting specs
