### PR TITLE
Don't try to use SauceLabs on pull request builds

### DIFF
--- a/travis-core-script.sh
+++ b/travis-core-script.sh
@@ -1,12 +1,21 @@
 #!/bin/bash -e
 
-export DISPLAY=:99.0
-
-/etc/init.d/xvfb start
-
 if [ $USE_SAUCE == true ]
 then
+  if [ $TRAVIS_SECURE_ENV_VARS == true ]
+  then
     curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash
+  else
+    if [ $JASMINE_BROWSER == firefox ]
+    then
+      export USE_SAUCE=false
+      export DISPLAY=:99.0
+      /etc/init.d/xvfb start
+    else
+      echo "skipping tests since we can't use sauce"
+      exit 0
+    fi
+  fi
 fi
 
 bundle exec rake jasmine:ci


### PR DESCRIPTION
This isn't quite ideal, we're treating a bunch of browsers as "passed" but we're not actually running them. Still attempt to run in a local firefox to get at least one real browser.
