### PR TITLE
Short-circuit 'eq' when custom matchers return true or false

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1781,10 +1781,8 @@ getJasmineRequireObj().matchersUtil = function(j$) {
     var result = true;
 
     for (var i = 0; i < customTesters.length; i++) {
-      result = customTesters[i](a, b);
-      if (result) {
-        return true;
-      }
+      var customTesterResult = customTesters[i](a, b);
+      if (!j$.util.isUndefined(customTesterResult)) return customTesterResult;
     }
 
     if (a instanceof j$.Any) {

--- a/spec/javascripts/core/matchers/matchersUtilSpec.js
+++ b/spec/javascripts/core/matchers/matchersUtilSpec.js
@@ -92,6 +92,18 @@ describe("matchersUtil", function() {
       expect(j$.matchersUtil.equals(actual, expected)).toBe(true);
     });
 
+    it("passes for two empty Objects", function () {
+      expect(j$.matchersUtil.equals({}, {})).toBe(true);
+    });
+
+    describe("when a custom equality matcher is installed that returns 'undefined'", function () {
+      var tester = function(a, b) { return jasmine.undefined; };
+
+      it("passes for two empty Objects", function () {
+        expect(j$.matchersUtil.equals({}, {}, [tester])).toBe(true);
+      });
+    });
+
     it("fails for Objects that are not equivalent (with cycles)", function() {
       var actual = { a: "foo" },
         expected = { a: "bar" };
@@ -156,7 +168,7 @@ describe("matchersUtil", function() {
     it("fails for equivalents when a custom equality matcher returns false", function() {
       var tester = function(a, b) { return false; };
 
-      expect(j$.matchersUtil.equals(1, 2, [tester])).toBe(false);
+      expect(j$.matchersUtil.equals(1, 1, [tester])).toBe(false);
     });
   });
 

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -52,10 +52,8 @@ getJasmineRequireObj().matchersUtil = function(j$) {
     var result = true;
 
     for (var i = 0; i < customTesters.length; i++) {
-      result = customTesters[i](a, b);
-      if (result) {
-        return true;
-      }
+      var customTesterResult = customTesters[i](a, b);
+      if (!j$.util.isUndefined(customTesterResult)) return customTesterResult;
     }
 
     if (a instanceof j$.Any) {


### PR DESCRIPTION
I stumbled across this problem when I noticed that `expect({}).toEqual({})` returned false, but only when custom matchers were defined. Consider the following friendly matcher:

```
var backboneModelEqualityTester = function(a, b) {
    if(a instanceof Backbone.Model && b instanceof Backbone.Model) {
        if (a.constructor !== b.constructor) return false;
        if (!_.isUndefined(a.id) && !_.isUndefined(b.id)) return (a.id === b.id);
        if (!_.isUndefined(a.cid) && !_.isUndefined(b.cid)) return (a.cid === b.cid);
    }
};
```

Our friend `backboneModelEqualityTester` wants to say "If these two objects are Backbone objects, they're equal if their 'id' or 'cid' properties are equal. Otherwise, who knows?".

In the current version of the code, the result of each custom matcher is written back into `eq`'s `result` var, possibly in error. This is what causes the `expect({}).toEqual({})` problem, because the success of that statement relies on the original value of `result` being preserved.

Additionally, instead of allowing matchers to say "yes/no/who knows?", only a result of `true` is really respected. There was a test asserting that a custom matcher returning `false` would trump the decision's of `eq`'s body, but it was typoed so as to be passing incorrectly.
