### PR TITLE
Make getGlobal() work in strict mode

### DIFF
--- a/src/core/base.js
+++ b/src/core/base.js
@@ -1,3 +1,4 @@
+getJasmineRequireObj().global = this;
 getJasmineRequireObj().base = function(j$) {
   j$.unimplementedMethod_ = function() {
     throw new Error("unimplemented method");
@@ -6,13 +7,11 @@ getJasmineRequireObj().base = function(j$) {
   j$.MAX_PRETTY_PRINT_DEPTH = 40;
   j$.DEFAULT_TIMEOUT_INTERVAL = 5000;
 
-  j$.getGlobal = function() {
-    function getGlobal() {
-      return this;
-    }
-
-    return getGlobal();
-  };
+  j$.getGlobal = (function(global) {
+    return function() {
+      return global;
+    };
+  })(this.global);  // Here, this === getJasmineRequireObj()
 
   j$.getEnv = function(options) {
     var env = j$.currentEnv_ = j$.currentEnv_ || new j$.Env(options);


### PR DESCRIPTION
An update of https://github.com/metaweta/jasmine/commit/fb3e1acb09b4dbb9ccdbc15ce64b4a0e471f4541

ES5 strict mode does not promote an undefined 'this' to the global object.  The only way to get the global object in strict mode is to say 'this' while in the global scope.
