### PR TITLE
Expanding the getContainer in boot.js so it will work in IE8

### DIFF
--- a/lib/jasmine-core/boot/boot.js
+++ b/lib/jasmine-core/boot/boot.js
@@ -70,7 +70,15 @@
     env: env,
     queryString: queryString,
     onRaiseExceptionsClick: function() { queryString.setParam("catch", !env.catchingExceptions()); },
-    getContainer: function() { return document.body; },
+    getContainer: function() { 
+      if(!document.getElementsByClassName) {
+        document.getElementsByClassName = function(className) {
+          return this.querySelectorAll("." + className);
+        };
+        Element.prototype.getElementsByClassName = document.getElementsByClassName;
+      }
+      return document.body;
+    },
     createElement: function() { return document.createElement.apply(document, arguments); },
     createTextNode: function() { return document.createTextNode.apply(document, arguments); }
   });


### PR DESCRIPTION
I'm not a ruby developer and I'm not familiar with getting bundle/rake/etc... running in my Windows environment. I did run some of the grunt tasks to ensure I didn't break anything there, but I don't see any test specifically for the boot.js file.

Since I'm using jasmine in an enterprise environment and we're restricted to IE8, I've updated the getContainer method to add the getElementsByClassName method needed in the Html Reporter. I can add to this if there are other places that need to be updated.
