### PR TITLE
make sure the stacktrace printed by Jasmine on failing to pass an `expect(f)` shows the faulty user code

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1206,15 +1206,19 @@ getJasmineRequireObj().Expectation = function() {
       }
 
       // TODO: how many of these params are needed?
+      var attrs = {
+        matcherName: name,
+        passed: result.pass,
+        message: message,
+        actual: this.actual,
+        expected: expected // TODO: this may need to be arrayified/sliced
+      };
+      if (result.error) {
+        attrs.error = result.error;
+      }
       this.addExpectationResult(
         result.pass,
-        {
-          matcherName: name,
-          passed: result.pass,
-          message: message,
-          actual: this.actual,
-          expected: expected // TODO: this may need to be arrayified/sliced
-        }
+        attrs
       );
     };
   };
@@ -2219,6 +2223,8 @@ getJasmineRequireObj().toThrow = function(j$) {
           return result;
         }
 
+        result.error = thrown;
+        
         if (arguments.length == 1) {
           result.pass = true;
           result.message = "Expected function not to throw, but it threw " + j$.pp(thrown) + ".";

--- a/src/core/Expectation.js
+++ b/src/core/Expectation.js
@@ -52,15 +52,19 @@ getJasmineRequireObj().Expectation = function() {
       }
 
       // TODO: how many of these params are needed?
+      var attrs = {
+        matcherName: name,
+        passed: result.pass,
+        message: message,
+        actual: this.actual,
+        expected: expected // TODO: this may need to be arrayified/sliced
+      };
+      if (result.error) {
+        attrs.error = result.error;
+      }
       this.addExpectationResult(
         result.pass,
-        {
-          matcherName: name,
-          passed: result.pass,
-          message: message,
-          actual: this.actual,
-          expected: expected // TODO: this may need to be arrayified/sliced
-        }
+        attrs
       );
     };
   };

--- a/src/core/matchers/toThrow.js
+++ b/src/core/matchers/toThrow.js
@@ -23,6 +23,8 @@ getJasmineRequireObj().toThrow = function(j$) {
           return result;
         }
 
+        result.error = thrown;
+        
         if (arguments.length == 1) {
           result.pass = true;
           result.message = "Expected function not to throw, but it threw " + j$.pp(thrown) + ".";


### PR DESCRIPTION
make sure the stacktrace printed by Jasmine on failing to pass an `expect(f).toThrow()` or `expect(f).not.toThrow()` is the exception stack that shows the first USER CODE exception whenever possible.

Previously, these tests would create a default stackdump (created by stack() inside the Jasmine stack itself) which is useless when you need to track down the origin of the unexpected(!) exception which can occur anywhere in the user test code.

Note: jasmine grunt test task again passes all tests with this edit.
