### PR TITLE
Make getGlobal() work in strict mode

### DIFF
--- a/src/core/base.js
+++ b/src/core/base.js
@@ -51,12 +51,13 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
  */
 jasmine.CATCH_EXCEPTIONS = true;
 
+/**
+ * ECMAScript 5 strict mode doesn't promote undefined to the global object,
+ * so if you want to run jasmine in strict mode, this is the only way to
+ * get the global obje
+jasmine.global = this;
 jasmine.getGlobal = function() {
-  function getGlobal() {
-    return this;
-  }
-
-  return getGlobal();
+  return jasmine.global;
 };
 
 /**


### PR DESCRIPTION
ES5 strict mode does not promote an undefined 'this' to the 
global object.  The only way to get the global object in 
strict mode is to say 'this' while in the global scope.
