### PR TITLE
Bugfix. The updateInterval env variable wasn't having any effect

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -2080,11 +2080,17 @@ jasmine.Queue.prototype.next_ = function() {
         self.index++;
 
         var now = new Date().getTime();
-        if (self.env.updateInterval && now - self.env.lastUpdate > self.env.updateInterval) {
-          self.env.lastUpdate = now;
+        if (self.env.updateInterval) {
+            var timeout;
+            if (now - self.env.lastUpdate > self.env.updateInterval) {
+                timeout = 0;
+            } else {
+                timeout = self.env.updateInterval;
+            }
           self.env.setTimeout(function() {
+            self.env.lastUpdate = now;
             self.next_();
-          }, 0);
+          }, timeout);
         } else {
           if (jasmine.Queue.LOOP_DONT_RECURSE && completedSynchronously) {
             goAgain = true;


### PR DESCRIPTION
Always set a timeout when _updateInterval_ was specified. Either 0 if enough time has passed, or the _updateInterval_.
