### PR TITLE
Fixed jsdoc for jasmine.Spy.prototype.andCallFake

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -354,10 +354,10 @@ jasmine.Spy.prototype.andThrow = function(exceptionMsg) {
  *   // do some stuff, return something
  * }
  * // defining a spy from scratch: foo() calls the function baz
- * var foo = jasmine.createSpy('spy on foo').andCall(baz);
+ * var foo = jasmine.createSpy('spy on foo').andCallFake(baz);
  *
  * // defining a spy on an existing property: foo.bar() calls an anonymnous function
- * spyOn(foo, 'bar').andCall(function() { return 'baz';} );
+ * spyOn(foo, 'bar').andCallFake(function() { return 'baz';} );
  *
  * @param {Function} fakeFunc
  */


### PR DESCRIPTION
The @example for [jasmine.Spy.prototype.andCallFake](https://github.com/pivotal/jasmine/blob/master/lib/jasmine-core/jasmine.js#L349) showed the wrong function call.
Changed `andCall` to `andCallFake`.
