### PR TITLE
Custom error message of Matcher

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -516,8 +516,8 @@ if (isCommonJS) exports.xit = xit;
  *
  * @param {Object} actual Actual value to test against and expected value
  */
-var expect = function(actual) {
-  return jasmine.getEnv().currentSpec.expect(actual);
+var expect = function(actual, message, notMessage) {
+  return jasmine.getEnv().currentSpec.expect(actual, message, notMessage);
 };
 if (isCommonJS) exports.expect = expect;
 
@@ -2204,9 +2204,15 @@ jasmine.Spec.prototype.addMatcherResult = function(result) {
   this.results_.addResult(result);
 };
 
-jasmine.Spec.prototype.expect = function(actual) {
+jasmine.Spec.prototype.expect = function(actual, message, notMessage) {
   var positive = new (this.getMatchersClass_())(this.env, actual, this);
   positive.not = new (this.getMatchersClass_())(this.env, actual, this, true);
+  if (message) {
+      positive.message = function(){return message};;
+  }
+  if (notMessage) {
+      positive.not.message = function(){return notMessage};;
+  }
   return positive;
 };
 


### PR DESCRIPTION
Usage:

```
var failMessage = 'obj.selected is not true. obj.id = ' + obj.id;
expect(obj.selected, failMessage).toBe(true)
```

By default, when obj.selected is false, "Expected false to be true" is printed. if you needs more information when test fail, that can show custom message.
I know get same effect to add message function to matcher object. but that is prolixity.
