### PR TITLE
Support running jasmine within CSP (remove eval)

### DIFF
--- a/src/core/base.js
+++ b/src/core/base.js
@@ -1,98 +1,97 @@
-getJasmineRequireObj().base = function(j$) {
-  j$.unimplementedMethod_ = function() {
-    throw new Error("unimplemented method");
-  };
+getJasmineRequireObj().base = (function (jasmineGlobal) {
+  return function(j$) {
+    j$.unimplementedMethod_ = function() {
+      throw new Error("unimplemented method");
+    };
 
-  j$.MAX_PRETTY_PRINT_DEPTH = 40;
-  j$.DEFAULT_TIMEOUT_INTERVAL = 5000;
+    j$.MAX_PRETTY_PRINT_DEPTH = 40;
+    j$.DEFAULT_TIMEOUT_INTERVAL = 5000;
 
-  j$.getGlobal = (function() {
-    var jasmineGlobal = eval.call(null, "this");
-    return function() {
+    j$.getGlobal = function() {
       return jasmineGlobal;
     };
-  })();
 
-  j$.getEnv = function(options) {
-    var env = j$.currentEnv_ = j$.currentEnv_ || new j$.Env(options);
-    //jasmine. singletons in here (setTimeout blah blah).
-    return env;
-  };
+    j$.getEnv = function(options) {
+      var env = j$.currentEnv_ = j$.currentEnv_ || new j$.Env(options);
+      //jasmine. singletons in here (setTimeout blah blah).
+      return env;
+    };
 
-  j$.isArray_ = function(value) {
-    return j$.isA_("Array", value);
-  };
+    j$.isArray_ = function(value) {
+      return j$.isA_("Array", value);
+    };
 
-  j$.isString_ = function(value) {
-    return j$.isA_("String", value);
-  };
+    j$.isString_ = function(value) {
+      return j$.isA_("String", value);
+    };
 
-  j$.isNumber_ = function(value) {
-    return j$.isA_("Number", value);
-  };
+    j$.isNumber_ = function(value) {
+      return j$.isA_("Number", value);
+    };
 
-  j$.isA_ = function(typeName, value) {
-    return Object.prototype.toString.apply(value) === '[object ' + typeName + ']';
-  };
+    j$.isA_ = function(typeName, value) {
+      return Object.prototype.toString.apply(value) === '[object ' + typeName + ']';
+    };
 
-  j$.isDomNode = function(obj) {
-    return obj.nodeType > 0;
-  };
+    j$.isDomNode = function(obj) {
+      return obj.nodeType > 0;
+    };
 
-  j$.any = function(clazz) {
-    return new j$.Any(clazz);
-  };
+    j$.any = function(clazz) {
+      return new j$.Any(clazz);
+    };
 
-  j$.objectContaining = function(sample) {
-    return new j$.ObjectContaining(sample);
-  };
+    j$.objectContaining = function(sample) {
+      return new j$.ObjectContaining(sample);
+    };
 
-  j$.createSpy = function(name, originalFn) {
+    j$.createSpy = function(name, originalFn) {
 
-    var spyStrategy = new j$.SpyStrategy({
-        name: name,
-        fn: originalFn,
-        getSpy: function() { return spy; }
-      }),
-      callTracker = new j$.CallTracker(),
-      spy = function() {
-        callTracker.track({
-          object: this,
-          args: Array.prototype.slice.apply(arguments)
-        });
-        return spyStrategy.exec.apply(this, arguments);
-      };
+      var spyStrategy = new j$.SpyStrategy({
+          name: name,
+          fn: originalFn,
+          getSpy: function() { return spy; }
+        }),
+        callTracker = new j$.CallTracker(),
+        spy = function() {
+          callTracker.track({
+            object: this,
+            args: Array.prototype.slice.apply(arguments)
+          });
+          return spyStrategy.exec.apply(this, arguments);
+        };
 
-    for (var prop in originalFn) {
-      if (prop === 'and' || prop === 'calls') {
-        throw new Error("Jasmine spies would overwrite the 'and' and 'calls' properties on the object being spied upon");
+      for (var prop in originalFn) {
+        if (prop === 'and' || prop === 'calls') {
+          throw new Error("Jasmine spies would overwrite the 'and' and 'calls' properties on the object being spied upon");
+        }
+
+        spy[prop] = originalFn[prop];
       }
 
-      spy[prop] = originalFn[prop];
-    }
+      spy.and = spyStrategy;
+      spy.calls = callTracker;
 
-    spy.and = spyStrategy;
-    spy.calls = callTracker;
+      return spy;
+    };
 
-    return spy;
+    j$.isSpy = function(putativeSpy) {
+      if (!putativeSpy) {
+        return false;
+      }
+      return putativeSpy.and instanceof j$.SpyStrategy &&
+        putativeSpy.calls instanceof j$.CallTracker;
+    };
+
+    j$.createSpyObj = function(baseName, methodNames) {
+      if (!j$.isArray_(methodNames) || methodNames.length === 0) {
+        throw "createSpyObj requires a non-empty array of method names to create spies for";
+      }
+      var obj = {};
+      for (var i = 0; i < methodNames.length; i++) {
+        obj[methodNames[i]] = j$.createSpy(baseName + '.' + methodNames[i]);
+      }
+      return obj;
+    };
   };
-
-  j$.isSpy = function(putativeSpy) {
-    if (!putativeSpy) {
-      return false;
-    }
-    return putativeSpy.and instanceof j$.SpyStrategy &&
-      putativeSpy.calls instanceof j$.CallTracker;
-  };
-
-  j$.createSpyObj = function(baseName, methodNames) {
-    if (!j$.isArray_(methodNames) || methodNames.length === 0) {
-      throw "createSpyObj requires a non-empty array of method names to create spies for";
-    }
-    var obj = {};
-    for (var i = 0; i < methodNames.length; i++) {
-      obj[methodNames[i]] = j$.createSpy(baseName + '.' + methodNames[i]);
-    }
-    return obj;
-  };
-};
+})(this);


### PR DESCRIPTION
The jasmine.getGlobal method was recently changed (post 2.0-rc5) (https://github.com/pivotal/jasmine/pull/437) to support working within javascript 'strict' mode.  However, that fix broke running jasmine from within CSP (content security policy) mode, which is gaining popularity (such as within chrome / firefox packaged apps).

This pull request fixes the issue by binding the global 'this' early (using an anonymous function wrapper instead of a global variable, since that was a previously proposed solution that was disliked), allowing the removal of eval.

The diff delow looks busy, but its mostly an indentation change.  All that really changes is a trivial re-definition of getGlobal(), and the addition of a function wrapper around the assignment to base.
