### PR TITLE
Fix swapped template values in build_standalone_runner.rb.

### DIFF
--- a/tasks/jasmine_dev/build_standalone_runner.rb
+++ b/tasks/jasmine_dev/build_standalone_runner.rb
@@ -49,11 +49,11 @@ class JasmineDev < Thor
     end
 
     def example_source_tags
-      script_tags_for ['spec/SpecHelper.js', 'spec/PlayerSpec.js']
+      script_tags_for ['src/Player.js', 'src/Song.js']
     end
 
     def example_spec_tags
-      script_tags_for ['src/Player.js', 'src/Song.js']
+      script_tags_for ['spec/SpecHelper.js', 'spec/PlayerSpec.js']
     end
   end
 end


### PR DESCRIPTION
This fixes a bug in build_standalone_runner.rb that causes the standalone SpecRunner.html to appear to have wrongly-ordered comments. The SpecRunner.html comments gave my coworker and me a short pause when we first started using Jasmine ([jasmine-standalone-1.2.0.zip](https://github.com/downloads/pivotal/jasmine/jasmine-standalone-1.2.0.zip)).
