### PR TITLE
Asynchronous test functions with continuations.

### DIFF
--- a/spec/core/QueueRunnerSpec.js
+++ b/spec/core/QueueRunnerSpec.js
@@ -93,6 +93,70 @@ describe("QueueRunner", function() {
       expect(onComplete).toHaveBeenCalled();
     });
 
+    it("supports continuations of asynchronous functions", function() {
+      var onComplete = jasmine.createSpy('onComplete'),
+        fnCallback = jasmine.createSpy('fnCallback'),
+        contCallback1 = jasmine.createSpy('contCallback1'),
+        contCallback2 = jasmine.createSpy('contCallback2'),
+        afterCallback = jasmine.createSpy('afterCallback'),
+        fn1 = function(async) {
+          var cont1 = async.continuation(function(a){
+                contCallback1(a);
+                setTimeout(
+                  function(){ cont2(1,2); },
+                  100
+                );
+              }),
+            cont2 = async.continuation(function(a,b){
+              contCallback2(a,b);
+              setTimeout(async.done, 100);
+            });
+          fnCallback();
+          setTimeout(
+            function(){ cont1('xyz'); },
+            100
+          );
+        },
+        fn2 = function(done) {
+          afterCallback();
+          setTimeout(done, 100);
+        },
+        queueRunner = new j$.QueueRunner({
+          fns: [fn1, fn2],
+          onComplete: onComplete
+        });
+
+      queueRunner.execute();
+
+      expect(fnCallback).toHaveBeenCalled();
+      expect(contCallback1).not.toHaveBeenCalled();
+      expect(contCallback2).not.toHaveBeenCalled();
+      expect(afterCallback).not.toHaveBeenCalled();
+      expect(onComplete).not.toHaveBeenCalled();
+
+      jasmine.clock().tick(100);
+
+      expect(contCallback1).toHaveBeenCalledWith('xyz');
+      expect(contCallback2).not.toHaveBeenCalled();
+      expect(afterCallback).not.toHaveBeenCalled();
+      expect(onComplete).not.toHaveBeenCalled();
+
+      jasmine.clock().tick(100);
+
+      expect(contCallback2).toHaveBeenCalledWith(1,2);
+      expect(afterCallback).not.toHaveBeenCalled();
+      expect(onComplete).not.toHaveBeenCalled();
+
+      jasmine.clock().tick(100);
+
+      expect(afterCallback).toHaveBeenCalled();
+      expect(onComplete).not.toHaveBeenCalled();
+
+      jasmine.clock().tick(100);
+
+      expect(onComplete).toHaveBeenCalled();
+    })
+
     it("sets a timeout if requested for asynchronous functions so they don't go on forever", function() {
       var beforeFn = function(done) { },
         fn = jasmine.createSpy('fn'),

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -70,6 +70,20 @@ getJasmineRequireObj().QueueRunner = function(j$) {
         }, j$.DEFAULT_TIMEOUT_INTERVAL]]);
       }
 
+      next.continuation = function(innerFn) {
+        var wrapperFn = function() {
+          try {
+            innerFn.apply(self.userContext, arguments);
+          } catch (e) {
+            // TODO: Needs test coverage. Not sure how best to do that.
+            handleException(e);
+            next();
+          }
+        };
+        return wrapperFn;
+      };
+      next.done = next;
+
       try {
         fn.call(self.userContext, next);
       } catch (e) {


### PR DESCRIPTION
Allow spec function argument to be used as "done()" function or as "async" object with done() and continuation() members. async.continuation() wraps a given function so that it can be called asynchronously with the same user context (this) as the spec function from which it was constructed.

Errors thrown from within a wrapped continuation function should also be handled in the same way as they would have been if thrown from the spec function. I have not figured out the appropriate way to add test coverage for that though (so it might not be working) and I expect this PR to not be acceptable for merge yet for that reason. I'm making the PR now though in hopes of getting feedback on what I have done so far (including tips on how I should add the missing coverage).
