### PR TITLE
Env no longer automatically uninstalls the clock after each spec

### DIFF
--- a/spec/core/EnvSpec.js
+++ b/spec/core/EnvSpec.js
@@ -356,6 +356,7 @@ describe("Env integration", function() {
         env.clock.install();
         env.clock.setTimeout(delayedFunctionForMockClock, 100);
         env.clock.tick(100);
+        env.clock.uninstall();
       });
       env.it("test without mock clock", function() {
         env.clock.setTimeout(delayedFunctionForGlobalClock, 100);

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -170,7 +170,6 @@ getJasmineRequireObj().Env = function(j$) {
         removeAllSpies();
         j$.Expectation.resetMatchers();
         customEqualityTesters.length = 0;
-        self.clock.uninstall();
         self.currentSpec = null;
         self.reporter.specDone(result);
       }


### PR DESCRIPTION
- Behaves more like how we want plugins to behave

[#58281436]
