### PR TITLE
Remove remaining references to term-ansicolor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source :rubygems
-gem "term-ansicolor", :require => "term/ansicolor"
 gem "rake"
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require "bundler"
 Bundler::GemHelper.install_tasks
-require "term/ansicolor"
 require "json"
 require "tilt"
 

--- a/tasks/jasmine_dev.rb
+++ b/tasks/jasmine_dev.rb
@@ -1,6 +1,5 @@
 require 'thor'
 require 'json'
-require 'term/ansicolor'
 require 'tilt'
 require 'ostruct'
 


### PR DESCRIPTION
There were a couple remaining mentions of term/ansicolor.  This commit removes them.
