### PR TITLE
Added Data Driven Tests

### DIFF
--- a/lib/jasmine-core/boot.js
+++ b/lib/jasmine-core/boot.js
@@ -71,6 +71,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
       return env.xit(desc, func);
     },
 
+    all: function(desc, values, func) {
+      return env.all(desc, values, func);
+    },
+
+    xall: function(desc, values, func) {
+      return env.xall(desc, values, func);
+    },
+
     beforeEach: function(beforeEachFunction) {
       return env.beforeEach(beforeEachFunction);
     },

--- a/lib/jasmine-core/boot/boot.js
+++ b/lib/jasmine-core/boot/boot.js
@@ -49,6 +49,14 @@
       return env.xit(desc, func);
     },
 
+    all: function(desc, values, func) {
+      return env.all(desc, values, func);
+    },
+
+    xall: function(desc, values, func) {
+      return env.xall(desc, values, func);
+    },
+
     beforeEach: function(beforeEachFunction) {
       return env.beforeEach(beforeEachFunction);
     },

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -201,6 +201,247 @@ describe("Env integration", function() {
     env.execute([secondSuite.id, firstSpec.id]);
   });
 
+  describe("data driven testing", function() {
+
+    it("Allows single arguments", function(done) {
+      var env = new j$.Env(),
+          calls = [],
+          suiteCallback = jasmine.createSpy('suite callback'),
+          specs, suite;
+
+      var assertions = function() {
+        expect(calls).toEqual([1, 2, 3]);
+        expect(suiteCallback).toHaveBeenCalled();
+        done();
+      };
+
+      env.addReporter({jasmineDone: assertions, suiteDone: suiteCallback});
+
+      suite = env.describe("data-driven testing", function() {
+        specs = env.all("data-driven tests work", [1,2,3], function(x) {
+          calls.push(x);
+        });
+      });
+
+      expect(specs.length).toBe(3);
+      expect(specs[0].description).toBe("data-driven tests work (Variant #0 <1>)");
+      expect(specs[1].description).toBe("data-driven tests work (Variant #1 <2>)");
+      expect(specs[2].description).toBe("data-driven tests work (Variant #2 <3>)");
+
+      env.execute([suite.id]);
+    });
+
+    it("Allows multiple arguments", function(done) {
+      var env = new j$.Env(),
+          a = [],
+          b = [],
+          suiteCallback = jasmine.createSpy('suite callback'),
+          specs, suite;
+
+      var assertions = function() {
+        expect(a).toEqual([1, 2, 3]);
+        expect(b).toEqual([-6, 3, 4]);
+        expect(suiteCallback).toHaveBeenCalled();
+        done();
+      };
+
+      env.addReporter({jasmineDone: assertions, suiteDone: suiteCallback});
+
+      suite = env.describe("data-driven testing", function() {
+        specs = env.all("data-driven tests can have multiple arguments", [
+          [1,-6],
+          [2, 3],
+          [3, 4]
+        ], function(x, y) {
+          a.push(x);
+          b.push(y);
+        });
+      });
+
+      expect(specs.length).toBe(3);
+      expect(specs[0].description).toBe("data-driven tests can have multiple arguments (Variant #0 <1, -6>)");
+      expect(specs[1].description).toBe("data-driven tests can have multiple arguments (Variant #1 <2, 3>)");
+      expect(specs[2].description).toBe("data-driven tests can have multiple arguments (Variant #2 <3, 4>)");
+
+      env.execute();
+    });
+
+    it("maintains the reference to 'this'", function(done) {
+      var env = new j$.Env(),
+          calls = 0;
+
+      var assertions = function() {
+        expect(calls).toBe(2);
+        done();
+      };
+
+      env.addReporter({jasmineDone: assertions});
+
+      env.beforeEach(function() {
+        this.x = 12;
+      });
+
+      env.all("data-driven tests", [2, 3], function(a) {
+        expect(this.x).toBe(12);
+        calls++;
+      });
+
+      env.execute();
+    });
+
+    describe("Does not create specs when", function() {
+
+      it("One of the argument groups in the dataset does not have enough values", function() {
+        var env = new j$.Env(),
+            expectedError = new Error("Expected 2 argument(s). Found 1 at index 1 (data-driven test fail)");
+
+        expectedError.name = "Jasmine.ArgumentCountMismatchError";
+
+        expect(function() {
+          env.all("data-driven test fail", [ [1,2], [1] ], function(x, y) { });
+        }).toThrow(expectedError);
+      });
+
+      it("The (fn argument count) > (dataset argument count + 1)", function() {
+        var env = new j$.Env(),
+            expectedError = new Error("Expecting data driven spec to accept 2 arguments, but 4 arguments are specified in the dataset at index 0 (data-driven test fail)");
+
+        expectedError.name = "Jasmine.ArgumentCountMismatchError";
+
+        expect(function() {
+          env.all("data-driven test fail", [ [1,2], [4,6] ], function(a, b, c, d) { });
+        }).toThrow(expectedError);
+      });
+
+      it("The (fn argument count) < (dataset argument count)", function() {
+        var env = new j$.Env(),
+            expectedError = new Error("Expecting data driven spec to accept 2 arguments, but 1 argument is specified in the dataset at index 0 (data-driven test fail)");
+
+        expectedError.name = "Jasmine.ArgumentCountMismatchError";
+
+        expect(function() {
+          env.all("data-driven test fail", [ [1,2], [4,7] ], function(x) { });
+        }).toThrow(expectedError);
+      });
+
+    });
+
+    it("Creates asynchronous specs when the (fn argument count) == (dataset argument count + 1)", function(done) {
+      var env = new j$.Env(),
+          mutatedVar,
+          a = [],
+          b = [];
+
+      var assertions = function() {
+        if (a.length < 2) return;
+
+        expect(a).toEqual([1, -3]);
+        expect(b).toEqual([2, 4]);
+        expect(mutatedVar).toBe(3);
+        done();
+      };
+
+      env.describe("tests", function() {
+        env.beforeEach(function() {
+          mutatedVar = 2;
+        });
+
+        env.all("async spec",
+          [
+            [ 1, 2],
+            [-3, 4]
+          ],
+          function(x, y, underTestCallback) {
+            setTimeout(function() {
+              expect(mutatedVar).toEqual(2);
+              a.push(x);
+              b.push(y);
+              underTestCallback();
+              assertions();
+            }, 0);
+          }
+        );
+
+        env.it("after async spec", function() {
+          mutatedVar = 3;
+        });
+      });
+
+      env.execute();
+    });
+
+    all("Data driven test definitions throw errors with invalid datasets",
+      [ null, undefined, NaN, false, true, "", [[]], {} ],
+      function(values) {
+        var env = new j$.Env(),
+            expectedError = new Error("No arguments for a data-driven test were provided (epic failures)");
+
+        expectedError.name = "Jasmine.ArgumentsMissingError";
+
+        expect(function() {
+          env.all("epic failures", values, function(x) { });
+        }).toThrow(expectedError);
+      }
+    );
+
+    it("Allows specifying which variant should be run", function(done) {
+      var env = new j$.Env(),
+          calls = [],
+          suiteCallback = jasmine.createSpy('suite callback'),
+          specs, suite;
+
+      // TODO: Is this correct?
+      var assertions = function() {
+        expect(calls).toEqual([ 2 ]);
+        expect(suiteCallback).not.toHaveBeenCalled();
+        done();
+      };
+
+      env.addReporter({jasmineDone: assertions, suiteDone: suiteCallback});
+
+      suite = env.describe("tests", function() {
+        specs = env.all("specify variant", [1, 2], function(x) {
+          calls.push(x);
+        });
+      });
+
+      env.execute([ specs[1].id ]);
+    });
+
+    it("Should return a variant specific full name", function() {
+      var env = new j$.Env({global: { setTimeout: setTimeout }}),
+        topLevelSpecs, nestedSpecs, doublyNestedSpecs;
+
+      env.describe("my tests", function() {
+        topLevelSpecs = env.all("are top level", [1, 2], function(x) {});
+
+        env.describe("are sometimes", function() {
+          nestedSpecs = env.all("singly nested", [1, 2], function(x) {});
+
+          env.describe("even", function() {
+            doublyNestedSpecs = env.all("doubly nested", [1, 2], function(x) {});
+          });
+        });
+      });
+
+      expect(topLevelSpecs[0].getFullName())
+        .toBe("my tests are top level (Variant #0 <1>)");
+      expect(topLevelSpecs[1].getFullName())
+        .toBe("my tests are top level (Variant #1 <2>)");
+
+      expect(nestedSpecs[0].getFullName())
+        .toBe("my tests are sometimes singly nested (Variant #0 <1>)");
+      expect(nestedSpecs[1].getFullName())
+        .toBe("my tests are sometimes singly nested (Variant #1 <2>)");
+
+      expect(doublyNestedSpecs[0].getFullName())
+        .toBe("my tests are sometimes even doubly nested (Variant #0 <1>)");
+      expect(doublyNestedSpecs[1].getFullName())
+        .toBe("my tests are sometimes even doubly nested (Variant #1 <2>)");
+    });
+
+  });
+
   it("Functions can be spied on and have their calls tracked", function () {
       var env = new j$.Env();
 

--- a/spec/node_suite.js
+++ b/spec/node_suite.js
@@ -29,6 +29,14 @@ var jasmineInterface = {
     return env.xit(desc, func);
   },
 
+  all: function(desc, values, func) {
+    return env.all(desc, values, func);
+  },
+
+  xall: function(desc, values, func) {
+    return env.xall(desc, values, func);
+  },
+
   beforeEach: function(beforeEachFunction) {
     return env.beforeEach(beforeEachFunction);
   },

--- a/spec/support/dev_boot.js
+++ b/spec/support/dev_boot.js
@@ -23,6 +23,14 @@
       return env.xit(desc, func);
     },
 
+    all: function(desc, values, func) {
+      return env.all(desc, values, func);
+    },
+
+    xall: function(desc, values, func) {
+      return env.xall(desc, values, func);
+    },
+
     beforeEach: function(beforeEachFunction) {
       return env.beforeEach(beforeEachFunction);
     },


### PR DESCRIPTION
Resolves Issue #480

Clean up your repetive Jasmine specs with data driven tests using an easy to read
syntax:

```
all("your base are belong to us", [ [2,3], [1,4] ], function(your, base) {
    var longToUs = 5;

    expect(your + base).toBe(longToUs);
});
```

Specify single arguments or multiple arguments:

```
all("specs can have one argument", [1, 2, 3, 4], function(x) {
    expect(x > 0).toBe(true);
});

all("specs can have multiple arguments", [ [1,2], [3,4] ], function(x, y) {
    expect(y > x).toBe(true);
});
```

Under the hood, data driven tests are expanded into multiple `it`'s, which are visible
in the Spec Runner:

```
all("numbers are greater than zero", [ [2,1], [4,3] ], function(a, b) {
    expect(a - b > 0).toBe(true);
});
```

Becomes:

```
numbers are greater than zero (Variant #0 <2, 1>)
numbers are greater than zero (Variant #1 <4, 3>)
```

Since each argument group in the dataset becomes its own spec, you can easily run a
single variant by clicking on the spec name in the browser based spec runner.

Data driven tests can be marked as pending:

```
xall("these are pending", [1, 2, 3], function(x) { });
```

The `all` and `xall` functions return the array of specs that were created:

```
var specs = all("foo", [1, 2], function(x) { ... });
```

Asynchronous data driven tests are executed in the order they are declared, just
like regular async specs defined using `it`:

```
all("repetitive async tests are supported", [1, 2, 3, 4], function(x, done) {
    setTimeout(function() {
        expect(x > 0).toBe(true);

        done();
    }, 500);
});
```

Jasmine will assume your data driven test is asynchronous and provide a `done` callback if
your test function defines `n + 1` arguments, where `n` is the number of arguments in each
dataset argument group. So beware of:

```
all("foo", [1, 2], function(x, y) {
    // "y" is a callback function!
});
```

The dataset is validated to ensure your test function doesn't exhibit wonky behavior, which
should prevent some hair pulling and head banging.

Consider the following test definition:

```
all("test description", [ [1,2], [5] ], function(x, y) {
    ...
});
```

The second argument group only has one argument. When the test is created, this error will
be thrown:

```
Jasmine.ArgumentCountMismatchError: Expected 2 argument(s). Found 1 at index 1 (test description)
```

Now consider:

```
all("test description", [ [1,2], [3,4] ], function(a, b, c, d) {
    ...
});
```

The dataset has two arguments in each group, but the test function itself is expecting 4
arguments. When the test is created, this error will be thrown:

```
Jasmine.ArgumentCountMismatchError: Expecting data driven spec to accept 2 arguments, but 4 arguments are specified in the dataset at index 0 (test description)
```

If you give an invalid or empty dataset:

```
all("test description", [], function(x) {
    ...
});
```

This error is thrown:

```
Jasmine.ArgumentsMissingError: No arguments for a data-driven test were provided (test description)
```
