### PR TITLE
Preserve significant whitespace in test names.

### DIFF
--- a/lib/jasmine-core/jasmine.css
+++ b/lib/jasmine-core/jasmine.css
@@ -44,7 +44,7 @@ body { background-color: #eeeeee; padding: 0; margin: 5px; overflow-y: scroll; }
 #HTMLReporter .summary .specSummary.failed a { color: #b03911; }
 #HTMLReporter .description + .suite { margin-top: 0; }
 #HTMLReporter .suite { margin-top: 14px; }
-#HTMLReporter .suite a { color: #333333; }
+#HTMLReporter .suite a { color: #333333; white-space: pre; }
 #HTMLReporter #details .specDetail { margin-bottom: 28px; }
 #HTMLReporter #details .specDetail .description { display: block; color: white; background-color: #b03911; }
 #HTMLReporter .resultMessage { padding-top: 14px; color: #333333; }

--- a/src/html/jasmine.css
+++ b/src/html/jasmine.css
@@ -44,7 +44,7 @@ body { background-color: #eeeeee; padding: 0; margin: 5px; overflow-y: scroll; }
 #HTMLReporter .summary .specSummary.failed a { color: #b03911; }
 #HTMLReporter .description + .suite { margin-top: 0; }
 #HTMLReporter .suite { margin-top: 14px; }
-#HTMLReporter .suite a { color: #333333; }
+#HTMLReporter .suite a { color: #333333; white-space: pre; }
 #HTMLReporter #details .specDetail { margin-bottom: 28px; }
 #HTMLReporter #details .specDetail .description { display: block; color: white; background-color: #b03911; }
 #HTMLReporter .resultMessage { padding-top: 14px; color: #333333; }


### PR DESCRIPTION
This is important when your test suite doubles as documentation.

Example post-change output:

```
on.dom plugins:
  on( { dom: "my_plugin", ready: ready = (x) -> }
    , { dom: "my_plugin": -> document.body }
    ) => ready(document.body)
  on.dom(["my_plugin", "xpath ."]) => body
  on.dom(["my_plugin", "xpath .."]) => html
  on.dom("xpath .") => document
```

(example borrowed from http://git.io/on.js)
