### PR TITLE
Detect CommonJS usage by exports variable only 

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1,4 +1,4 @@
-var isCommonJS = typeof window == "undefined" && typeof exports == "object";
+var isCommonJS = typeof exports == "object";
 
 /**
  * Top level namespace for Jasmine, a lightweight JavaScript BDD/spec/testing framework.

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -1,4 +1,4 @@
-var isCommonJS = typeof window == "undefined" && typeof exports == "object";
+var isCommonJS = typeof exports == "object";
 
 /**
  * Top level namespace for Jasmine, a lightweight JavaScript BDD/spec/testing framework.


### PR DESCRIPTION
Because PhantomJS uses a CommonJS interface, but also has a window variable defined.
