### PR TITLE
Spy: cloning arguments so we can assert on the value at the time they were called

### DIFF
--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -198,4 +198,36 @@ describe('Spies', function () {
     });
   });
 
+  describe("Spied arguments are cloned so they dont get modified futher down", function() {
+      it("should clone objects (shallow clone)", function() {
+        var mock = { fn: function(x) {} };
+        spyOn(mock, 'fn');
+        var params = { val: 1 };
+        mock.fn(params);            
+        params.val = 2;
+        mock.fn(params); 
+        expect(mock.fn.argsForCall[0]).toEqual([{val: 1}]);
+        expect(mock.fn.argsForCall[1]).toEqual([{val: 2}]);          
+      });
+      it("should clone arrays", function() {
+        var mock = { fn: function(x) {} };
+        spyOn(mock, 'fn');
+        var params = [1, 2, 3];
+        mock.fn(params);
+        params.splice(2);
+        params.push(4);
+        mock.fn(params); 
+        expect(mock.fn.argsForCall[0]).toEqual([[1, 2, 3]]);
+        expect(mock.fn.argsForCall[1]).toEqual([[1, 2, 4]]);
+      });
+      it("should leave primitives alone", function() {
+        var mock = { fn: function(x) {} };
+        spyOn(mock, 'fn');
+        mock.fn(1, 'foo', null, undefined, true);
+        mock.fn(false, undefined, null, 'bar', 2);
+        expect(mock.fn.argsForCall[0]).toEqual([1, 'foo', null, undefined, true]);
+        expect(mock.fn.argsForCall[1]).toEqual([false, undefined, null, 'bar', 2]);          
+      });
+  });
+
 });

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -400,7 +400,9 @@ jasmine.createSpy = function(name) {
   var spyObj = function() {
     spyObj.wasCalled = true;
     spyObj.callCount++;
-    var args = jasmine.util.argsToArray(arguments);
+    var args = jasmine.util.argsToArray(arguments).map(function(arg) {
+        return jasmine.util.clone(arg);
+    });
     spyObj.mostRecentCall.object = this;
     spyObj.mostRecentCall.args = args;
     spyObj.argsForCall.push(args);

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -65,3 +65,12 @@ jasmine.util.extend = function(destination, source) {
   return destination;
 };
 
+jasmine.util.clone = function(obj) {
+  if (Array.isArray(obj)) {
+    return obj.slice();
+  } else if (typeof obj === 'object' && obj !== null) {
+    return jasmine.util.extend({}, obj);
+  } else {
+    return obj;
+  }
+};


### PR DESCRIPTION
Hi,

I noticed that `spyOn` only keeps a reference to the arguments used in function calls.
This can be handy to compare exact reference-equality, but not so much in cases like this:

```
var mock = { fn: function(x) {} };
spyOn(mock, 'fn');

var params = { val: 1 };
mock.fn(params);            
params.val = 2;
mock.fn(params); 

expect(mock.fn.argsForCall[0]).toEqual([{val: 1}]);
// currently fails, saying it was called with "val = 2"
```

This pull request does a **shallow copy** of all arguments to avoid this - with corresponding unit tests.

All existing tests pass, however it **does** change the existing behaviour, in cases where users are testing for reference-equality of arguments. What do you think? A possibility could be to keep both the reference and a copy, and leave the option of which one to check to the user.
