### PR TITLE
comparison for regExp that compares pattern and modifiers

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -887,6 +887,9 @@ jasmine.Env.prototype.compareRegExps_ = function(a, b, mismatchKeys, mismatchVal
   if (a.multiline != b.multiline)
     mismatchValues.push("expected modifier m was" + (b.multiline ? " " : " not ") + "set and does not equal the origin modifier");
 
+  if (a.sticky != b.sticky)
+    mismatchValues.push("expected modifier y was" + (b.sticky ? " " : " not ") + "set and does not equal the origin modifier");
+
   return (mismatchValues.length === 0);
 };
 

--- a/spec/core/MatchersSpec.js
+++ b/spec/core/MatchersSpec.js
@@ -80,6 +80,13 @@ describe("jasmine.Matchers", function() {
     expect((match(/1/i).toNotEqual(/1/i))).toFail();
     expect((match(/[abc]/gm).toEqual(/1/i))).toFail();
     expect((match(/[abc]/gm).toNotEqual(/1/i))).toPass();
+
+    // only test if the browser supports the sticky option on a regExp see pull #234
+    if (RegExp.prototype.sticky !== undefined) {
+      var sticky_regexp = new RegExp("[abc]", "y");
+      expect((match(sticky_regexp).toEqual(/1/i))).toFail();
+      expect((match(sticky_regexp).toNotEqual(/1/i))).toPass();
+    }
   });
 
   it("toEqual to build an Expectation Result", function() {

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -181,6 +181,9 @@ jasmine.Env.prototype.compareRegExps_ = function(a, b, mismatchKeys, mismatchVal
   if (a.multiline != b.multiline)
     mismatchValues.push("expected modifier m was" + (b.multiline ? " " : " not ") + "set and does not equal the origin modifier");
 
+  if (a.sticky != b.sticky)
+    mismatchValues.push("expected modifier y was" + (b.sticky ? " " : " not ") + "set and does not equal the origin modifier");
+
   return (mismatchValues.length === 0);
 };
 


### PR DESCRIPTION
... objects were not properly compared resulting in non-matching RegExp objects to always return true. a patch to jasmine.Env.equals_ adds an extra step for RexExp objects to be compared.

related to issue pivotal/jasmine#199
