### PR TITLE
Fix for jasmine.Spy.andCallThrough() and custom function props

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -312,6 +312,14 @@ jasmine.Spy = function(name) {
  */
 jasmine.Spy.prototype.andCallThrough = function() {
   this.plan = this.originalValue;
+
+  // Copy original function properties to the spy
+  for ( var prop in this.originalValue ) {
+    if ( this.originalValue.hasOwnProperty(prop) ) {
+      this[prop] = this.originalValue[prop];
+    };
+  };
+
   return this;
 };
 

--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -50,9 +50,14 @@ describe('Spies', function () {
         return "return value from original function";
       }
     };
+    
+    TestClass.someFunction.prop1 = 'foo';
+    TestClass.someFunction.prop2 = { bar: 'baz' };
 
     this.spyOn(TestClass, 'someFunction').andCallThrough();
     var result = TestClass.someFunction('arg1', 'arg2');
+    expect(TestClass.someFunction.prop1).toBe('foo');
+    expect(TestClass.someFunction.prop2).toEqual({ bar: 'baz' });
     expect(result).toEqual("return value from original function");
     expect(originalFunctionWasCalled).toEqual(true);
     expect(passedArgs).toEqual(['arg1', 'arg2']);


### PR DESCRIPTION
When a function has object properties, calling spyOn() for that function may break other code that depend on those properties. This fix adds property replication to .andCallThrough(), which is assumed to make the spy "blend in" and follow original function behavior.
