### PR TITLE
spec that to spy on an undefined method throws exception

### DIFF
--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -165,6 +165,21 @@ describe('Spies', function () {
     expect(exception).toBeDefined();
   });
 
+	
+	it('to spy on an undefined method throws exception', function() {
+		var TestClass = {
+			someFunction : function() {
+			}
+		};
+		function efunc() {
+			this.spyOn(TestClass, 'someOtherFunction');
+		};
+		expect(function() {
+			efunc();
+		}).toThrow('someOtherFunction() method does not exist');
+	
+	}); 
+
   it('should be able to reset a spy', function() {
     var TestClass = { someFunction: function() {} };
     this.spyOn(TestClass, 'someFunction');


### PR DESCRIPTION
My first, and trivial contribution. It documents a feature not specified by the specs. 
If you spy on an undefined method a specific exception is raised. This contribution adds a specification for that.
