### PR TITLE
Don't assume exports is defined when window is undefined

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1,4 +1,4 @@
-var isCommonJS = typeof window == "undefined";
+var isCommonJS = typeof window == "undefined" && typeof exports == "object";
 
 /**
  * Top level namespace for Jasmine, a lightweight JavaScript BDD/spec/testing framework.

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -1,4 +1,4 @@
-var isCommonJS = typeof window == "undefined";
+var isCommonJS = typeof window == "undefined" && typeof exports == "object";
 
 /**
  * Top level namespace for Jasmine, a lightweight JavaScript BDD/spec/testing framework.


### PR DESCRIPTION
The current code makes the assumption that if `window` is undefined it is
being run in an environment which supports the CommonJS Modules spec.
This is not the case when Jasmine is being run in rhino or SpiderMonkey
(smjs) without EnvJS (e.g. using either http://stackoverflow.com/a/5767884 or https://gist.github.com/3146420 to provide setTimeout).

The attached commit fixes the issue by checking that exports is an object.
