### PR TITLE
Fixing afterEach getting called if waitsFor times out

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -470,7 +470,7 @@ jasmine.log = function() {
  * @see jasmine.createSpy
  * @param obj
  * @param methodName
- * @returns a Jasmine spy that can be chained with all spy methods
+ * @return {jasmine.Spy} a Jasmine spy that can be chained with all spy methods
  */
 var spyOn = function(obj, methodName) {
   return jasmine.getEnv().currentSpec.spyOn(obj, methodName);
@@ -515,6 +515,7 @@ if (isCommonJS) exports.xit = xit;
  * jasmine.Matchers functions.
  *
  * @param {Object} actual Actual value to test against and expected value
+ * @return {jasmine.Matchers}
  */
 var expect = function(actual) {
   return jasmine.getEnv().currentSpec.expect(actual);
@@ -1381,18 +1382,14 @@ jasmine.Matchers.prototype.toHaveBeenCalledWith = function() {
     throw new Error('Expected a spy, but got ' + jasmine.pp(this.actual) + '.');
   }
   this.message = function() {
+    var invertedMessage = "Expected spy " + this.actual.identity + " not to have been called with " + jasmine.pp(expectedArgs) + " but it was.";
+    var positiveMessage = "";
     if (this.actual.callCount === 0) {
-      // todo: what should the failure message for .not.toHaveBeenCalledWith() be? is this right? test better. [xw]
-      return [
-        "Expected spy " + this.actual.identity + " to have been called with " + jasmine.pp(expectedArgs) + " but it was never called.",
-        "Expected spy " + this.actual.identity + " not to have been called with " + jasmine.pp(expectedArgs) + " but it was."
-      ];
+      positiveMessage = "Expected spy " + this.actual.identity + " to have been called with " + jasmine.pp(expectedArgs) + " but it was never called.";
     } else {
-      return [
-        "Expected spy " + this.actual.identity + " to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall),
-        "Expected spy " + this.actual.identity + " not to have been called with " + jasmine.pp(expectedArgs) + " but was called with " + jasmine.pp(this.actual.argsForCall)
-      ];
+      positiveMessage = "Expected spy " + this.actual.identity + " to have been called with " + jasmine.pp(expectedArgs) + " but actual calls were " + jasmine.pp(this.actual.argsForCall).replace(/^\[ | \]$/g, '')
     }
+    return [positiveMessage, invertedMessage];
   };
 
   return this.env.contains_(this.actual.argsForCall, expectedArgs);
@@ -1462,7 +1459,7 @@ jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
 /**
  * Matcher that checks that the expected exception was thrown by the actual.
  *
- * @param {String} expected
+ * @param {String} [expected]
  */
 jasmine.Matchers.prototype.toThrow = function(expected) {
   var result = false;
@@ -2030,7 +2027,14 @@ jasmine.Queue.prototype.next_ = function() {
   while (goAgain) {
     goAgain = false;
     
-    if (self.index < self.blocks.length && !(this.abort && !this.ensured[self.index])) {
+    if (this.abort) {
+      var blockNotEnsured = !this.ensured[self.index];
+      while (blockNotEnsured && self.index < self.blocks.length) {
+        self.index++;
+        blockNotEnsured = !this.ensured[self.index];
+      }
+    }
+    if (self.index < self.blocks.length) {
       var calledSynchronously = true;
       var completedSynchronously = false;
 
@@ -2564,5 +2568,5 @@ jasmine.version_= {
   "major": 1,
   "minor": 2,
   "build": 0,
-  "revision": 1343710612
+  "revision": 1351621339
 };

--- a/spec/core/SpecRunningSpec.js
+++ b/spec/core/SpecRunningSpec.js
@@ -406,8 +406,14 @@ describe("jasmine spec running", function () {
         env.afterEach(afterEach);
 
         env.it('waitsFor', function () {
+          this.runs(function() {
+            return true;
+          });
           this.waitsFor(100, function() {
             return false;
+          });
+          this.runs(function() {
+            return true;
           });
         });
       }).execute();

--- a/src/core/Queue.js
+++ b/src/core/Queue.js
@@ -58,7 +58,14 @@ jasmine.Queue.prototype.next_ = function() {
   while (goAgain) {
     goAgain = false;
     
-    if (self.index < self.blocks.length && !(this.abort && !this.ensured[self.index])) {
+    if (this.abort) {
+      var blockNotEnsured = !this.ensured[self.index];
+      while (blockNotEnsured && self.index < self.blocks.length) {
+        self.index++;
+        blockNotEnsured = !this.ensured[self.index];
+      }
+    }
+    if (self.index < self.blocks.length) {
       var calledSynchronously = true;
       var completedSynchronously = false;
 


### PR DESCRIPTION
When a test has runs and waitsFor blocks and one of the waitsFor blocks times out, afterEach does not get called. This can leave the test suite in a bad state.
