### PR TITLE
Allow stub or spy Date object safely using a closure to get a clean copy

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1720,24 +1720,26 @@ if (typeof window == void 0 && typeof exports == "object") {
   exports.Suite = jasmineRequire.Suite;
 }
 
-getJasmineRequireObj().Timer = function() {
-  function Timer(options) {
-    options = options || {};
+getJasmineRequireObj().Timer = (function(Date) {
+  return function() {
+    function Timer(options) {
+      options = options || {};
 
-    var now = options.now || function() { return new Date().getTime(); },
+      var now = options.now || function() { return new Date().getTime(); },
         startTime;
 
-    this.start = function() {
-      startTime = now();
-    };
+      this.start = function() {
+        startTime = now();
+      };
 
-    this.elapsed = function() {
-      return now() - startTime;
-    };
-  }
+      this.elapsed = function() {
+        return now() - startTime;
+      };
+    }
 
-  return Timer;
-};
+    return Timer;
+  };
+}(Date));
 
 getJasmineRequireObj().matchersUtil = function(j$) {
   // TODO: what to do about jasmine.pp not being inject? move to JSON.stringify? gut PrettyPrinter?

--- a/src/core/Timer.js
+++ b/src/core/Timer.js
@@ -1,18 +1,20 @@
-getJasmineRequireObj().Timer = function() {
-  function Timer(options) {
-    options = options || {};
+getJasmineRequireObj().Timer = (function(Date) {
+  return function() {
+    function Timer(options) {
+      options = options || {};
 
-    var now = options.now || function() { return new Date().getTime(); },
+      var now = options.now || function() { return new Date().getTime(); },
         startTime;
 
-    this.start = function() {
-      startTime = now();
-    };
+      this.start = function() {
+        startTime = now();
+      };
 
-    this.elapsed = function() {
-      return now() - startTime;
-    };
-  }
+      this.elapsed = function() {
+        return now() - startTime;
+      };
+    }
 
-  return Timer;
-};
+    return Timer;
+  };
+}(Date));


### PR DESCRIPTION
Hi, I'm using Jasmine for my open source projects and in my job, and I had some problems when trying to stub or spy Date object using Jasmine spies or Sinon.js stubs.
The problem is that Jasmine uses the original Date object for timers and if you stub or spy the object then you can't use Jasmine because it fails when it tries to execute the 'getTime' method.
The solution I propose is to store a clean copy of the original Date object using a closure to store and use it even if the original object has been stubbed or spied in any other test.
I've not created a new test because the original behaviour should became the same.
