### PR TITLE
Fix ObjectContaining to match recursively

### DIFF
--- a/spec/core/ObjectContainingSpec.js
+++ b/spec/core/ObjectContainingSpec.js
@@ -61,4 +61,10 @@ describe("ObjectContaining", function() {
 
     expect(containing.jasmineToString()).toMatch("<jasmine.objectContaining");
   });
+
+  it("matches recursively", function() {
+    var containing = new j$.ObjectContaining({one: new j$.ObjectContaining({two: {}})});
+
+    expect(containing.jasmineMatches({one: {two: {}}})).toBe(true);
+  });
 });

--- a/src/core/ObjectContaining.js
+++ b/src/core/ObjectContaining.js
@@ -18,7 +18,7 @@ getJasmineRequireObj().ObjectContaining = function(j$) {
       if (!hasKey(other, property) && hasKey(this.sample, property)) {
         mismatchKeys.push('expected has key \'' + property + '\', but missing from actual.');
       }
-      else if (!j$.matchersUtil.equals(this.sample[property], other[property])) {
+      else if (!j$.matchersUtil.equals(other[property], this.sample[property])) {
         mismatchValues.push('\'' + property + '\' was \'' + (other[property] ? j$.util.htmlEscape(other[property].toString()) : other[property]) + '\' in actual, but was \'' + (this.sample[property] ? j$.util.htmlEscape(this.sample[property].toString()) : this.sample[property]) + '\' in expected.');
       }
     }


### PR DESCRIPTION
`matchersUtil.equals()` does not expect a matcher as its first argument. Follow the convention of `compare()` functions by passing the "actual" value followed by the "expected" value.

(It's not clear to me whether or not `matchersUtil.equals()` should be symmetric. If so, some code there should be added; if not, some code can be removed.)
