### PR TITLE
Support loading of jasmine more than once during a page load

### DIFF
--- a/src/core/base.js
+++ b/src/core/base.js
@@ -5,7 +5,49 @@ var isCommonJS = typeof window == "undefined";
  *
  * @namespace
  */
-var jasmine = {};
+var initedBefore=!!window.jasmine;
+
+var jasmine = initedBefore? {
+    setTimeout:jasmine.setTimeout,
+    clearTimeout:jasmine.clearTimeout,
+    setInterval:jasmine.setInterval,
+    clearInterval:jasmine.clearInterval
+
+} : {};
+
+/**
+ * Allows for bound functions to be compared.  Internal use only.
+ *
+ * @ignore
+ * @private
+ * @param base {Object} bound 'this' for the function
+ * @param name {Function} function to find
+ */
+jasmine.bindOriginal_ = function(base, name) {
+    var original = base[name];
+    if (original.apply) {
+        return function() {
+            return original.apply(base, arguments);
+        };
+    } else {
+        // IE support
+        return jasmine.getGlobal()[name];
+    }
+};
+
+jasmine.getGlobal = function() {
+    function getGlobal() {
+        return this;
+    }
+
+    return getGlobal();
+};
+if (!initedBefore){
+    jasmine.setTimeout = jasmine.bindOriginal_(jasmine.getGlobal(), 'setTimeout');
+    jasmine.clearTimeout = jasmine.bindOriginal_(jasmine.getGlobal(), 'clearTimeout');
+    jasmine.setInterval = jasmine.bindOriginal_(jasmine.getGlobal(), 'setInterval');
+    jasmine.clearInterval = jasmine.bindOriginal_(jasmine.getGlobal(), 'clearInterval');
+}
 if (isCommonJS) exports.jasmine = jasmine;
 /**
  * @private
@@ -45,39 +87,6 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
  *
  */
 jasmine.CATCH_EXCEPTIONS = true;
-
-jasmine.getGlobal = function() {
-  function getGlobal() {
-    return this;
-  }
-
-  return getGlobal();
-};
-
-/**
- * Allows for bound functions to be compared.  Internal use only.
- *
- * @ignore
- * @private
- * @param base {Object} bound 'this' for the function
- * @param name {Function} function to find
- */
-jasmine.bindOriginal_ = function(base, name) {
-  var original = base[name];
-  if (original.apply) {
-    return function() {
-      return original.apply(base, arguments);
-    };
-  } else {
-    // IE support
-    return jasmine.getGlobal()[name];
-  }
-};
-
-jasmine.setTimeout = jasmine.bindOriginal_(jasmine.getGlobal(), 'setTimeout');
-jasmine.clearTimeout = jasmine.bindOriginal_(jasmine.getGlobal(), 'clearTimeout');
-jasmine.setInterval = jasmine.bindOriginal_(jasmine.getGlobal(), 'setInterval');
-jasmine.clearInterval = jasmine.bindOriginal_(jasmine.getGlobal(), 'clearInterval');
 
 jasmine.MessageResult = function(values) {
   this.type = 'log';

--- a/src/core/mock-timeout.js
+++ b/src/core/mock-timeout.js
@@ -128,10 +128,10 @@ jasmine.Clock = {
   },
 
   real: {
-    setTimeout: jasmine.getGlobal().setTimeout,
-    clearTimeout: jasmine.getGlobal().clearTimeout,
-    setInterval: jasmine.getGlobal().setInterval,
-    clearInterval: jasmine.getGlobal().clearInterval
+    setTimeout: jasmine.setTimeout,
+    clearTimeout: jasmine.clearTimeout,
+    setInterval: jasmine.setInterval,
+    clearInterval: jasmine.clearInterval
   },
 
   assertInstalled: function() {


### PR DESCRIPTION
Hi, this prabably doesn't handle the commonJS case correctly.

But this is the change I've made to support loading jasmin.js more than once for a single page.

This fixes the issue where jasmine goes into an infinite loop on the timeout methods
https://github.com/pivotal/jasmine/issues/247

To reproduce, have a page with something like 
<script src="jasmine.js">
<script src="jasmine.js">
