### PR TITLE
Have Jasmine HTML use the source files in specs

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -51,7 +51,7 @@ jasmineRequire.HtmlReporter = function() {
       htmlReporterMain = createDom("div", {className: "html-reporter"},
         createDom("div", {className: "banner"},
           createDom("span", {className: "title"}, "Jasmine"),
-          createDom("span", {className: "version"}, jasmine.version)
+          createDom("span", {className: "version"}, j$.version)
         ),
         createDom("ul", {className: "symbol-summary"}),
         createDom("div", {className: "alert"}),
@@ -72,7 +72,7 @@ jasmineRequire.HtmlReporter = function() {
 
     var summary = createDom("div", {className: "summary"});
 
-    var topResults = new jasmine.ResultsNode({}, "", null),
+    var topResults = new j$.ResultsNode({}, "", null),
       currentParent = topResults;
 
     this.suiteStarted = function(result) {

--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -1,10 +1,10 @@
 describe("New HtmlReporter", function() {
   // TODO: Figure out why this isn't rendering...
   it("builds the initial DOM elements, including the title banner", function() {
-    var env = new jasmine.Env(),
+    var env = new j$.Env(),
       container = document.createElement("div"),
       getContainer = function() { return container; },
-      reporter = new jasmine.HtmlReporter({
+      reporter = new j$.HtmlReporter({
         env: env,
         getContainer: getContainer,
         createElement: function() { return document.createElement.apply(document, arguments); },
@@ -26,8 +26,9 @@ describe("New HtmlReporter", function() {
     var title = banner.querySelector(".title");
     expect(title.innerHTML).toMatch(/Jasmine/);
 
-    var version = banner.querySelector(".version");
-    expect(version.innerHTML).toEqual(jasmine.version);
+    var version = banner.querySelector(".version"),
+      versionText = 'textContent' in version ? version.textContent : version.innerText;
+    expect(versionText).toEqual(j$.version);
   });
 
   it("starts the timer when jasmine begins", function() {
@@ -46,10 +47,10 @@ describe("New HtmlReporter", function() {
 
   describe("when a spec is done", function() {
     it("reports the status symbol of a disabled spec", function() {
-      var env = new jasmine.Env(),
+      var env = new j$.Env(),
         container = document.createElement("div"),
         getContainer = function() { return container; },
-        reporter = new jasmine.HtmlReporter({
+        reporter = new j$.HtmlReporter({
           env: env,
           getContainer: getContainer,
           createElement: function() { return document.createElement.apply(document, arguments); },
@@ -66,10 +67,10 @@ describe("New HtmlReporter", function() {
     });
 
     it("reports the status symbol of a pending spec", function() {
-      var env = new jasmine.Env(),
+      var env = new j$.Env(),
         container = document.createElement("div"),
         getContainer = function() { return container; },
-        reporter = new jasmine.HtmlReporter({
+        reporter = new j$.HtmlReporter({
           env: env,
           getContainer: getContainer,
           createElement: function() { return document.createElement.apply(document, arguments); },
@@ -85,10 +86,10 @@ describe("New HtmlReporter", function() {
     });
 
     it("reports the status symbol of a passing spec", function() {
-      var env = new jasmine.Env(),
+      var env = new j$.Env(),
         container = document.createElement("div"),
         getContainer = function() { return container; },
-        reporter = new jasmine.HtmlReporter({
+        reporter = new j$.HtmlReporter({
           env: env,
           getContainer: getContainer,
           createElement: function() { return document.createElement.apply(document, arguments); },
@@ -105,10 +106,10 @@ describe("New HtmlReporter", function() {
     });
 
     it("reports the status symbol of a failing spec", function() {
-      var env = new jasmine.Env(),
+      var env = new j$.Env(),
         container = document.createElement("div"),
         getContainer = function() { return container; },
-        reporter = new jasmine.HtmlReporter({
+        reporter = new j$.HtmlReporter({
           env: env,
           getContainer: getContainer,
           createElement: function() { return document.createElement.apply(document, arguments); },
@@ -131,11 +132,11 @@ describe("New HtmlReporter", function() {
 
   describe("when Jasmine is done", function() {
     it("reports the run time", function() {
-      var env = new jasmine.Env(),
+      var env = new j$.Env(),
         container = document.createElement("div"),
         timer = jasmine.createSpyObj('timer', ['start', 'elapsed']),
         getContainer = function() { return container; },
-        reporter = new jasmine.HtmlReporter({
+        reporter = new j$.HtmlReporter({
           env: env,
           getContainer: getContainer,
           createElement: function() { return document.createElement.apply(document, arguments); },
@@ -155,10 +156,10 @@ describe("New HtmlReporter", function() {
     });
 
     it("reports the suite and spec names with status", function() {
-      var env = new jasmine.Env(),
+      var env = new j$.Env(),
         container = document.createElement("div"),
         getContainer = function() { return container; },
-        reporter = new jasmine.HtmlReporter({
+        reporter = new j$.HtmlReporter({
           env: env,
           getContainer: getContainer,
           createElement: function() { return document.createElement.apply(document, arguments); },
@@ -244,12 +245,12 @@ describe("New HtmlReporter", function() {
 
     describe("UI for raising/catching exceptions", function() {
       it("should be unchecked if the env is catching", function() {
-        var env = new jasmine.Env(),
+        var env = new j$.Env(),
           container = document.createElement("div"),
           getContainer = function() {
             return container;
           },
-          reporter = new jasmine.HtmlReporter({
+          reporter = new j$.HtmlReporter({
             env: env,
             getContainer: getContainer,
             createElement: function() {
@@ -268,12 +269,12 @@ describe("New HtmlReporter", function() {
       });
 
       it("should be checked if the env is not catching", function() {
-        var env = new jasmine.Env(),
+        var env = new j$.Env(),
           container = document.createElement("div"),
           getContainer = function() {
             return container;
           },
-          reporter = new jasmine.HtmlReporter({
+          reporter = new j$.HtmlReporter({
             env: env,
             getContainer: getContainer,
             createElement: function() {
@@ -293,13 +294,13 @@ describe("New HtmlReporter", function() {
       });
 
       it("should affect the query param for catching exceptions", function() {
-        var env = new jasmine.Env(),
+        var env = new j$.Env(),
           container = document.createElement("div"),
           exceptionsClickHandler = jasmine.createSpy("raise exceptions checked"),
           getContainer = function() {
             return container;
           },
-          reporter = new jasmine.HtmlReporter({
+          reporter = new j$.HtmlReporter({
             env: env,
             getContainer: getContainer,
             onRaiseExceptionsClick: exceptionsClickHandler,
@@ -323,10 +324,10 @@ describe("New HtmlReporter", function() {
     describe("and all specs pass", function() {
       var env, container, reporter;
       beforeEach(function() {
-        env = new jasmine.Env();
+        env = new j$.Env();
         container = document.createElement("div");
         getContainer = function() { return container; },
-          reporter = new jasmine.HtmlReporter({
+          reporter = new j$.HtmlReporter({
             env: env,
             getContainer: getContainer,
             createElement: function() { return document.createElement.apply(document, arguments); },
@@ -374,10 +375,10 @@ describe("New HtmlReporter", function() {
     describe("and there are pending specs", function() {
       var env, container, reporter;
       beforeEach(function() {
-        env = new jasmine.Env();
+        env = new j$.Env();
         container = document.createElement("div");
         getContainer = function() { return container; },
-          reporter = new jasmine.HtmlReporter({
+          reporter = new j$.HtmlReporter({
             env: env,
             getContainer: getContainer,
             createElement: function() { return document.createElement.apply(document, arguments); },
@@ -412,10 +413,10 @@ describe("New HtmlReporter", function() {
       var env, container, reporter;
 
       beforeEach(function() {
-        env = new jasmine.Env();
+        env = new j$.Env();
         container = document.createElement("div"),
         getContainer = function() { return container; },
-          reporter = new jasmine.HtmlReporter({
+          reporter = new j$.HtmlReporter({
             env: env,
             getContainer: getContainer,
             createElement: function() { return document.createElement.apply(document, arguments); },

--- a/spec/html/HtmlSpecFilterSpec.js
+++ b/spec/html/HtmlSpecFilterSpec.js
@@ -1,14 +1,14 @@
-describe("jasmine.HtmlSpecFilter", function() {
+describe("j$.HtmlSpecFilter", function() {
 
   it("should match when no string is provided", function() {
-    var specFilter = new jasmine.HtmlSpecFilter();
+    var specFilter = new j$.HtmlSpecFilter();
 
     expect(specFilter.matches("foo")).toBe(true);
     expect(specFilter.matches("*bar")).toBe(true);
   });
 
   it("should only match the provided string", function() {
-    var specFilter = new jasmine.HtmlSpecFilter({
+    var specFilter = new j$.HtmlSpecFilter({
       filterString: function() { return "foo"; }
     });
 

--- a/spec/html/PrettyPrintHtmlSpec.js
+++ b/spec/html/PrettyPrintHtmlSpec.js
@@ -1,8 +1,8 @@
-describe("jasmine.pp (HTML Dependent)", function () {
+describe("j$.pp (HTML Dependent)", function () {
   it("should stringify HTML nodes properly", function() {
     var sampleNode = document.createElement('div');
     sampleNode.innerHTML = 'foo<b>bar</b>';
-    expect(jasmine.pp(sampleNode)).toEqual("HTMLNode");
-    expect(jasmine.pp({foo: sampleNode})).toEqual("{ foo : HTMLNode }");
+    expect(j$.pp(sampleNode)).toEqual("HTMLNode");
+    expect(j$.pp({foo: sampleNode})).toEqual("{ foo : HTMLNode }");
   });
 });

--- a/spec/html/QueryStringSpec.js
+++ b/spec/html/QueryStringSpec.js
@@ -6,7 +6,7 @@ describe("QueryString", function() {
       var windowLocation = {
           search: ""
         },
-        queryString = new jasmine.QueryString({
+        queryString = new j$.QueryString({
           getWindowLocation: function() { return windowLocation }
         });
 
@@ -22,7 +22,7 @@ describe("QueryString", function() {
       var windowLocation = {
           search: "?baz=quux%20corge"
         },
-        queryString = new jasmine.QueryString({
+        queryString = new j$.QueryString({
           getWindowLocation: function() { return windowLocation }
         });
 
@@ -33,7 +33,7 @@ describe("QueryString", function() {
       var windowLocation = {
           search: ""
         },
-        queryString = new jasmine.QueryString({
+        queryString = new j$.QueryString({
           getWindowLocation: function() { return windowLocation }
         });
 

--- a/spec/html/ResultsNodeSpec.js
+++ b/spec/html/ResultsNodeSpec.js
@@ -4,7 +4,7 @@ describe("ResultsNode", function() {
         id: 123,
         message: "foo"
       },
-      node = new jasmine.ResultsNode(fakeResult, "suite", null);
+      node = new j$.ResultsNode(fakeResult, "suite", null);
 
     expect(node.result).toBe(fakeResult);
     expect(node.type).toEqual("suite");
@@ -19,7 +19,7 @@ describe("ResultsNode", function() {
         id: 456,
         message: "bar"
       },
-      node = new jasmine.ResultsNode(fakeResult, "suite", null);
+      node = new j$.ResultsNode(fakeResult, "suite", null);
 
     node.addChild(fakeChildResult, "spec");
 
@@ -37,7 +37,7 @@ describe("ResultsNode", function() {
         id: 456,
         message: "bar"
       },
-      node = new jasmine.ResultsNode(fakeResult, "suite", null);
+      node = new j$.ResultsNode(fakeResult, "suite", null);
 
     node.addChild(fakeChildResult, "spec");
 
@@ -53,7 +53,7 @@ describe("ResultsNode", function() {
         id: 456,
         message: "bar"
       },
-      node = new jasmine.ResultsNode(fakeResult, "suite", null);
+      node = new j$.ResultsNode(fakeResult, "suite", null);
 
     node.addChild(fakeChildResult, "spec");
 

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -1,4 +1,4 @@
-jasmineRequire.HtmlReporter = function() {
+jasmineRequire.HtmlReporter = function(j$) {
 
   var noopTimer = {
     start: function(){},
@@ -23,7 +23,7 @@ jasmineRequire.HtmlReporter = function() {
       htmlReporterMain = createDom("div", {className: "html-reporter"},
         createDom("div", {className: "banner"},
           createDom("span", {className: "title"}, "Jasmine"),
-          createDom("span", {className: "version"}, jasmine.version)
+          createDom("span", {className: "version"}, j$.version)
         ),
         createDom("ul", {className: "symbol-summary"}),
         createDom("div", {className: "alert"}),
@@ -44,7 +44,7 @@ jasmineRequire.HtmlReporter = function() {
 
     var summary = createDom("div", {className: "summary"});
 
-    var topResults = new jasmine.ResultsNode({}, "", null),
+    var topResults = new j$.ResultsNode({}, "", null),
       currentParent = topResults;
 
     this.suiteStarted = function(result) {

--- a/src/html/requireHtml.js
+++ b/src/html/requireHtml.js
@@ -1,6 +1,6 @@
 jasmineRequire.html = function(j$) {
   j$.ResultsNode = jasmineRequire.ResultsNode();
-  j$.HtmlReporter = jasmineRequire.HtmlReporter();
+  j$.HtmlReporter = jasmineRequire.HtmlReporter(j$);
   j$.QueryString = jasmineRequire.QueryString();
   j$.HtmlSpecFilter = jasmineRequire.HtmlSpecFilter();
 };


### PR DESCRIPTION
Similar to the changes in Jasmine core and console, this gets the
HTML specs of Jasmine using j$ instead of jasmine so that they use
the source files instead of the built distribution

Any thoughts on using `j$.version` instead of `jasmine.version`? I went with j$ as it's consistent and seemed more correct, but because it hasn't gone through concatenation, `j$.version` in the spec files is the literal string `"<%= version %>"` (which is why the spec had to use innerText/textContent instead of innerHTML). 
