### PR TITLE
Fix issue where #jasmine_content was not crteated within the HTMLReporter

### DIFF
--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -86,6 +86,7 @@ jasmine.HtmlReporter = function(_doc) {
 
   function createReporterDom(version) {
     dom.reporter = self.createDom('div', { id: 'HTMLReporter', className: 'jasmine_reporter' },
+      dom.jasmineContent = self.createDom('div', { id: 'jasmine_content' }),
       dom.banner = self.createDom('div', { className: 'banner' },
         self.createDom('span', { className: 'title' }, "Jasmine "),
         self.createDom('span', { className: 'version' }, version)),


### PR DESCRIPTION
I reported this issue in the jasmine-gem project but I think the fix probably goes here.

The problem is that the `#HTMLReporter div` which is created through the `createReporterDom` function does not create the `#jasmine_content div` that is styled through the following rule:

``` css
#HTMLReporter #jasmine_content {
  position: fixed;
  right: 100%;
}
```

The CSS rule either needs to not be scoped around `#HTMLReporter` or the `jasmine.HtmlReporter createReporterDom` function needs to also create the `#jasmine_content div`.

This patch goes with the latter solution and creates the `#jasmine_content div` inside the `#HTMLReporter div`.
