### PR TITLE
Passing arguments to setInterval and setTimeout callbacks

### DIFF
--- a/spec/core/MockClockSpec.js
+++ b/spec/core/MockClockSpec.js
@@ -1,7 +1,7 @@
 describe("MockClock", function () {
 
   beforeEach(function() {
-    jasmine.Clock.useMock();    
+    jasmine.Clock.useMock();
   });
 
   describe("setTimeout", function () {
@@ -14,6 +14,17 @@ describe("MockClock", function () {
       jasmine.Clock.tick(30001);
       expect(expected).toBe(true);
     });
+
+		it('should pass the specified arguments to the callback', function() {
+			var aUnicorn = "a unicorn";
+			var expectItToBeAUnicorn = function() {
+				expect(arguments.length).toEqual(1);
+				expect(arguments[0]).toBe(aUnicorn);
+			};
+
+			setTimeout(expectItToBeAUnicorn, 0, aUnicorn);
+			jasmine.Clock.tick(0);
+		});
   });
 
   describe("setInterval", function () {
@@ -30,6 +41,17 @@ describe("MockClock", function () {
       jasmine.Clock.tick(1);
       expect(interval).toEqual(2);
     });
+
+		it('should pass the specified arguments to the callback', function() {
+			var aUnicorn = "a unicorn";
+			var expectItToBeAUnicorn = function() {
+				expect(arguments.length).toEqual(1);
+				expect(arguments[0]).toBe(aUnicorn);
+			};
+
+			setInterval(expectItToBeAUnicorn, 0, aUnicorn);
+			jasmine.Clock.tick(0);
+		});
   });
 
   it("shouldn't complain if you call jasmine.Clock.useMock() more than once", function() {


### PR DESCRIPTION
I noticed an issue where Jasmine's mock `setInterval` and `setTimeout` functions had different behavior from most browsers (read, non-IE).

In non-IE browsers, you can pass more than two arguments to setInterval. The first two, which are implemented in Jasmine, are the callback and the time in ms. The additional arguments specify the arguments that are supposed to be applied to the callback function; Jasmine does not capture these arguments or pass them to the callback.

```
setInterval(callback, time, [arg1, arg2, ...])
```

See the attached code for an example of this usage.

I could imagine that this behavior was not included intentionally in order to avoid Internet Explorer compatibility issues. I am also aware of one basic workaround to this issue that involves wrapping the callback in an anonymous function.

However, if you agree that these specs are correct, reply to this pull request, and I can try to implement the behavior.

Thanks!

See also: http://msdn.microsoft.com/en-us/library/ie/ms536753(v=vs.85).aspx
And: https://developer.mozilla.org/en-US/docs/DOM/window.setTimeout#Callback_arguments
