### PR TITLE
Add execution time elapsed to JsApiReporter

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -30,11 +30,10 @@ jasmineRequire.HtmlReporter = function() {
   function HtmlReporter(options) {
     var env = options.env || {},
       getContainer = options.getContainer,
-      now = options.now || function() { return new Date().getTime();},
       createElement = options.createElement,
       createTextNode = options.createTextNode,
+      onRaiseExceptionsClick = options.onRaiseExceptionsClick,
       results = [],
-      startTime,
       specsExecuted = 0,
       failureCount = 0,
       pendingSpecCount = 0,
@@ -61,7 +60,6 @@ jasmineRequire.HtmlReporter = function() {
     var totalSpecsDefined;
     this.jasmineStarted = function(options) {
       totalSpecsDefined = options.totalSpecsDefined || 0;
-      startTime = now();
     };
 
     var summary = createDom("div", {className: "summary"});
@@ -122,11 +120,9 @@ jasmineRequire.HtmlReporter = function() {
       }
     };
 
-    this.jasmineDone = function() {
-      var elapsed = now() - startTime;
-
+    this.jasmineDone = function(options) {
       var banner = find(".banner");
-      banner.appendChild(createDom("span", {className: "duration"}, "finished in " + elapsed / 1000 + "s"));
+      banner.appendChild(createDom("span", {className: "duration"}, "finished in " + options.executionTime / 1000 + "s"));
 
       var alert = find(".alert");
 
@@ -141,7 +137,7 @@ jasmineRequire.HtmlReporter = function() {
       var checkbox = find("input");
 
       checkbox.checked = !env.catchingExceptions();
-      checkbox.onclick = options.onRaiseExceptionsClick;
+      checkbox.onclick = onRaiseExceptionsClick;
 
       if (specsExecuted < totalSpecsDefined) {
         var skippedMessage = "Ran " + specsExecuted + " of " + totalSpecsDefined + " specs - run all";

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -307,7 +307,8 @@ getJasmineRequireObj().Env = function(j$) {
   function Env(options) {
     options = options || {};
     var self = this;
-    var global = options.global || j$.getGlobal();
+    var global = options.global || j$.getGlobal(),
+      now = options.now || function() { return new Date().getTime(); };
 
     var catchExceptions = true;
 
@@ -497,10 +498,13 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.execute = function() {
+      var startTime = now();
       this.reporter.jasmineStarted({
         totalSpecsDefined: totalSpecsDefined
       });
-      this.topSuite.execute(this.reporter.jasmineDone);
+      this.topSuite.execute(function() {
+        self.reporter.jasmineDone({executionTime: now() - startTime});
+      });
     };
   }
 
@@ -655,8 +659,11 @@ getJasmineRequireObj().JsApiReporter = function() {
       status = 'started';
     };
 
-    this.jasmineDone = function() {
+    var executionTime;
+
+    this.jasmineDone = function(options) {
       this.finished = true;
+      executionTime = options.executionTime;
       status = 'done';
     };
 
@@ -695,6 +702,10 @@ getJasmineRequireObj().JsApiReporter = function() {
 
     this.specs = function() {
       return specs;
+    };
+
+    this.executionTime = function() {
+      return executionTime;
     };
 
   }

--- a/spec/console/ConsoleReporterSpec.js
+++ b/spec/console/ConsoleReporterSpec.js
@@ -69,20 +69,15 @@ describe("ConsoleReporter", function() {
   });
 
   it("reports a summary when done (singluar spec and time)", function() {
-    var fakeNow = jasmine.createSpy('fake Date.now'),
-      reporter = new j$.ConsoleReporter({
+    var reporter = new j$.ConsoleReporter({
         print: out.print,
-        now: fakeNow
       });
-
-    fakeNow.andReturn(500);
 
     reporter.jasmineStarted();
     reporter.specDone({status: "passed"});
-    fakeNow.andReturn(1500);
 
     out.clear();
-    reporter.jasmineDone();
+    reporter.jasmineDone({executionTime: 1000});
 
     expect(out.getOutput()).toMatch(/1 spec, 0 failures/);
     expect(out.getOutput()).not.toMatch(/0 pending specs/);
@@ -90,13 +85,10 @@ describe("ConsoleReporter", function() {
   });
 
   it("reports a summary when done (pluralized specs and seconds)", function() {
-    var fakeNow = jasmine.createSpy('fake Date.now'),
-      reporter = new j$.ConsoleReporter({
+    var reporter = new j$.ConsoleReporter({
         print: out.print,
-        now: fakeNow
       });
 
-    fakeNow.andReturn(500);
     reporter.jasmineStarted();
     reporter.specDone({status: "passed"});
     reporter.specDone({status: "pending"});
@@ -117,8 +109,7 @@ describe("ConsoleReporter", function() {
 
     out.clear();
 
-    fakeNow.andReturn(600);
-    reporter.jasmineDone();
+    reporter.jasmineDone({executionTime: 100});
 
     expect(out.getOutput()).toMatch(/3 specs, 1 failure, 1 pending spec/);
     expect(out.getOutput()).toMatch("Finished in 0.1 seconds\n");
@@ -148,7 +139,7 @@ describe("ConsoleReporter", function() {
 
     out.clear();
 
-    reporter.jasmineDone();
+    reporter.jasmineDone({});
 
     expect(out.getOutput()).toMatch(/foo bar baz/);
   });
@@ -160,7 +151,7 @@ describe("ConsoleReporter", function() {
         onComplete: onComplete
       });
 
-    reporter.jasmineDone();
+    reporter.jasmineDone({});
 
     expect(onComplete).toHaveBeenCalled();
   });

--- a/spec/core/EnvSpec.js
+++ b/spec/core/EnvSpec.js
@@ -167,8 +167,9 @@ describe("Env (integration)", function() {
 
   // TODO: something is wrong with this spec
   it("should report as expected", function() {
-    var env = new j$.Env(),
-      reporter = jasmine.createSpyObj('fakeReproter', [
+    var fakeNow = jasmine.createSpy('fake Date.now'),
+      env = new j$.Env({now: fakeNow}),
+      reporter = jasmine.createSpyObj('fakeReporter', [
         "jasmineStarted",
         "jasmineDone",
         "suiteStarted",
@@ -176,6 +177,9 @@ describe("Env (integration)", function() {
         "specStarted",
         "specDone"
       ]);
+
+    fakeNow.andReturn(500);
+    reporter.suiteDone.andCallFake(function() { fakeNow.andReturn(1500); });
 
     env.addReporter(reporter);
 
@@ -200,7 +204,9 @@ describe("Env (integration)", function() {
     });
     var suiteResult = reporter.suiteStarted.calls[0].args[0];
     expect(suiteResult.description).toEqual("A Suite");
-    expect(reporter.jasmineDone).toHaveBeenCalled();
+    expect(reporter.jasmineDone).toHaveBeenCalledWith({
+      executionTime: 1000
+    });
   });
 
   it("should be possible to get full name from a spec", function() {

--- a/spec/core/JsApiReporterSpec.js
+++ b/spec/core/JsApiReporterSpec.js
@@ -101,7 +101,7 @@ describe("JsApiReporter", function() {
     expect(reporter.finished).toBe(false);
 
     reporter.jasmineStarted();
-    reporter.jasmineDone();
+    reporter.jasmineDone({});
 
     expect(reporter.finished).toBe(true);
   });
@@ -123,7 +123,7 @@ describe("JsApiReporter", function() {
   it("reports 'done' when Jasmine is done", function() {
     var reporter = new j$.JsApiReporter();
 
-    reporter.jasmineDone();
+    reporter.jasmineDone({});
 
     expect(reporter.status()).toEqual('done');
   });
@@ -175,6 +175,24 @@ describe("JsApiReporter", function() {
       it("should return a slice of shorter length", function() {
         expect(reporter.specResults(0, 3)).toEqual([specResult1, specResult2]);
         expect(reporter.specResults(2, 3)).toEqual([]);
+      });
+    });
+  });
+
+  describe("#executionTime", function() {
+    var reporter;
+    beforeEach(function() {
+      reporter = new j$.JsApiReporter();
+    });
+
+    it("should return the time it took the specs to run, in ms", function() {
+      reporter.jasmineDone({executionTime: 1000});
+      expect(reporter.executionTime()).toEqual(1000);
+    });
+
+    describe("when the specs haven't finished being run", function() {
+      it("should return undefined", function() {
+        expect(reporter.executionTime()).toBeUndefined();
       });
     });
   });

--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -118,23 +118,19 @@ describe("New HtmlReporter", function() {
   describe("when Jasmine is done", function() {
     it("reports the run time", function() {
       var env = new jasmine.Env(),
-        fakeNow = jasmine.createSpy('fake Date.now'),
         container = document.createElement("div"),
         getContainer = function() { return container; },
         reporter = new jasmine.HtmlReporter({
           env: env,
           getContainer: getContainer,
-          now: fakeNow,
           createElement: function() { return document.createElement.apply(document, arguments); },
           createTextNode: function() { return document.createTextNode.apply(document, arguments); }
         });
 
       reporter.initialize();
 
-      fakeNow.andReturn(500);
       reporter.jasmineStarted({});
-      fakeNow.andReturn(600);
-      reporter.jasmineDone();
+      reporter.jasmineDone({executionTime: 100});
 
       var duration = container.querySelector(".banner .duration");
       expect(duration.innerHTML).toMatch(/finished in 0.1s/);
@@ -197,7 +193,7 @@ describe("New HtmlReporter", function() {
 
       reporter.suiteDone({id: 1});
 
-      reporter.jasmineDone();
+      reporter.jasmineDone({});
       var summary = container.querySelector(".summary");
 
       expect(summary.childNodes.length).toEqual(1);
@@ -247,7 +243,7 @@ describe("New HtmlReporter", function() {
           });
 
         reporter.initialize();
-        reporter.jasmineDone();
+        reporter.jasmineDone({});
 
         var raisingExceptionsUI = container.querySelector(".raise");
         expect(raisingExceptionsUI.checked).toBe(false);
@@ -272,7 +268,7 @@ describe("New HtmlReporter", function() {
 
         reporter.initialize();
         env.catchExceptions(false);
-        reporter.jasmineDone();
+        reporter.jasmineDone({});
 
         var raisingExceptionsUI = container.querySelector(".raise");
         expect(raisingExceptionsUI.checked).toBe(true);
@@ -298,7 +294,7 @@ describe("New HtmlReporter", function() {
           });
 
         reporter.initialize();
-        reporter.jasmineDone();
+        reporter.jasmineDone({});
 
         var input = container.querySelector(".raise");
         input.click();
@@ -333,7 +329,7 @@ describe("New HtmlReporter", function() {
           fullName: "A Suite inner suite with another spec",
           status: "passed"
         });
-        reporter.jasmineDone();
+        reporter.jasmineDone({});
       });
 
       it("reports the specs counts", function() {
@@ -378,7 +374,7 @@ describe("New HtmlReporter", function() {
           fullName: "A Suite with a spec",
           status: "pending"
         });
-        reporter.jasmineDone();
+        reporter.jasmineDone({});
       });
 
       it("reports the pending specs count", function() {
@@ -429,7 +425,7 @@ describe("New HtmlReporter", function() {
         };
         reporter.specStarted(failingResult);
         reporter.specDone(failingResult);
-        reporter.jasmineDone();
+        reporter.jasmineDone({});
       });
 
       it("reports the specs counts", function() {

--- a/src/console/ConsoleReporter.js
+++ b/src/console/ConsoleReporter.js
@@ -3,8 +3,6 @@ getJasmineRequireObj().ConsoleReporter = function() {
     var print = options.print,
       showColors = options.showColors || false,
       onComplete = options.onComplete || function() {},
-      now = options.now || function() { return new Date().getTime();},
-      startTime = 0,
       specCount,
       failureCount,
       failedSpecs = [],
@@ -17,7 +15,6 @@ getJasmineRequireObj().ConsoleReporter = function() {
       };
 
     this.jasmineStarted = function() {
-      startTime = now();
       specCount = 0;
       failureCount = 0;
       pendingCount = 0;
@@ -25,9 +22,7 @@ getJasmineRequireObj().ConsoleReporter = function() {
       printNewline();
     };
 
-    this.jasmineDone = function() {
-      var elapsed = now() - startTime;
-
+    this.jasmineDone = function(options) {
       printNewline();
       for (var i = 0; i < failedSpecs.length; i++) {
         specFailureDetails(failedSpecs[i]);
@@ -44,7 +39,7 @@ getJasmineRequireObj().ConsoleReporter = function() {
       print(specCounts);
 
       printNewline();
-      var seconds = elapsed / 1000;
+      var seconds = options.executionTime / 1000;
       print("Finished in " + seconds + " " + plural("second", seconds));
 
       printNewline();

--- a/src/console/console.js
+++ b/src/console/console.js
@@ -38,8 +38,6 @@ getJasmineRequireObj().ConsoleReporter = function() {
     var print = options.print,
       showColors = options.showColors || false,
       onComplete = options.onComplete || function() {},
-      now = options.now || function() { return new Date().getTime();},
-      startTime = 0,
       specCount,
       failureCount,
       failedSpecs = [],
@@ -52,7 +50,6 @@ getJasmineRequireObj().ConsoleReporter = function() {
       };
 
     this.jasmineStarted = function() {
-      startTime = now();
       specCount = 0;
       failureCount = 0;
       pendingCount = 0;
@@ -60,9 +57,7 @@ getJasmineRequireObj().ConsoleReporter = function() {
       printNewline();
     };
 
-    this.jasmineDone = function() {
-      var elapsed = now() - startTime;
-
+    this.jasmineDone = function(options) {
       printNewline();
       for (var i = 0; i < failedSpecs.length; i++) {
         specFailureDetails(failedSpecs[i]);
@@ -79,7 +74,7 @@ getJasmineRequireObj().ConsoleReporter = function() {
       print(specCounts);
 
       printNewline();
-      var seconds = elapsed / 1000;
+      var seconds = options.executionTime / 1000;
       print("Finished in " + seconds + " " + plural("second", seconds));
 
       printNewline();

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -2,7 +2,8 @@ getJasmineRequireObj().Env = function(j$) {
   function Env(options) {
     options = options || {};
     var self = this;
-    var global = options.global || j$.getGlobal();
+    var global = options.global || j$.getGlobal(),
+      now = options.now || function() { return new Date().getTime(); };
 
     var catchExceptions = true;
 
@@ -192,10 +193,13 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.execute = function() {
+      var startTime = now();
       this.reporter.jasmineStarted({
         totalSpecsDefined: totalSpecsDefined
       });
-      this.topSuite.execute(this.reporter.jasmineDone);
+      this.topSuite.execute(function() {
+        self.reporter.jasmineDone({executionTime: now() - startTime});
+      });
     };
   }
 

--- a/src/core/JsApiReporter.js
+++ b/src/core/JsApiReporter.js
@@ -11,8 +11,11 @@ getJasmineRequireObj().JsApiReporter = function() {
       status = 'started';
     };
 
-    this.jasmineDone = function() {
+    var executionTime;
+
+    this.jasmineDone = function(options) {
       this.finished = true;
+      executionTime = options.executionTime;
       status = 'done';
     };
 
@@ -51,6 +54,10 @@ getJasmineRequireObj().JsApiReporter = function() {
 
     this.specs = function() {
       return specs;
+    };
+
+    this.executionTime = function() {
+      return executionTime;
     };
 
   }

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -2,11 +2,10 @@ jasmineRequire.HtmlReporter = function() {
   function HtmlReporter(options) {
     var env = options.env || {},
       getContainer = options.getContainer,
-      now = options.now || function() { return new Date().getTime();},
       createElement = options.createElement,
       createTextNode = options.createTextNode,
+      onRaiseExceptionsClick = options.onRaiseExceptionsClick,
       results = [],
-      startTime,
       specsExecuted = 0,
       failureCount = 0,
       pendingSpecCount = 0,
@@ -33,7 +32,6 @@ jasmineRequire.HtmlReporter = function() {
     var totalSpecsDefined;
     this.jasmineStarted = function(options) {
       totalSpecsDefined = options.totalSpecsDefined || 0;
-      startTime = now();
     };
 
     var summary = createDom("div", {className: "summary"});
@@ -94,11 +92,9 @@ jasmineRequire.HtmlReporter = function() {
       }
     };
 
-    this.jasmineDone = function() {
-      var elapsed = now() - startTime;
-
+    this.jasmineDone = function(options) {
       var banner = find(".banner");
-      banner.appendChild(createDom("span", {className: "duration"}, "finished in " + elapsed / 1000 + "s"));
+      banner.appendChild(createDom("span", {className: "duration"}, "finished in " + options.executionTime / 1000 + "s"));
 
       var alert = find(".alert");
 
@@ -113,7 +109,7 @@ jasmineRequire.HtmlReporter = function() {
       var checkbox = find("input");
 
       checkbox.checked = !env.catchingExceptions();
-      checkbox.onclick = options.onRaiseExceptionsClick;
+      checkbox.onclick = onRaiseExceptionsClick;
 
       if (specsExecuted < totalSpecsDefined) {
         var skippedMessage = "Ran " + specsExecuted + " of " + totalSpecsDefined + " specs - run all";


### PR DESCRIPTION
Since this information is desired in ConsoleReporter, HtmlReporter,
and now JsApiReporter, the executionTime is passed through in
jasmineDone from Env instead of making each reporter compute it.

Fixes #30, [Finishes #45659879]
