### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/MIT.LICENSE
+++ b/MIT.LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2008-2011 Pivotal Labs
+Copyright (c) 2008-2014 Pivotal Labs
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Please read the [contributors' guide](https://github.com/pivotal/jasmine/blob/ma
 
 * [Christian Williams](mailto:antixian666@gmail.com), Square
 
-Copyright (c) 2008-2013 Pivotal Labs. This software is licensed under the MIT License.
+Copyright (c) 2008-2014 Pivotal Labs. This software is licensed under the MIT License.


### PR DESCRIPTION
The copyright year was out of date. Copyright notices should reflect the current year. This commit updates the listed year to 2014.
see: http://www.copyright.gov/circs/circ01.pdf for more info
