### PR TITLE
Add titles to specs in HtmlReporter

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -87,7 +87,8 @@ jasmine.HtmlReporter = function(options) {
 
     symbols.appendChild(createDom("li", {
         className: result.status,
-        id: "spec_" + result.id}
+        id: "spec_" + result.id,
+        title: result.fullName}
     ));
 
     if (result.status == "failed") {

--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -46,12 +46,13 @@ describe("New HtmlReporter", function() {
         });
       reporter.initialize();
 
-      reporter.specDone({id: 789, status: "disabled"});
+      reporter.specDone({id: 789, status: "disabled", fullName: "symbols should have titles"});
 
       var statuses = container.getElementsByClassName('symbol-summary')[0];
       var specEl = statuses.getElementsByTagName('li')[0];
       expect(specEl.getAttribute("class")).toEqual("disabled");
       expect(specEl.getAttribute("id")).toEqual("spec_789");
+      expect(specEl.getAttribute("title")).toEqual("symbols should have titles");
     });
 
     it("reports the status symbol of a pending spec", function() {

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -65,7 +65,8 @@ jasmine.HtmlReporter = function(options) {
 
     symbols.appendChild(createDom("li", {
         className: result.status,
-        id: "spec_" + result.id}
+        id: "spec_" + result.id,
+        title: result.fullName}
     ));
 
     if (result.status == "failed") {


### PR DESCRIPTION
Adding titles to each spec symbol in the HtmlReporter, which allows for seeing the spec name on hover (as requested in https://www.pivotaltracker.com/story/show/48420677).

Each title is the full name of the spec it represents.
