### PR TITLE
Allow users to set the maximum length of array that the pretty-printer will print out

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -40,6 +40,11 @@ jasmine.DEFAULT_UPDATE_INTERVAL = 250;
 jasmine.MAX_PRETTY_PRINT_DEPTH = 40;
 
 /**
+ * Maximum length of array that will be pretty-printed
+ */
+jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH = 100;
+
+/**
  * Default timeout interval in milliseconds for waitsFor() blocks.
  */
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
@@ -1957,6 +1962,13 @@ jasmine.StringPrettyPrinter.prototype.emitString = function(value) {
 jasmine.StringPrettyPrinter.prototype.emitArray = function(array) {
   if (this.ppNestLevel_ > jasmine.MAX_PRETTY_PRINT_DEPTH) {
     this.append("Array");
+    return;
+  }
+
+  if (array.length > jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH) {
+    this.append("Array[");
+    this.append(array.length);
+    this.append("]");
     return;
   }
 

--- a/spec/core/PrettyPrintSpec.js
+++ b/spec/core/PrettyPrintSpec.js
@@ -62,7 +62,21 @@ describe("jasmine.pp", function () {
     }
   });
 
-  it("should stringify RegExp objects properly", function() {
+    it("should not print contents of arrays that are longer than jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH", function() {
+        var originalMaxLength = jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH;
+        var array = []; array[1] = "foop";
+
+        try {
+            expect(jasmine.pp(array)).toEqual("[ undefined, 'foop' ]");
+
+            jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH = 1;
+            expect(jasmine.pp(array)).toEqual("Array[2]");
+        } finally {
+            jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH = originalMaxLength;
+        }
+    });
+
+    it("should stringify RegExp objects properly", function() {
     expect(jasmine.pp(/x|y|z/)).toEqual("/x|y|z/");
   });
 

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -86,6 +86,13 @@ jasmine.StringPrettyPrinter.prototype.emitArray = function(array) {
     return;
   }
 
+  if (array.length > jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH) {
+    this.append("Array[");
+    this.append(array.length);
+    this.append("]");
+    return;
+  }
+
   this.append('[ ');
   for (var i = 0; i < array.length; i++) {
     if (i > 0) {

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -40,6 +40,11 @@ jasmine.DEFAULT_UPDATE_INTERVAL = 250;
 jasmine.MAX_PRETTY_PRINT_DEPTH = 40;
 
 /**
+ * Maximum length of array that will be pretty-printed
+ */
+jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH = 100;
+
+/**
  * Default timeout interval in milliseconds for waitsFor() blocks.
  */
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;


### PR DESCRIPTION
Currently, jasmine's pretty printer will iterate over an entire array, formatting every element recursively. For very large arrays, this can crash the page, or cause a 'slow script' warning.

This commit exposes a 'MAX_PRETTY_PRINT_ARRAY_LENGTH' option. If an array larger than this is encountered, recursion will stop and the array length will be printed instead e.g. "Array[20000000]".

The 'MAX_PRETTY_PRINT_ARRAY_LENGTH' option defaults to 100. This length of array will not kill your browser, but will allow you to see big arrays, if you can stomach the output.
