### PR TITLE
Added toBeNearTo() matcher

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1483,6 +1483,18 @@ jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
 };
 
 /**
+ * Matcher that checks if a number is close enough to the actual to be
+ * acceptable. For example if the expected is 100 and the precision is 2 the 
+ * numbers 98, 99, 100, 101 & 102 will return true.
+ *
+ * @param {Number} expected
+ * @param {Number} precision
+ */
+jasmine.Matchers.prototype.toBeNearTo = function(expected, precision) {
+  return Math.abs((expected - this.actual)) <= precision;
+};
+
+/**
  * Matcher that checks that the expected exception was thrown by the actual.
  *
  * @param {String} expected

--- a/spec/core/MatchersSpec.js
+++ b/spec/core/MatchersSpec.js
@@ -574,6 +574,37 @@ describe("jasmine.Matchers", function() {
     });
   });
 
+  describe('toBeNearTo', function() {
+    it("Returns true if the expected and actual numbers are within the given precision", function() {
+      expect(98).toBeNearTo(100, 2);
+      expect(99).toBeNearTo(100, 2);
+      expect(100).toBeNearTo(100, 2);
+      expect(101).toBeNearTo(100, 2);
+      expect(102).toBeNearTo(100, 2);
+    });
+
+    it("Returns false if the expected and actual numbers are outside the given precision", function () {
+      expect(97).not.toBeNearTo(100, 2);
+      expect(103).not.toBeNearTo(100, 2);
+    });
+
+    it("Builds an expectation result", function() {
+      var actual = 100;
+      var matcher = match(actual);
+      var expected = 97;
+      var precision = 2;
+      matcher.toBeNearTo(expected, precision);
+
+      var result = lastResult();
+
+      expect(result.matcherName).toBe("toBeNearTo");
+      expect(result.passed()).toFail();
+      expect(result.message).toMatch(jasmine.pp(actual) + ' to be near to');
+      expect(result.actual).toEqual(actual);
+      expect(result.expected).toEqual([expected, precision]);
+    });
+  });
+
   describe("toThrow", function() {
     describe("when code block throws an exception", function() {
       var throwingFn;

--- a/src/core/Matchers.js
+++ b/src/core/Matchers.js
@@ -313,6 +313,18 @@ jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
 };
 
 /**
+ * Matcher that checks if a number is close enough to the actual to be
+ * acceptable. For example if the expected is 100 and the precision is 2 the 
+ * numbers 98, 99, 100, 101 & 102 will return true.
+ *
+ * @param {Number} expected
+ * @param {Number} precision
+ */
+jasmine.Matchers.prototype.toBeNearTo = function(expected, precision) {
+  return Math.abs((expected - this.actual)) <= precision;
+};
+
+/**
  * Matcher that checks that the expected exception was thrown by the actual.
  *
  * @param {String} [expected]


### PR DESCRIPTION
Matcher for numbers that are close to the actual or 'near enough'.

Accepts an expected result and a precision modifier.

i.e. .toBeNearTo(100, 2) would match 98, 99, 100, 101 & 102

This should perhaps be called toBeCloseTo(), and the existing method of that name might more accurately be called .toBePrecision() or some such but I'll leave that up to you.
