### PR TITLE
Fix for missing traces on test failure if using Phantom.js

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -106,7 +106,9 @@ jasmine.ExpectationResult = function(params) {
   this.actual = params.actual;
   this.message = this.passed_ ? 'Passed.' : params.message;
 
-  var trace = (params.trace || new Error(this.message));
+  var err;
+  try { throw new Error(this.message); } catch(e) { err = e };
+  var trace = (params.trace || err);
   this.trace = this.passed_ ? '' : trace;
 };
 


### PR DESCRIPTION
Hi

I've started to run my Jasmine tests using Phantom.js and I noticed that I was not getting a stacktrace for the expectation failures, which makes debugging a test failure harder. After some research, I found a [similar issue on Stackoverflow](http://stackoverflow.com/questions/11245016/stack-trace-for-jasmine-test-with-the-resharper-7-test-runner). After applying the patch, I get the exception trace as expected. I thought I'll submit the patch as a pull request as other might encounter the issue. 

I tested in Chrome and Firefox and still see a stack trace there, so that's good. I also ran `thor jasmine_dev:execute_specs` and did not see any failures. Please let me know what you think :)

Before the patch, no trace:

```
$ rake phantomjs
phantomjs lib/phantom-jasmine/run_jasmine_test.coffee SpecRunner.html
Starting...
when song has been paused : should be possible to resume
Error: Expected false to be truthy.

when song has been paused: 3 of 4 passed.
#resume: 1 of 1 passed.

Finished
-----------------
5 specs, 1 failure in 0.087s.
```

After the patch, here is our trace:

```
$ rake phantomjs
phantomjs lib/phantom-jasmine/run_jasmine_test.coffee SpecRunner.html
Starting...
when song has been paused : should be possible to resume
Error: Expected false to be truthy.
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:103
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:1201
    at file:///home/jpc/public_html/jasmine-phantomjs/spec/PlayerSpec.js:33
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:1026
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:2027
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:1980
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:2309
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:2027
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:1980
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:2454
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:2027
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:2023
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:2281
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:2308
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:2037
    at file:///home/jpc/public_html/jasmine-phantomjs/lib/jasmine-1.2.0/jasmine.js:2017

when song has been paused: 3 of 4 passed.
#resume: 1 of 1 passed.

Finished
-----------------
5 specs, 1 failure in 0.076s.
```
