### PR TITLE
Async queue runner fixes

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1323,13 +1323,10 @@ getJasmineRequireObj().QueueRunner = function() {
       }
     }
 
-    var runnerDone = iterativeIndex >= length,
-        hasBeenAsyncSpec = recursiveIndex > 0;
+    var runnerDone = iterativeIndex >= length;
 
-    if (runnerDone && hasBeenAsyncSpec) {
+    if (runnerDone) {
       this.clearStack(this.onComplete);
-    } else if(runnerDone) {
-      this.onComplete();
     }
 
     function attempt(fn) {
@@ -1550,7 +1547,7 @@ getJasmineRequireObj().Suite = function() {
       children = this.children_;
 
     for (var i = 0; i < children.length; i++) {
-      allFns.push(wrapChild(children[i]));
+      allFns.push(wrapChildAsAsync(children[i]));
     }
 
     this.onStart(this);
@@ -1568,8 +1565,8 @@ getJasmineRequireObj().Suite = function() {
       }
     }
 
-    function wrapChild(child) {
-      return function() { child.execute(); };
+    function wrapChildAsAsync(child) {
+      return function(done) { child.execute(done); };
     }
   };
   

--- a/spec/core/EnvSpec.js
+++ b/spec/core/EnvSpec.js
@@ -189,6 +189,30 @@ describe("Env integration", function() {
     env.execute();
   });
 
+  it("should run async specs in order, waiting for them to complete", function(done) {
+    var env = new j$.Env(), mutatedVar;
+
+    env.describe("tests", function() {
+      env.beforeEach(function() {
+        mutatedVar = 2;
+      });
+
+      env.it("async spec", function(underTestCallback) {
+        setTimeout(function() {
+          expect(mutatedVar).toEqual(2);
+          underTestCallback();
+          done();
+        }, 0);
+      });
+
+      env.it("after async spec", function() {
+        mutatedVar = 3;
+      });
+    });
+
+    env.execute();
+  });
+
   // TODO: something is wrong with this spec
   it("should report as expected", function(done) {
     var env = new j$.Env(),

--- a/spec/core/QueueRunnerSpec.js
+++ b/spec/core/QueueRunnerSpec.js
@@ -127,7 +127,7 @@ describe("QueueRunner", function() {
     expect(completeCallback).toHaveBeenCalled();
   });
 
-  it("with an async spec, calls a provided stack clearing function when done", function() {
+  it("calls a provided stack clearing function when done", function() {
     var asyncFn = function(done) { done() },
         afterFn = jasmine.createSpy('afterFn'),
         completeCallback = jasmine.createSpy('completeCallback'),

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -32,13 +32,10 @@ getJasmineRequireObj().QueueRunner = function() {
       }
     }
 
-    var runnerDone = iterativeIndex >= length,
-        hasBeenAsyncSpec = recursiveIndex > 0;
+    var runnerDone = iterativeIndex >= length;
 
-    if (runnerDone && hasBeenAsyncSpec) {
+    if (runnerDone) {
       this.clearStack(this.onComplete);
-    } else if(runnerDone) {
-      this.onComplete();
     }
 
     function attempt(fn) {

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -74,7 +74,7 @@ getJasmineRequireObj().Suite = function() {
       children = this.children_;
 
     for (var i = 0; i < children.length; i++) {
-      allFns.push(wrapChild(children[i]));
+      allFns.push(wrapChildAsAsync(children[i]));
     }
 
     this.onStart(this);
@@ -92,8 +92,8 @@ getJasmineRequireObj().Suite = function() {
       }
     }
 
-    function wrapChild(child) {
-      return function() { child.execute(); };
+    function wrapChildAsAsync(child) {
+      return function(done) { child.execute(done); };
     }
   };
   


### PR DESCRIPTION
If an async spec throws an exception during the synchronous part of the execution (where the try/catch still takes effect), the QueueRunner now finishes off the rest of the functions that it was supposed to run (iteratively since recursive isn't necessary). 

Also gets QueueRunner back to where it properly waits for an async spec, instead of just finishing the suite.
