### PR TITLE
Fix spec to throw error, ensuring a stack property

### DIFF
--- a/spec/core/ExceptionFormatterSpec.js
+++ b/spec/core/ExceptionFormatterSpec.js
@@ -41,7 +41,8 @@ describe("ExceptionFormatter", function() {
 
   describe("#stack", function() {
     it("formats stack traces from Webkit, Firefox or node.js", function() {
-      var error = new Error("an error");
+      var error;
+      try { throw new Error("an error") } catch(e) { error = e; };
       expect(new j$.ExceptionFormatter().stack(error)).toMatch(/ExceptionFormatterSpec\.js.*\d+/)
     });
 


### PR DESCRIPTION
In Safari Mac 6.0.4 (and possibly other versions), a new error does
not have the stack property. Throwing the error and then catching it
ensures that the stack property has the correct value.

This fix gets the specs to run green in Safari.
