### PR TITLE
force query selector to seek within the html-reporter element

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -230,7 +230,7 @@ jasmineRequire.HtmlReporter = function(j$) {
     return this;
 
     function find(selector) {
-      return getContainer().querySelector(selector);
+      return getContainer().querySelector('.html-reporter ' + selector);
     }
 
     function createDom(type, attrs, childrenVarArgs) {


### PR DESCRIPTION
Using jasmine-html.js can create conflicts with your page DOM.

For example:

```
var alert = find(".alert");
```

will conflict with Bootstrap 3 alerts, inserting within the first `.alert` found the jasmine DOM: "2 specs, 0 failures" etc.

Forcing the querySelector to start seeking nodes within the `html-reporter` class will quickly fix the problem, though it is not ideal (ideally a `jasmine` prefix would be better to avoid conflicts => either `.jasmine-html-reporter` class or as an ID).
