### PR TITLE
feat(QueueRunner): accept optional error via done(err)

### DIFF
--- a/spec/core/QueueRunnerSpec.js
+++ b/spec/core/QueueRunnerSpec.js
@@ -115,6 +115,62 @@ describe("QueueRunner", function() {
       expect(onComplete).toHaveBeenCalled();
     });
 
+    it('logs async errors passed via done(err)', function() {
+      var error = new Error('failure');
+      
+      function asyncError(done) {
+        setTimeout(function() {
+          // node style error indication
+          done(error);
+        }, 100);
+      }
+
+      var fn = asyncError,
+        onComplete = jasmine.createSpy('onComplete'),
+        onException = jasmine.createSpy('onException'),
+        queueRunner = new j$.QueueRunner({
+          fns: [asyncError],
+          onComplete: onComplete,
+          onException: onException
+        });
+
+      queueRunner.execute();
+      expect(onComplete).not.toHaveBeenCalled();
+
+      jasmine.clock().tick(110);
+
+      expect(onException).toHaveBeenCalledWith(error);
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    it('logs NO async errors via done(null)', function() {
+      var error = new Error('failure');
+      
+      function asyncNoError(done) {
+        setTimeout(function() {
+          // node style no error indication
+          done(null);
+        }, 100);
+      }
+
+      var fn = asyncNoError,
+        onComplete = jasmine.createSpy('onComplete'),
+        onException = jasmine.createSpy('onException'),
+        queueRunner = new j$.QueueRunner({
+          fns: [asyncNoError],
+          onComplete: onComplete,
+          onException: onException
+        });
+
+      queueRunner.execute();
+      expect(onComplete).not.toHaveBeenCalled();
+
+      jasmine.clock().tick(110);
+
+      expect(onException).not.toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalled();
+    });
+
     it("by default does not set a timeout for asynchronous functions", function() {
       var beforeFn = function(done) { },
         fn = jasmine.createSpy('fn'),

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -2,10 +2,10 @@ getJasmineRequireObj().QueueRunner = function(j$) {
 
   function once(fn) {
     var called = false;
-    return function() {
+    return function(err) {
       if (!called) {
         called = true;
-        fn();
+        fn(err);
       }
     };
   }
@@ -57,7 +57,10 @@ getJasmineRequireObj().QueueRunner = function(j$) {
       var clearTimeout = function () {
           Function.prototype.apply.apply(self.timer.clearTimeout, [j$.getGlobal(), [timeoutId]]);
         },
-        next = once(function () {
+        next = once(function (err) {
+          if (err) {
+            handleException(err);
+          }
           clearTimeout(timeoutId);
           self.run(fns, iterativeIndex + 1);
         }),


### PR DESCRIPTION
This pull request adds the ability to pass an optional error to the done
callback, indicating an async failure.
#### Example

``` javascript
describe('async fail', function() {

  it('fails asnchronously', function(done) {
    setTimeout(function() {
      done(new Error('OOPS, async fail'));
    }, 100);
  });
});
```
#### Notes
- Should not break existing functionality, as done() does not accept
  any arguments so far.
- The err as the first argument is a common practice in NodeJS
  applications.

Closes #567
