### PR TITLE
Feature: Add a unloadSuites method

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -528,6 +528,15 @@ jasmine.Spec.isPendingSpecException = function(e) {
       });
       this.topSuite.execute(this.reporter.jasmineDone);
     };
+
+    this.unloadSuites = function() {
+      this.topSuite.children_ = [];
+      this.nextSuiteId_ = 0;
+      this.nextSpecId_ = 0;
+      totalSpecsDefined = 0;
+      this.suites = [];
+    };
+    
   };
 
   //TODO: shim Spec addMatchers behavior into Env. Should be rewritten to remove globals, etc.

--- a/spec/core/EnvSpec.js
+++ b/spec/core/EnvSpec.js
@@ -182,6 +182,47 @@ describe("Env (integration)", function() {
 
   });
 
+    it("unloadSuites unloads the all registered suites", function() {
+    var env = new jasmine.Env(),
+      calls = [];
+
+    env.describe("Outer suite", function() {
+      env.it("an outer spec", function() {
+        calls.push('an outer spec')
+      });
+      env.describe("Inner suite", function() {
+        env.it("an inner spec", function() {
+          calls.push('an inner spec');
+        });
+        env.it("another inner spec", function() {
+          calls.push('another inner spec');
+        });
+      });
+    });
+
+    env.execute();
+
+    expect(calls).toEqual([
+      'an outer spec',
+      'an inner spec',
+      'another inner spec'
+    ]);
+
+    env.unloadSuites();
+    calls = [];
+    env.describe("New Suite", function() {
+      env.it("a spec of the new suite", function() {
+        calls.push('a spec of the new suite');
+      });  
+    });
+
+    env.execute();
+
+    expect(calls).toEqual([
+      'a spec of the new suite'
+    ]);  
+  });
+
   it("Multiple top-level Suites execute as expected", function() {
     var env = new jasmine.Env(),
       calls = [];


### PR DESCRIPTION
There should be a way to unload currently loaded suites. 

I am working on a taskrunner for jasmine which as a feature should be able to run multiple sets of specs with the same instance of jasmine.

Adding a unloadSuites would make this possible.

Targeted flow is:
1. Load setA of specs 
2. Call jasmine.execute()
3. jasmine.unloadSpecs()
4. load setB of specs
   5 call jasmine.execute()
