### PR TITLE
Adding additional edge case tests for toThrow and toThrowError

### DIFF
--- a/spec/core/matchersSpec.js
+++ b/spec/core/matchersSpec.js
@@ -473,7 +473,7 @@ describe("Matchers", function() {
   });
 
   describe("toThrow", function() {
-    it("throws an error when the acutal is not a function", function() {
+    it("throws an error when the actual is not a function", function() {
       var matcher = j$.matchers.toThrow();
 
       expect(function() {
@@ -510,6 +510,18 @@ describe("Matchers", function() {
       expect(result.message).toEqual("Expected function not to throw.");
     });
 
+    it("passes even if what is thrown is falsy", function() {
+      var matcher = j$.matchers.toThrow(),
+        fn = function() {
+          throw undefined;
+        },
+        result;
+
+      result = matcher.compare(fn);
+      expect(result.pass).toBe(true);
+      expect(result.message).toEqual("Expected function not to throw.");
+    });
+
     it("passes if what is thrown is equivalent to what is expected", function() {
       var util = {
           equals: j$.createSpy('delegated-equal').andReturn(true)
@@ -541,10 +553,26 @@ describe("Matchers", function() {
       expect(result.pass).toBe(false);
       expect(result.message).toEqual("Expected function to throw 'foo'.");
     });
+
+    it("fails if what is thrown is not equivalent to undefined", function() {
+      var util = {
+          equals: j$.createSpy('delegated-equal').andReturn(false)
+        },
+        matcher = j$.matchers.toThrow(util),
+        fn = function() {
+          throw 5;
+        },
+        result;
+
+      result = matcher.compare(fn, void 0);
+
+      expect(result.pass).toBe(false);
+      expect(result.message).toEqual("Expected function to throw undefined.");
+    });
   });
 
   describe("toThrowError", function() {
-    it("throws an error when the acutal is not a function ", function() {
+    it("throws an error when the actual is not a function", function() {
       var matcher = j$.matchers.toThrowError();
 
       expect(function() {
@@ -560,7 +588,29 @@ describe("Matchers", function() {
 
       expect(function() {
         matcher.compare(fn, 1);
-      }).toThrow(new Error("Expected is not an Error, message, or RegExp.")); // TODO: this needs to change for self-test
+      }).toThrow(new Error("Expected is not an Error, string, or RegExp.")); // TODO: this needs to change for self-test
+    });
+
+    it("throws an error when the expected error type is not an Error", function() {
+      var matcher = j$.matchers.toThrowError(),
+        fn = function() {
+          throw new Error("foo");
+        };
+
+      expect(function() {
+        matcher.compare(fn, "string", "foo");
+      }).toThrow(new Error("Expected error type is not an Error.")); // TODO: this needs to change for self-test
+    });
+
+    it("throws an error when the expected error message is not a string or RegExp", function() {
+      var matcher = j$.matchers.toThrowError(),
+        fn = function() {
+          throw new Error("foo");
+        };
+
+      expect(function() {
+        matcher.compare(fn, Error, 1);
+      }).toThrow(new Error("Expected error message is not a string or RegExp.")); // TODO: this needs to change for self-test
     });
 
     it("fails if actual does not throw at all", function() {
@@ -574,6 +624,30 @@ describe("Matchers", function() {
 
       expect(result.pass).toBe(false);
       expect(result.message).toEqual("Expected function to throw an Error.");
+    });
+
+    it("fails if thrown is not an instanceof Error", function() {
+      var matcher = j$.matchers.toThrowError(),
+        fn = function() {
+          throw 4;
+        },
+        result;
+
+      result = matcher.compare(fn);
+      expect(result.pass).toBe(false);
+      expect(result.message).toEqual("Expected function to throw an Error, but it threw 4.");
+    });
+
+    it("fails with the correct message if thrown is a falsy value", function() {
+      var matcher = j$.matchers.toThrowError(),
+        fn = function() {
+          throw undefined;
+        },
+        result;
+
+      result = matcher.compare(fn);
+      expect(result.pass).toBe(false);
+      expect(result.message).toEqual("Expected function to throw an Error, but it threw undefined.");
     });
 
     it("passes if thrown is an Error, but there is no expected error", function() {
@@ -683,7 +757,7 @@ describe("Matchers", function() {
         },
         result;
 
-      result = matcher.compare(fn, [Error, "foo"]);
+      result = matcher.compare(fn, Error, "foo");
 
       expect(result.pass).toBe(true);
       expect(result.message).toEqual("Expected function not to throw Error with message \"foo\".");
@@ -699,7 +773,7 @@ describe("Matchers", function() {
         },
         result;
 
-      result = matcher.compare(fn, [Error, "bar"]);
+      result = matcher.compare(fn, Error, "bar");
 
       expect(result.pass).toBe(false);
       expect(result.message).toEqual("Expected function to throw Error with message \"bar\".");
@@ -715,7 +789,7 @@ describe("Matchers", function() {
         },
         result;
 
-      result = matcher.compare(fn, [Error, /foo/]);
+      result = matcher.compare(fn, Error, /foo/);
 
       expect(result.pass).toBe(true);
       expect(result.message).toEqual("Expected function not to throw Error with message matching /foo/.");
@@ -731,7 +805,7 @@ describe("Matchers", function() {
         },
         result;
 
-      result = matcher.compare(fn, [Error, /bar/]);
+      result = matcher.compare(fn, Error, /bar/);
 
       expect(result.pass).toBe(false);
       expect(result.message).toEqual("Expected function to throw Error with message matching /bar/.");

--- a/src/core/matchers.js
+++ b/src/core/matchers.js
@@ -213,7 +213,7 @@ getJasmineRequireObj().matchers = function() {
           return result;
         }
 
-        if (expected == void 0) {
+        if (arguments.length == 1) {
           result.pass = true;
           result.message = "Expected function not to throw.";
 
@@ -234,7 +234,7 @@ getJasmineRequireObj().matchers = function() {
 
   matchers.toThrowError = function(util) {
     return {
-      compare: function(actual, expected) {
+      compare: function(actual) {
         var threw = false,
           thrown,
           errorType,
@@ -245,7 +245,7 @@ getJasmineRequireObj().matchers = function() {
           throw new Error("Actual is not a Function");
         }
 
-        extractExpectedParams();
+        extractExpectedParams.apply(null, arguments);
 
         try {
           actual();
@@ -262,7 +262,7 @@ getJasmineRequireObj().matchers = function() {
           return fail("Expected function to throw an Error, but it threw " + thrown + ".");
         }
 
-        if (expected == void 0) {
+        if (arguments.length == 1) {
           return pass("Expected function not to throw an Error, but it threw " + thrown + ".");
         }
 
@@ -321,29 +321,36 @@ getJasmineRequireObj().matchers = function() {
         }
 
         function extractExpectedParams() {
-          if (expected == void 0) {
+          if (arguments.length == 1) {
             return;
-          }
+          } else if (arguments.length == 2) {
+            var expected = arguments[1];
 
-          if (expected instanceof RegExp) {
-            regexp = expected;
-          } else if (typeof expected == "string") {
-            message = expected;
-          } else if (typeof expected == "function" && new expected() instanceof Error) {
-            errorType = expected;
-          } else if (expected.length) {
-            if (typeof expected[0] == "function" && new expected[0]() instanceof Error) {
-              errorType = expected[0];
+            if (expected instanceof RegExp) {
+              regexp = expected;
+            } else if (typeof expected == "string") {
+              message = expected;
+            } else if (typeof expected == "function" && new expected() instanceof Error) {
+              errorType = expected;
             }
-            if (expected[1] instanceof RegExp) {
-              regexp = expected[1];
-            } else if (typeof expected[1] == "string") {
-              message = expected[1];
-            }
-          }
 
-          if (!(errorType || message || regexp)) {
-            throw new Error("Expected is not an Error, message, or RegExp.");
+            if (!(errorType || message || regexp)) {
+              throw new Error("Expected is not an Error, string, or RegExp.");
+            }
+          } else {
+            if (typeof arguments[1] == "function" && new arguments[1]() instanceof Error) {
+              errorType = arguments[1];
+            } else {
+              throw new Error("Expected error type is not an Error.");
+            }
+
+            if (arguments[2] instanceof RegExp) {
+              regexp = arguments[2];
+            } else if (typeof arguments[2] == "string") {
+              message = arguments[2];
+            } else {
+              throw new Error("Expected error message is not a string or RegExp.");
+            }
           }
         }
       }


### PR DESCRIPTION
Also, changed dealing of multiple arguments so the user can do:
`expect(fn).toThrowError(TypeError, "foo")`
instead of:
`expect(fn).toThrowError([TypeError, "foo"])`

and updated the error messaging around when the user uses this multiple argument format.
