### PR TITLE
Describe only

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -501,6 +501,31 @@ var it = function(desc, func) {
 if (isCommonJS) exports.it = it;
 
 /**
+ * Creates an exclusive Jasmine spec that will be added to the current suite.
+ *
+ * If at least one exclusive (it.only) spec is registered, only these exclusive specs are run.
+ * Note, that this behavior works only with the default specFilter.
+ * Note, that it.only has higher priority over describe.only
+ *
+ * @example
+ * describe('suite', function() {
+ *   it.only('should be true', function() {
+ *     // only this spec will be run
+ *   });
+ *
+ *   it('should be false', function() {
+ *     // this won't be run
+ *   });
+ * });
+ *
+ * @param {String} desc description of this specification
+ * @param {Function} func defines the preconditions and expectations of the spec
+ */
+it.only = function(desc, func) {
+  return jasmine.getEnv().it.only(desc, func);
+};
+
+/**
  * Creates a <em>disabled</em> Jasmine spec.
  *
  * A convenience method that allows existing specs to be disabled temporarily during development.
@@ -603,6 +628,36 @@ var describe = function(description, specDefinitions) {
   return jasmine.getEnv().describe(description, specDefinitions);
 };
 if (isCommonJS) exports.describe = describe;
+
+
+/**
+ * Defines an exclusive suite of specifications.
+ *
+ * If at least one exclusive (describe.only) suite is registered, only these exclusive suites are run.
+ * Note, that this behavior works only with the default specFilter.
+ *
+ * @example
+ * describe.only('exclusive suite', function() {
+ *   it('should be true', function() {
+ *     // this spec will be run
+ *   });
+ *
+ *   it('should be false', function() {
+ *     // this spec will be run as well
+ *   });
+ * });
+ *
+ * describe('normal suite', function() {
+ *   // no spec from this suite will be run
+ * });
+ *
+ *
+ * @param {String} description A string, usually the class under test.
+ * @param {Function} specDefinitions function that defines several specs.
+ */
+describe.only = function(description, specDefinitions) {
+  return jasmine.getEnv().describe.only(description, specDefinitions);
+};
 
 /**
  * Disables a suite of specifications.  Used to disable some suites in a file, or files, temporarily during development.
@@ -725,13 +780,18 @@ jasmine.Env = function() {
   this.updateInterval = jasmine.DEFAULT_UPDATE_INTERVAL;
   this.defaultTimeoutInterval = jasmine.DEFAULT_TIMEOUT_INTERVAL;
   this.lastUpdate = 0;
-  this.specFilter = function() {
-    return true;
+  this.specFilter = function(spec) {
+    return this.exclusive_ <= spec.exclusive_;
   };
 
   this.nextSpecId_ = 0;
   this.nextSuiteId_ = 0;
   this.equalityTesters_ = [];
+
+  // 0 - normal
+  // 1 - contains some describe.only
+  // 2 - contains some it.only
+  this.exclusive_ = 0;
 
   // wrap matchers
   this.matchersClass = function() {
@@ -740,6 +800,33 @@ jasmine.Env = function() {
   jasmine.util.inherit(this.matchersClass, jasmine.Matchers);
 
   jasmine.Matchers.wrapInto_(jasmine.Matchers.prototype, this.matchersClass);
+
+  // setup describe.only and it.only helpers
+  var describeOnly = function(description, specDefinitions) {
+    var suite = new jasmine.Suite(this, description, null, this.currentSuite);
+    suite.exclusive_ = 1;
+    this.exclusive_ = Math.max(this.exclusive_, 1);
+
+    return this.describe_(suite, specDefinitions);
+  };
+
+  var self = this;
+  this.describe.only = function(){
+    return describeOnly.apply(self, arguments);
+  };
+
+  var itOnly = function(description, func) {
+    var spec = this.it(description, func);
+    spec.exclusive_ = 2;
+    this.exclusive_ = 2;
+
+    return spec;
+  };
+
+  this.it.only = function(){
+    return itOnly.apply(self, arguments);
+  };
+
 };
 
 
@@ -803,8 +890,11 @@ jasmine.Env.prototype.execute = function() {
 };
 
 jasmine.Env.prototype.describe = function(description, specDefinitions) {
-  var suite = new jasmine.Suite(this, description, specDefinitions, this.currentSuite);
+  var suite = new jasmine.Suite(this, description, null, this.currentSuite);
+  return this.describe_(suite, specDefinitions);
+};
 
+jasmine.Env.prototype.describe_ = function(suite, specDefinitions) {
   var parentSuite = this.currentSuite;
   if (parentSuite) {
     parentSuite.add(suite);
@@ -2225,6 +2315,7 @@ jasmine.Spec = function(env, suite, description) {
   spec.results_ = new jasmine.NestedResults();
   spec.results_.description = description;
   spec.matchersClass = null;
+  spec.exclusive_ = suite.exclusive_;
 };
 
 jasmine.Spec.prototype.getFullName = function() {
@@ -2461,6 +2552,7 @@ jasmine.Suite = function(env, description, specDefinitions, parentSuite) {
   self.children_ = [];
   self.suites_ = [];
   self.specs_ = [];
+  self.exclusive_ = parentSuite && parentSuite.exclusive_ || 0;
 };
 
 jasmine.Suite.prototype.getFullName = function() {

--- a/spec/core/RunnerSpec.js
+++ b/spec/core/RunnerSpec.js
@@ -277,4 +277,62 @@ describe('RunnerTest', function() {
       expect(suiteNames(suites)).toEqual([suite1.getFullName(), suite3.getFullName()]);
     });
   });
+
+  describe('describe.only', function() {
+    it('should run only describe.only suites when at least one registered', function() {
+      var normal = jasmine.createSpy('normal spec');
+      var exclusive = jasmine.createSpy('exclusive spec');
+
+      env.describe('normal', function() {
+        env.it('not executed 1', normal);
+        env.it('not executed 2', normal);
+      });
+
+      env.describe.only('exclusive', function() {
+        env.it('executed 1', exclusive);
+        env.it('executed 2', exclusive);
+        env.describe('nested exclusive', function() {
+          env.it('executed 3', exclusive);
+        });
+      });
+
+      env.describe('normal 2', function() {
+        env.it('not executed 3', normal);
+      });
+
+      env.execute();
+      expect(normal).not.toHaveBeenCalled();
+      expect(exclusive).toHaveBeenCalled();
+      expect(exclusive.callCount).toBe(3);
+    });
+  });
+
+  describe('it.only', function() {
+    it('should run only it.only specs when at least one registered', function() {
+      var normal = jasmine.createSpy('normal spec');
+      var exclusive = jasmine.createSpy('exclusive spec');
+
+      env.describe('normal', function() {
+        env.it('not executed 1', normal);
+        env.it.only('executed 1', exclusive);
+      });
+
+      env.describe.only('exclusive', function() {
+        env.it('not executed 2', normal);
+        env.it.only('executed 2', exclusive);
+        env.describe('nested exclusive', function() {
+          env.it.only('executed 3', exclusive);
+        });
+      });
+
+      env.describe.only('normal 2', function() {
+        env.it('not executed 3', normal);
+      });
+
+      env.execute();
+      expect(normal).not.toHaveBeenCalled();
+      expect(exclusive).toHaveBeenCalled();
+      expect(exclusive.callCount).toBe(3);
+    })
+  })
 });

--- a/src/core/Spec.js
+++ b/src/core/Spec.js
@@ -26,6 +26,7 @@ jasmine.Spec = function(env, suite, description) {
   spec.results_ = new jasmine.NestedResults();
   spec.results_.description = description;
   spec.matchersClass = null;
+  spec.exclusive_ = suite.exclusive_;
 };
 
 jasmine.Spec.prototype.getFullName = function() {

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -19,6 +19,7 @@ jasmine.Suite = function(env, description, specDefinitions, parentSuite) {
   self.children_ = [];
   self.suites_ = [];
   self.specs_ = [];
+  self.exclusive_ = parentSuite && parentSuite.exclusive_ || 0;
 };
 
 jasmine.Suite.prototype.getFullName = function() {

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -501,6 +501,31 @@ var it = function(desc, func) {
 if (isCommonJS) exports.it = it;
 
 /**
+ * Creates an exclusive Jasmine spec that will be added to the current suite.
+ *
+ * If at least one exclusive (it.only) spec is registered, only these exclusive specs are run.
+ * Note, that this behavior works only with the default specFilter.
+ * Note, that it.only has higher priority over describe.only
+ *
+ * @example
+ * describe('suite', function() {
+ *   it.only('should be true', function() {
+ *     // only this spec will be run
+ *   });
+ *
+ *   it('should be false', function() {
+ *     // this won't be run
+ *   });
+ * });
+ *
+ * @param {String} desc description of this specification
+ * @param {Function} func defines the preconditions and expectations of the spec
+ */
+it.only = function(desc, func) {
+  return jasmine.getEnv().it.only(desc, func);
+};
+
+/**
  * Creates a <em>disabled</em> Jasmine spec.
  *
  * A convenience method that allows existing specs to be disabled temporarily during development.
@@ -603,6 +628,36 @@ var describe = function(description, specDefinitions) {
   return jasmine.getEnv().describe(description, specDefinitions);
 };
 if (isCommonJS) exports.describe = describe;
+
+
+/**
+ * Defines an exclusive suite of specifications.
+ *
+ * If at least one exclusive (describe.only) suite is registered, only these exclusive suites are run.
+ * Note, that this behavior works only with the default specFilter.
+ *
+ * @example
+ * describe.only('exclusive suite', function() {
+ *   it('should be true', function() {
+ *     // this spec will be run
+ *   });
+ *
+ *   it('should be false', function() {
+ *     // this spec will be run as well
+ *   });
+ * });
+ *
+ * describe('normal suite', function() {
+ *   // no spec from this suite will be run
+ * });
+ *
+ *
+ * @param {String} description A string, usually the class under test.
+ * @param {Function} specDefinitions function that defines several specs.
+ */
+describe.only = function(description, specDefinitions) {
+  return jasmine.getEnv().describe.only(description, specDefinitions);
+};
 
 /**
  * Disables a suite of specifications.  Used to disable some suites in a file, or files, temporarily during development.


### PR DESCRIPTION
It's holiday season and tis the time to give, thus this pull request.

This is a mod of @vojtajina's ddescribe/iit pull request (https://github.com/pivotal/jasmine/pull/181)

The difference is I've renamed `ddescribe` to `describe.only` and `iit` to `it.only`, following Mocha's syntax. Tests are included. My hope is that this has a higher chance of getting merged in given that
1. it has prior art: see Mocha.
2. it does not introduce any additional globals.

Cheers!
