### PR TITLE
Fix to check if doc.body exists before using it

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -77,7 +77,12 @@ jasmine.HtmlReporter = function(_doc) {
     }
 
     createReporterDom(runner.env.versionString());
-    doc.body.appendChild(dom.reporter);
+    if (typeof doc.body !== 'undefined') {
+      doc.body.appendChild(dom.reporter);
+    }
+    else {
+      doc.appendChild(dom.reporter);
+    }
     setExceptionHandling();
 
     reporterView = new jasmine.HtmlReporter.ReporterView(dom);


### PR DESCRIPTION
This is the fix for issue 487. This only appears to be a problem for the 1.3x branch.
