### PR TITLE
Make jasmine.pp work with Object.create(null) objects.

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1927,7 +1927,7 @@ jasmine.PrettyPrinter.prototype.format = function(value) {
 
 jasmine.PrettyPrinter.prototype.iterateObject = function(obj, fn) {
   for (var property in obj) {
-    if (!obj.hasOwnProperty(property)) continue;
+    if (obj.hasOwnProperty && !obj.hasOwnProperty(property)) continue;
     if (property == '__Jasmine_been_here_before__') continue;
     fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) !== jasmine.undefined && 
                                          obj.__lookupGetter__(property) !== null) : false);

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -53,7 +53,7 @@ jasmine.PrettyPrinter.prototype.format = function(value) {
 
 jasmine.PrettyPrinter.prototype.iterateObject = function(obj, fn) {
   for (var property in obj) {
-    if (!obj.hasOwnProperty(property)) continue;
+    if (obj.hasOwnProperty && !obj.hasOwnProperty(property)) continue;
     if (property == '__Jasmine_been_here_before__') continue;
     fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) !== jasmine.undefined && 
                                          obj.__lookupGetter__(property) !== null) : false);


### PR DESCRIPTION
Objects created with `Object.create(null)` currently cause iterateObject to throw a TypeError:

```
TypeError: 'undefined' is not a function (evaluating 'obj.hasOwnProperty(property)')
```

A quick check for the existence of obj.hasOwnProperty fixes this.
