### PR TITLE
Change HTMLReporter symbols to be inline-block instead of floated

### DIFF
--- a/lib/jasmine-core/jasmine.css
+++ b/lib/jasmine-core/jasmine.css
@@ -11,7 +11,7 @@ body { background-color: #eeeeee; padding: 0; margin: 5px; overflow-y: scroll; }
 .html-reporter .banner { margin-top: 14px; }
 .html-reporter .duration { color: #aaaaaa; float: right; }
 .html-reporter .symbol-summary { overflow: hidden; *zoom: 1; margin: 14px 0; }
-.html-reporter .symbol-summary li { display: block; float: left; height: 7px; width: 14px; margin-bottom: 7px; font-size: 16px; }
+.html-reporter .symbol-summary li { display: inline-block; height: 7px; width: 14px; font-size: 16px; }
 .html-reporter .symbol-summary li.passed { font-size: 14px; }
 .html-reporter .symbol-summary li.passed:before { color: #5e7d00; content: "\02022"; }
 .html-reporter .symbol-summary li.failed { line-height: 9px; }

--- a/src/html/_HTMLReporter.scss
+++ b/src/html/_HTMLReporter.scss
@@ -93,11 +93,9 @@ body {
     margin: $line-height 0;
 
     li {
-      display: block;
-      float: left;
+      display: inline-block;
       height: $line-height / 2;
       width: $line-height;
-      margin-bottom: $line-height / 2;
 
       font-size: 16px;
 


### PR DESCRIPTION
On a very large test suite (8000 specs), a significant amount of time is spent just drawing the spec dots. Some sort of worse-than-linear artifact that summons itself only when you have 8000 floated elements trying to hang out together.

This performance penalty is not seen with inline-block.

In Chrome 29:
  Floated dots: 16.795s
  Inline-block dots: 2.774s

Setting the dots to 'display: none;' takes about the same time as the inline-block figure, so this is probably a low enough bound (no need for chunked rendering or who knows what).

This is the amazing test suite I used in my profiling:

```
describe("Object A", function () {
  for (var i = 0; i < 8000; i++) {
    it("has a test numbered " + i.toString() + ", which is cool", function () {
      expect(1).toEqual(1);
    });
  }
});
```
