### PR TITLE
Don't try to use SauceLabs on pull request builds

### DIFF
--- a/travis-core-script.sh
+++ b/travis-core-script.sh
@@ -6,15 +6,8 @@ then
   then
     curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash
   else
-    if [ $JASMINE_BROWSER == firefox ]
-    then
-      export USE_SAUCE=false
-      export DISPLAY=:99.0
-      /etc/init.d/xvfb start
-    else
-      echo "skipping tests since we can't use sauce"
-      exit 0
-    fi
+    echo "skipping tests since we can't use sauce"
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
Needed to initiate this from a separate repo because the encrypted sauce credentials were still being included
when we initiated a pull request from the jasmine repository.
