### PR TITLE
Change andThrow to always throw an Error

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1565,8 +1565,9 @@ getJasmineRequireObj().SpyStrategy = function() {
     };
 
     this.callThrow = function(something) {
+      var error = (something instanceof Error) ? something : new Error(something);
       plan = function() {
-        throw something;
+        throw error;
       };
       return getSpy();
     };

--- a/spec/core/SpyStrategySpec.js
+++ b/spec/core/SpyStrategySpec.js
@@ -50,9 +50,19 @@ describe("SpyStrategy", function() {
     var originalFn = jasmine.createSpy("original"),
         spyStrategy = new j$.SpyStrategy({fn: originalFn});
 
+    spyStrategy.callThrow(new TypeError("bar"));
+
+    expect(function() { spyStrategy.exec(); }).toThrowError(TypeError, "bar");
+    expect(originalFn).not.toHaveBeenCalled();
+  });
+
+  it("allows a non-Error to be thrown, wrapping it into an exception when executed", function() {
+    var originalFn = jasmine.createSpy("original"),
+        spyStrategy = new j$.SpyStrategy({fn: originalFn});
+
     spyStrategy.callThrow("bar");
 
-    expect(function() { spyStrategy.exec(); }).toThrow("bar");
+    expect(function() { spyStrategy.exec(); }).toThrowError(Error, "bar");
     expect(originalFn).not.toHaveBeenCalled();
   });
 

--- a/src/core/SpyStrategy.js
+++ b/src/core/SpyStrategy.js
@@ -29,8 +29,9 @@ getJasmineRequireObj().SpyStrategy = function() {
     };
 
     this.callThrow = function(something) {
+      var error = (something instanceof Error) ? something : new Error(something);
       plan = function() {
-        throw something;
+        throw error;
       };
       return getSpy();
     };


### PR DESCRIPTION
If an error is passed in, it is thrown, otherwise the argument passed
in is wrapped in an Error.

Needs Discussion:
Since anything other than an error becomes wrapped in an Error, this commit makes it no longer to do code such as:

``` javascript
var spy = jasmine.createSpy().andThrow(/regex/);
expect(spy).toThrow(/regex/); // fails since what is now thrown is an Error with message of the string "/abc/"
```

Was this part of the intention of the story to always throw an error?

[finishes #50607615][closes #372]
