### PR TITLE
Wrapped the reserved word, "for", in quotes.

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -154,7 +154,7 @@ jasmine.HtmlReporter = function(_doc) {
       dom.symbolSummary = self.createDom('ul', {className: 'symbolSummary'}),
       dom.alert = self.createDom('div', {className: 'alert'},
         self.createDom('span', { className: 'exceptions' },
-          self.createDom('label', { className: 'label', for: 'no_try_catch' }, 'No try/catch'),
+          self.createDom('label', { className: 'label', 'for': 'no_try_catch' }, 'No try/catch'),
           self.createDom('input', { id: 'no_try_catch', type: 'checkbox' }))),
       dom.results = self.createDom('div', {className: 'results'},
         dom.summary = self.createDom('div', { className: 'summary' }),


### PR DESCRIPTION
This stops it throwing errors in IE and other browsers. I think the newer Firefox and Chrome versions are the only browsers to not die when running it.
