### PR TITLE
Fix for doc being assumed to be window.document

### DIFF
--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -17,7 +17,12 @@ jasmine.HtmlReporter = function(_doc) {
     }
 
     createReporterDom(runner.env.versionString());
-    doc.body.appendChild(dom.reporter);
+    if (typeof doc.body !== 'undefined') {
+      doc.body.appendChild(dom.reporter);
+    }
+    else {
+      doc.appendChild(dom.reporter);
+    }
     setExceptionHandling();
 
     reporterView = new jasmine.HtmlReporter.ReporterView(dom);
@@ -138,7 +143,12 @@ jasmine.HtmlReporter = function(_doc) {
   }
 };
 jasmine.HtmlReporter.parameters = function(doc) {
-  var paramStr = doc.location.search.substring(1);
+  if (typeof doc.location !== 'undefined') {
+    paramStr = doc.location.search.substring(1);
+  }
+  else {
+    paramStr = window.location.search.substring(1);
+  }
   var params = [];
 
   if (paramStr.length > 0) {


### PR DESCRIPTION
I found a problem with the jasmine.HtmlReporter class. When you pass a HTML document element it should be using that to append the results into. However it was assuming that document was always passed.

I have changed this to check that the document element has a body or not to determine which element location it should append the report to.

I have also made a check to see that doc.location is available before trying to use it.

This seems only to be a problem in the 1.3x branch.
