### PR TITLE
Change toBeCloseTo matcher to be more consistent

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1445,10 +1445,7 @@ jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
   if (!(precision === 0)) {
     precision = precision || 2;
   }
-  var multiplier = Math.pow(10, precision);
-  var actual = Math.round(this.actual * multiplier);
-  expected = Math.round(expected * multiplier);
-  return expected == actual;
+  return Math.abs(expected - this.actual) < (Math.pow(10, -precision) / 2);
 };
 
 /**
@@ -2537,5 +2534,5 @@ jasmine.version_= {
   "major": 1,
   "minor": 2,
   "build": 0,
-  "revision": 1337006083
+  "revision": 1343710612
 };

--- a/spec/core/MatchersSpec.js
+++ b/spec/core/MatchersSpec.js
@@ -510,6 +510,11 @@ describe("jasmine.Matchers", function() {
       expect(-1.23).not.toBeCloseTo(-1.24);
     });
 
+    it("expects close numbers to 'be close' and further numbers not to", function() {
+      expect(1.225).not.toBeCloseTo(1.234); // difference is 0.009
+      expect(1.225).toBeCloseTo(1.224);     // difference is 0.001
+    });
+
     it("accepts an optional precision argument", function() {
       expect(1).toBeCloseTo(1.1, 0);
       expect(1.2).toBeCloseTo(1.23, 1);

--- a/src/core/Matchers.js
+++ b/src/core/Matchers.js
@@ -302,10 +302,7 @@ jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
   if (!(precision === 0)) {
     precision = precision || 2;
   }
-  var multiplier = Math.pow(10, precision);
-  var actual = Math.round(this.actual * multiplier);
-  expected = Math.round(expected * multiplier);
-  return expected == actual;
+  return Math.abs(expected - this.actual) < (Math.pow(10, -precision) / 2);
 };
 
 /**

--- a/src/version.js
+++ b/src/version.js
@@ -3,5 +3,5 @@ jasmine.version_= {
   "major": 1,
   "minor": 2,
   "build": 0,
-  "revision": 1337006083
+  "revision": 1343710612
 };


### PR DESCRIPTION
It now calculates and compares a difference, rather than rounding
two separate quantities and testing for their equality.

This fixes the problem where:
  expect(1.225).toBeCloseTo(1.234); // difference is 0.009, and it passes
  expect(1.225).toBeCloseTo(1.224); // difference is 0.001, but it fails

All the existing specs still pass; I've just added two examples like the above, with the first negated.
