### PR TITLE
Give priority to jasmine.Any and jasmine.ObjectContains

### DIFF
--- a/spec/core/matchers/matchersUtilSpec.js
+++ b/spec/core/matchers/matchersUtilSpec.js
@@ -138,6 +138,14 @@ describe("matchersUtil", function() {
       expect(j$.matchersUtil.equals(anyString, number)).toBe(false);
     });
 
+    it("Any should have priority over the custom equality matcher", function() {
+      var tester = function(a ,b) { return false; },
+        number = 3,
+        anyNumber = new j$.Any(Number);
+      
+      expect(j$.matchersUtil.equals(number, anyNumber, [tester])).toBe(true);
+    });
+
     it("passes when ObjectContaining is used", function() {
       var obj = {
         foo: 3,
@@ -146,6 +154,17 @@ describe("matchersUtil", function() {
 
       expect(j$.matchersUtil.equals(obj, new j$.ObjectContaining({foo: 3}))).toBe(true);
     });
+
+    it("ObjectContaining should have priority over the custom equality matcher", function() {
+      var tester = function(a ,b) { return false; },
+        obj = {
+          foo: 3,
+          bar: 7
+        };
+      
+      expect(j$.matchersUtil.equals(obj, new j$.ObjectContaining({foo: 3}), [tester])).toBe(true);
+    });
+
 
     it("passes when a custom equality matcher returns true", function() {
       var tester = function(a, b) { return true; };

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -53,13 +53,6 @@ getJasmineRequireObj().matchersUtil = function(j$) {
   function eq(a, b, aStack, bStack, customTesters) {
     var result = true;
 
-    for (var i = 0; i < customTesters.length; i++) {
-      var customTesterResult = customTesters[i](a, b);
-      if (!j$.util.isUndefined(customTesterResult)) {
-        return customTesterResult;
-      }
-    }
-
     if (a instanceof j$.Any) {
       result = a.jasmineMatches(b);
       if (result) {
@@ -78,6 +71,13 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       result = b.jasmineMatches(a);
       if (result) {
         return true;
+      }
+    }
+
+    for (var i = 0; i < customTesters.length; i++) {
+      var customTesterResult = customTesters[i](a, b);
+      if (!j$.util.isUndefined(customTesterResult)) {
+        return customTesterResult;
       }
     }
 


### PR DESCRIPTION
I think that expectations using Any or ObjectContains helpers should checks without customTesters.
Now I have an issue in my tests. I have a custom tester which calls `angular.equals` utillity function. It allows to compare ignoring private members used by angular.
But in the same time I want to use ObjectContains, but I can't, because custom matcher are called earlier. To make it work I need to check types of arguments in custom tester manually. 

I don't see a case where current behavior can be applied, so I suggest this changes.
