### PR TITLE
Html runner page can be auto-refreshed 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,9 +1,25 @@
-**A JavaScript Testing Framework**
+<a name="README">[Jasmine](http://pivotal.github.com/jasmine/)</a> <a title="Build at Travis CI" href="http://travis-ci.org/#!/pivotal/jasmine"><img src="https://secure.travis-ci.org/pivotal/jasmine.png" /></a>
 
-**This fork of Jasmine provides Auto-refresh checkbox in HTML runner. When enabled page is auto-refreshed 1sec after test suite finishes**
+=======
+**A JavaScript Testing Framework**
 
 Jasmine is a Behavior Driven Development testing framework for JavaScript. It does not rely on browsers, DOM, or any JavaScript framework. Thus it's suited for websites, [Node.js](http://nodejs.org) projects, or anywhere that JavaScript can run.
 
 Documentation & guides live here: [http://pivotal.github.com/jasmine/](http://pivotal.github.com/jasmine/)
+
+
+## Support
+
+* Search past discussions: [http://groups.google.com/group/jasmine-js](http://groups.google.com/group/jasmine-js)
+* Send an email to the list: [jasmine-js@googlegroups.com](jasmine-js@googlegroups.com)
+* View the project backlog at Pivotal Tracker: [http://www.pivotaltracker.com/projects/10606](http://www.pivotaltracker.com/projects/10606)
+* Follow us on Twitter: [@JasmineBDD](http://twitter.com/JasmineBDD)
+
+
+## Maintainers
+
+* [Davis W. Frank](mailto:dwfrank@pivotallabs.com), Pivotal Labs
+* [Rajan Agaskar](mailto:rajan@pivotallabs.com), Pivotal Labs
+* [Christian Williams](mailto:antixian666@gmail.com), Square
 
 Copyright (c) 2008-2012 Pivotal Labs. This software is licensed under the MIT License.


### PR DESCRIPTION
Checkbox was added (next to "No try/catch") to enable auto-refresh of runner's page. Currently refresh time is set to 1 sec. Refresh is done **only after test suite finishes**.
