### PR TITLE
Updating find method to use querySelectorAll to be compatible with IE8

### DIFF
--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -193,8 +193,7 @@ jasmine.HtmlReporter = function(options) {
 
   function find(selector) {
     if (selector.match(/^\./)) {
-      var className = selector.substring(1);
-      return getContainer().getElementsByClassName(className);
+      return getContainer().querySelectorAll(selector);
     } else {
       return getContainer().getElementsByTagName(selector);
     }


### PR DESCRIPTION
This is in reference to #350

Updating the find method to use querySelectorAll and pass in the entire selector.
I ran the specs via `grunt execSpecsInNode` and everything passed. I'm still not able to get the ruby stuff running.
