### PR TITLE
Added the ability to remove an individual spy

### DIFF
--- a/lib/jasmine-core/boot/boot.js
+++ b/lib/jasmine-core/boot/boot.js
@@ -41,6 +41,10 @@
     spyOn: function(obj, methodName) {
       return env.spyOn(obj, methodName);
     },
+            
+    removeSpy: function(obj, methodName) {
+      return env.removeSpy(obj, methodName);
+    },
 
     clock: env.clock,
     setTimeout: env.clock.setTimeout,

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -372,22 +372,9 @@ jasmine.createSpyObj = function(baseName, methodNames) {
   return obj;
 };
 
-/**
- * @namespace
- */
 jasmine.util = {};
 
-/**
- * Declare that a child class inherit it's prototype from the parent class.
- *
- * @private
- * @param {Function} childClass
- * @param {Function} parentClass
- */
 jasmine.util.inherit = function(childClass, parentClass) {
-  /**
-   * @private
-   */
   var subclass = function() {
   };
   subclass.prototype = parentClass.prototype;
@@ -793,6 +780,16 @@ jasmine.Spec.isPendingSpecException = function(e) {
     obj[methodName] = spyObj;
 
     return spyObj;
+  };
+  
+  jasmine.Env.prototype.removeSpy = function(obj, methodName) {
+    for (var i = 0; i < this.spies_.length; i++) {
+      var spy = this.spies_[i];
+      if(spy.baseObj === obj && spy.methodName === methodName){
+          spy.baseObj[spy.methodName] = spy.originalValue;
+          this.spies_.splice(i, 1);
+      }
+    }
   };
 
   // TODO: move this to closure

--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -211,7 +211,30 @@ describe('Spies', function () {
     expect(TestClass.someFunction).not.toHaveBeenCalled();
     expect(TestClass.someFunction.callCount).toEqual(0);
   });
-
+  
+  it('should allow you to remove a spy', function() {
+    var TestClass = { someFunction: function() {
+    } };
+    env.spyOn(TestClass, 'someFunction');
+    var exception;
+    try {
+      env.spyOn(TestClass, 'someFunction');
+    } catch (e) {
+      exception = e;
+    }
+    expect(exception).toBeDefined();
+    
+    env.removeSpy(TestClass, 'someFunction');
+    
+    var exception2;
+    try {
+      env.spyOn(TestClass, 'someFunction');
+    } catch (e) {
+      exception2 = e;
+    }
+    expect(exception2).not.toBeDefined();
+  });
+  
   describe("createSpyObj", function() {
     it("should create an object with a bunch of spy methods when you call jasmine.createSpyObj()", function() {
       var spyObj = jasmine.createSpyObj('BaseName', ['method1', 'method2']);

--- a/spec/node_performance_suite.js
+++ b/spec/node_performance_suite.js
@@ -45,6 +45,9 @@ var jasmineInterface = {
     return env.spyOn(obj, methodName);
   },
 
+  removeSpy: function(obj, methodName) {
+    return env.removeSpy(obj, methodName);
+  },
 
   jsApiReporter: new jasmine.JsApiReporter(jasmine)
 };

--- a/spec/node_suite.js
+++ b/spec/node_suite.js
@@ -44,6 +44,10 @@ var jasmineInterface = {
   spyOn: function(obj, methodName) {
     return env.spyOn(obj, methodName);
   },
+  
+  removeSpy: function(obj, methodName) {
+    return env.removeSpy(obj, methodName);
+  },
 
   clock: env.clock,
   setTimeout: env.clock.setTimeout,

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -236,6 +236,16 @@
 
     return spyObj;
   };
+  
+  jasmine.Env.prototype.removeSpy = function(obj, methodName) {
+    for (var i = 0; i < this.spies_.length; i++) {
+      var spy = this.spies_[i];
+      if(spy.baseObj === obj && spy.methodName === methodName){
+          spy.baseObj[spy.methodName] = spy.originalValue;
+          this.spies_.splice(i, 1);
+      }
+    }
+  };
 
   // TODO: move this to closure
   jasmine.Env.prototype.removeAllSpies = function() {


### PR DESCRIPTION
I really needed to overwrite one spy for a couple of my tests so I added a removeSpy function. I figure some other people might find this useful.
