### PR TITLE
JSDoc @return-tag to 'spyOn' and 'expect' functions

### DIFF
--- a/src/core/base.js
+++ b/src/core/base.js
@@ -470,7 +470,7 @@ jasmine.log = function() {
  * @see jasmine.createSpy
  * @param obj
  * @param methodName
- * @returns a Jasmine spy that can be chained with all spy methods
+ * @return {jasmine.Spy} a Jasmine spy that can be chained with all spy methods
  */
 var spyOn = function(obj, methodName) {
   return jasmine.getEnv().currentSpec.spyOn(obj, methodName);
@@ -515,6 +515,7 @@ if (isCommonJS) exports.xit = xit;
  * jasmine.Matchers functions.
  *
  * @param {Object} actual Actual value to test against and expected value
+ * @return {jasmine.Matchers}
  */
 var expect = function(actual) {
   return jasmine.getEnv().currentSpec.expect(actual);


### PR DESCRIPTION
 Add JSDoc @return-tag to 'spyOn' and 'expect' functions to support code completion in Spket IDE
