### PR TITLE
re-enable some older browsers

### DIFF
--- a/lib/jasmine-core/boot.js
+++ b/lib/jasmine-core/boot.js
@@ -147,8 +147,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     env: env,
     onRaiseExceptionsClick: function() { queryString.setParam("catch", !env.catchingExceptions()); },
     getContainer: function() { return document.body; },
-    createElement: function() { return document.createElement.apply(document, arguments); },
-    createTextNode: function() { return document.createTextNode.apply(document, arguments); },
+    createElement: function(type) { return document.createElement(type); },
+    createTextNode: function(child) { return document.createTextNode(child); },
     timer: new jasmine.Timer()
   });
 

--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -230,7 +230,22 @@ jasmineRequire.HtmlReporter = function(j$) {
     return this;
 
     function find(selector) {
-      return getContainer().querySelector(selector);
+      var container = getContainer(), cls, elem, i;
+      if (typeof container.querySelector !== "function") { // IE6 compatibility
+        if (selector.charAt(0) === ".") {
+          cls = selector.substring(1);
+          elem = container.getElementsByTagName("*");
+          for (i = 0; i < elem.length; i += 1) {
+            if ((" " + elem[i].className + " ").indexOf(" " + cls + " ") !== -1) {
+              return elem[i];
+            }
+          }
+        } else {
+          return container.getElementsByTagName(selector);
+        }
+      } else { // IE7+
+        return container.querySelector(selector);
+      }
     }
 
     function createDom(type, attrs, childrenVarArgs) {


### PR DESCRIPTION
I just tried to switch from jasmine 1.3 to 2.0.0 and noticed that some tests for older browsers failed (ie7, ie6 and firefox 3.0).
This patch got them running again :relieved: Hope this helps. Thanks
