### PR TITLE
Default value for setTimeout/setInterval delay param

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1652,6 +1652,7 @@ jasmine.FakeTimer.prototype.runFunctionsWithinRange = function(oldMillis, nowMil
 };
 
 jasmine.FakeTimer.prototype.scheduleFunction = function(timeoutKey, funcToCall, millis, recurring) {
+  millis = millis || 10
   this.scheduledFunctions[timeoutKey] = {
     runAtMillis: this.nowMillis + millis,
     funcToCall: funcToCall,


### PR DESCRIPTION
When delay param isn't passed, jasmine.Clock not works properly
