### PR TITLE
Avoid instantiating passed in errorType in toThrowError

### DIFF
--- a/spec/core/matchers/toThrowErrorSpec.js
+++ b/spec/core/matchers/toThrowErrorSpec.js
@@ -158,6 +158,26 @@ describe("toThrowError", function() {
     expect(result.message).toEqual("Expected function not to throw Error.");
   });
 
+  it("passes if thrown is a custom error that takes arguments and the expected is the same error", function() {
+    var util = {
+        equals: j$.createSpy('delegated-equal').andReturn(true)
+      },
+      matcher = j$.matchers.toThrowError(util),
+      CustomError = function CustomError(arg) { arg.x },
+      fn = function() {
+        throw new CustomError({ x: 1 });
+      },
+      result;
+
+    CustomError.prototype = new Error();
+    CustomError.prototype.constructor = CustomError;
+
+    result = matcher.compare(fn, CustomError);
+
+    expect(result.pass).toBe(true);
+    expect(result.message).toEqual("Expected function not to throw CustomError.");
+  });
+
   it("fails if thrown is an Error and the expected is a different Error", function() {
     var util = {
         equals: j$.createSpy('delegated-equal').andReturn(false)
@@ -185,6 +205,26 @@ describe("toThrowError", function() {
       result;
 
     result = matcher.compare(fn, Error, "foo");
+
+    expect(result.pass).toBe(true);
+    expect(result.message).toEqual("Expected function not to throw Error with message \"foo\".");
+  });
+
+  it("passes if thrown is a custom error that takes arguments and it is equal to the expected custom error and message", function() {
+    var util = {
+        equals: j$.createSpy('delegated-equal').andReturn(true)
+      },
+      matcher = j$.matchers.toThrowError(util),
+      CustomError = function CustomError(arg) { this.message = arg.message },
+      fn = function() {
+        throw new CustomError({message: "foo"});
+      },
+      result;
+
+    CustomError.prototype = new Error();
+    CustomError.prototype.constructor = CustomError;
+
+    result = matcher.compare(fn, CustomError, "foo");
 
     expect(result.pass).toBe(true);
     expect(result.message).toEqual("Expected function not to throw Error with message \"foo\".");

--- a/src/core/matchers/toThrowError.js
+++ b/src/core/matchers/toThrowError.js
@@ -34,7 +34,7 @@ getJasmineRequireObj().toThrowError = function() {
         }
 
         if (errorType && message) {
-          if (util.equals(thrown, new errorType(message))) {
+          if (thrown.constructor == errorType && util.equals(thrown.message, message)) {
             return pass("Expected function not to throw Error with message \"" + message + "\".");
           } else {
             return fail("Expected function to throw Error with message \"" + message + "\".");
@@ -99,7 +99,7 @@ getJasmineRequireObj().toThrowError = function() {
               regexp = expected;
             } else if (typeof expected == "string") {
               message = expected;
-            } else if (typeof expected == "function" && new expected() instanceof Error) {
+            } else if (checkForAnErrorType(expected)) {
               errorType = expected;
             }
 
@@ -107,7 +107,7 @@ getJasmineRequireObj().toThrowError = function() {
               throw new Error("Expected is not an Error, string, or RegExp.");
             }
           } else {
-            if (typeof arguments[1] == "function" && new arguments[1]() instanceof Error) {
+            if (checkForAnErrorType(arguments[1])) {
               errorType = arguments[1];
             } else {
               throw new Error("Expected error type is not an Error.");
@@ -122,6 +122,16 @@ getJasmineRequireObj().toThrowError = function() {
             }
           }
         }
+
+        function checkForAnErrorType(type) {
+          if (typeof expected == "function") {
+            return false;
+          }
+
+          var Surrogate = function() {};
+          Surrogate.prototype = type.prototype;
+          return (new Surrogate()) instanceof Error;
+        };
       }
     };
   }


### PR DESCRIPTION
since the passed in errorType could be a custom user function,
we instead detect if its an instanceof Error by using a Surrogate
(inspired by Backbone's use of surrogacy)
