### PR TITLE
don't specify pre/tt/code font-size for gh-pages

### DIFF
--- a/css/docco.css
+++ b/css/docco.css
@@ -114,7 +114,7 @@ table td {
     border-left: 1px solid #e5e5ee;
   }
     pre, tt, code {
-      font-size: 12px; line-height: 18px;
+      line-height: 18px;
       font-family: Monaco, Consolas, "Lucida Console", monospace;
       margin: 0; padding: 0;
     }


### PR DESCRIPTION
Makes [the introduction page](http://pivotal.github.io/jasmine/) a little more readable.

before:

![gh-pages-before](https://f.cloud.github.com/assets/174307/857700/6814755a-f557-11e2-802f-eba0ee6aba57.png)

after:

![gh-pages-after](https://f.cloud.github.com/assets/174307/857702/6d136a8e-f557-11e2-8ce3-e995a40f431a.png)

(Chrome on OS X)
