### PR TITLE
Delete background-color of th

### DIFF
--- a/css/jasmine_docco-1.3.1.css
+++ b/css/jasmine_docco-1.3.1.css
@@ -56,10 +56,6 @@ h1, h2, h3, h4, h5, h6 {
   box-flex: 1;
 }
 
-th {
-  background-color: #eee;
-}
-
 td.code, th.code {
   background-color: #073642;
 }


### PR DESCRIPTION
If you look closer, you would find that the title th element covers the separator line, the border of next code th element. I found it's caused by a useful-less background-color, so I delete it.
