### PR TITLE
Updated contribute.markdown links

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ Documentation & guides live here: [http://pivotal.github.com/jasmine/](http://pi
 
 ## Contributing
 
-Please read the [contributors' guide](https://github.com/pivotal/jasmine/blob/master/Contribute.markdown)
+Please read the [contributors' guide](https://github.com/pivotal/jasmine/blob/master/CONTRIBUTING.md)
 
 ## Support
 

--- a/Release.markdown
+++ b/Release.markdown
@@ -3,7 +3,7 @@
 ## Development
 ___Jasmine Core Maintainers Only___
 
-Follow the instructions in `Contribute.markdown` during development.
+Follow the instructions in `CONTRIBUTING.md` during development.
 
 ### Git Rules
 


### PR DESCRIPTION
The contributors' guide link was broken.
