### PR TITLE
Make baseName param in createSpyObj optional

### DIFF
--- a/src/core/base.js
+++ b/src/core/base.js
@@ -442,6 +442,10 @@ jasmine.isSpy = function(putativeSpy) {
  * @param {Array} methodNames array of names of methods to make spies
  */
 jasmine.createSpyObj = function(baseName, methodNames) {
+  if (jasmine.isArray_(baseName) && methodNames === undefined) {
+    methodNames = baseName;
+    baseName = 'unknown';
+  }
   if (!jasmine.isArray_(methodNames) || methodNames.length === 0) {
     throw new Error('createSpyObj requires a non-empty array of method names to create spies for');
   }


### PR DESCRIPTION
The name parameter in `jasmine.createSpy` is optional and defaults to 'unknown' if not provided. 

I have extended `jasmine.createSpyObj` so that the first parameter is optional and if called with only an array of method names then the base name defaults to 'unknown' as per `jasmine.createSpy`.
