### PR TITLE
fix JasmineDev#has_node? for Ruby 1.8.7

### DIFF
--- a/tasks/jasmine_dev/base.rb
+++ b/tasks/jasmine_dev/base.rb
@@ -36,9 +36,7 @@ class JasmineDev < Thor
 
     def has_node?
       run "which node", :verbose => false, :capture => true
-      last_exit_code = $?.to_s[-1]
-
-      last_exit_code == '0'
+      $?.exitstatus == 0
     end
 
     def pages_submodule_installed?


### PR DESCRIPTION
`has_node?` was relying on behavior that was different in 1.9.3 vs. 1.8.7 (particularly, `String#[fixnum]` returns a fixnum indicating that character code of the character at that index in 1.8.7, but it returns the character at that index in 1.9.3).  Checking `$?.exitstatus` should work properly across all 1.8+ versions of Ruby.

```
1.8.7 :002 > require 'rubygems'
 => true 
1.8.7 :003 > require 'jasmine_dev'
 => true 
1.8.7 :004 > JasmineDev.new.has_node?
 => false 
1.8.7 :005 > `which node`
 => "/usr/bin/node\n" 
1.8.7 :006 > $?
 => #<Process::Status: pid=8317,exited(0)> 
1.8.7 :007 > $?.to_s
 => "0" 
1.8.7 :008 > $?.to_s[-1]
 => 48 
1.8.7 :009 > $?.exitstatus
 => 0 
```

---

```
1.9.3p125 :006 > require 'jasmine_dev'
 => true 
1.9.3p125 :007 > JasmineDev.new.has_node?
 => true 
1.9.3p125 :008 > `which node`
 => "/usr/bin/node\n" 
1.9.3p125 :009 > $?
 => #<Process::Status: pid 8073 exit 0> 
1.9.3p125 :010 > $?.to_s
 => "pid 8073 exit 0" 
1.9.3p125 :011 > $?.to_s[-1]
 => "0" 
1.9.3p125 :012 > $?.exitstatus
 => 0 
```
