### PR TITLE
Replaced deprecated octal literal with hexadecimal

### DIFF
--- a/spec/console/ConsoleReporterSpec.js
+++ b/spec/console/ConsoleReporterSpec.js
@@ -187,7 +187,7 @@ describe("ConsoleReporter", function() {
 
       reporter.specDone({status: "passed"});
 
-      expect(out.getOutput()).toEqual("\033[32m.\033[0m");
+      expect(out.getOutput()).toEqual("\x1B[32m.\x1B[0m");
     });
 
     it("does not report a disabled spec", function() {
@@ -209,7 +209,7 @@ describe("ConsoleReporter", function() {
 
       reporter.specDone({status: 'failed'});
 
-      expect(out.getOutput()).toEqual("\033[31mF\033[0m");
+      expect(out.getOutput()).toEqual("\x1B[31mF\x1B[0m");
     });
   });
 });

--- a/src/console/ConsoleReporter.js
+++ b/src/console/ConsoleReporter.js
@@ -9,10 +9,10 @@ jasmine.ConsoleReporter = function(options) {
     failedSpecs = [],
     pendingCount,
     ansi = {
-      green: '\033[32m',
-      red: '\033[31m',
-      yellow: '\033[33m',
-      none: '\033[0m'
+      green: '\x1B[32m',
+      red: '\x1B[31m',
+      yellow: '\x1B[33m',
+      none: '\x1B[0m'
     };
 
   this.jasmineStarted = function() {


### PR DESCRIPTION
Octal literals are deprecated in JavaScript 1.5 and Gjs were generating
warnings because of them. I replaced the octal literals in ConsoleReporter and its spec with hexadecimal literals, which generate no warnings.
