### PR TITLE
Regex exception matching

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1347,7 +1347,7 @@ jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
 
 jasmine.Matchers.prototype.toThrow = function(expected) {
   var result = false;
-  var exception;
+  var exception, exceptionMessage;
   if (typeof this.actual != 'function') {
     throw new Error('Actual is not a function');
   }
@@ -1358,14 +1358,16 @@ jasmine.Matchers.prototype.toThrow = function(expected) {
   }
 
   if (exception) {
-    result = (jasmine.util.isUndefined(expected) || this.env.equals_(exception.message || exception, expected.message || expected));
+    exceptionMessage = exception.message || exception;
+    result = (jasmine.util.isUndefined(expected) || this.env.equals_(exceptionMessage, expected.message || expected) || (jasmine.isA_("RegExp", expected) && expected.test(exceptionMessage)));
   }
 
   var not = this.isNot ? "not " : "";
+  var regexMatch = jasmine.isA_("RegExp", expected) ? " an exception matching" : "";
 
   this.message = function() {
     if (exception) {
-      return ["Expected function " + not + "to throw", expected ? expected.message || expected : "an exception", ", but it threw", exception.message || exception].join(' ');
+      return ["Expected function " + not + "to throw" + regexMatch, expected ? expected.message || expected : "an exception", ", but it threw", exceptionMessage].join(' ');
     } else {
       return "Expected function to throw an exception.";
     }

--- a/spec/core/MatchersSpec.js
+++ b/spec/core/MatchersSpec.js
@@ -594,6 +594,12 @@ describe("jasmine.Matchers", function() {
         expect(lastResult().message).toMatch("Other Error");
       });
 
+      it("should match exceptions specified by regular expression", function() {
+        expect(match(throwingFn).toThrow(/Error/)).toPass();
+        expect(match(throwingFn).toThrow(/^Error/)).toFail();
+        expect(lastResult().message).toMatch("throw an exception matching /\\^Error/");
+      });
+
       it("should match exceptions specified by Error", function() {
         expect(match(throwingFn).toThrow(new Error("Fake Error"))).toPass();
         expect(match(throwingFn).toThrow(new Error("Other Error"))).toFail();
@@ -610,6 +616,12 @@ describe("jasmine.Matchers", function() {
           expect(match(throwingFn).not.toThrow("Fake Error")).toFail();
           //          expect(lastResult().message).toMatch(/Expected function not to throw Fake Error./);
           expect(match(throwingFn).not.toThrow("Other Error")).toPass();
+        });
+
+        it("should match exceptions specified by regular expression", function() {
+          expect(match(throwingFn).not.toThrow(/Error/)).toFail();
+          //          expect(lastResult().message).toMatch(/Expected function not to throw an exception matching \/Error\/./);
+          expect(match(throwingFn).not.toThrow(/^Error/)).toPass();
         });
 
         it("should match exceptions specified by Error", function() {

--- a/src/core/Matchers.js
+++ b/src/core/Matchers.js
@@ -222,7 +222,7 @@ jasmine.Matchers.prototype.toBeCloseTo = function(expected, precision) {
 
 jasmine.Matchers.prototype.toThrow = function(expected) {
   var result = false;
-  var exception;
+  var exception, exceptionMessage;
   if (typeof this.actual != 'function') {
     throw new Error('Actual is not a function');
   }
@@ -233,14 +233,16 @@ jasmine.Matchers.prototype.toThrow = function(expected) {
   }
 
   if (exception) {
-    result = (jasmine.util.isUndefined(expected) || this.env.equals_(exception.message || exception, expected.message || expected));
+    exceptionMessage = exception.message || exception;
+    result = (jasmine.util.isUndefined(expected) || this.env.equals_(exceptionMessage, expected.message || expected) || (jasmine.isA_("RegExp", expected) && expected.test(exceptionMessage)));
   }
 
   var not = this.isNot ? "not " : "";
+  var regexMatch = jasmine.isA_("RegExp", expected) ? " an exception matching" : "";
 
   this.message = function() {
     if (exception) {
-      return ["Expected function " + not + "to throw", expected ? expected.message || expected : "an exception", ", but it threw", exception.message || exception].join(' ');
+      return ["Expected function " + not + "to throw" + regexMatch, expected ? expected.message || expected : "an exception", ", but it threw", exceptionMessage].join(' ');
     } else {
       return "Expected function to throw an exception.";
     }


### PR DESCRIPTION
Here's an initial pass at adding support for regular expression matching in the toThrow matcher.

The first commit simply updates lib/jasmine-core/jasmine.js so depending on if/when this is merged, it may not be needed anymore. 

These commits are for issue #343.
