### PR TITLE
disabled suite should still call onStart callback

### DIFF
--- a/spec/core/SuiteSpec.js
+++ b/spec/core/SuiteSpec.js
@@ -67,12 +67,17 @@ describe("Suite", function() {
     expect(suite.afterFns).toEqual([innerAfter, outerAfter]);
   });
 
-  it("can be disabled", function() {
+  it("can be disabled, but still calls callbacks", function() {
     var env = new j$.Env(),
       fakeQueueRunner = jasmine.createSpy('fake queue runner'),
+      onStart = jasmine.createSpy('onStart'),
+      resultCallback = jasmine.createSpy('resultCallback'),
+      onComplete = jasmine.createSpy('onComplete'),
       suite = new j$.Suite({
         env: env,
         description: "with a child suite",
+        onStart: onStart,
+        resultCallback: resultCallback,
         queueRunner: fakeQueueRunner
       });
 
@@ -80,9 +85,12 @@ describe("Suite", function() {
 
     expect(suite.disabled).toBe(true);
 
-    suite.execute();
+    suite.execute(onComplete);
 
     expect(fakeQueueRunner).not.toHaveBeenCalled();
+    expect(onStart).toHaveBeenCalled();
+    expect(resultCallback).toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalled();
   });
 
   it("delegates execution of its specs and suites", function() {

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -51,6 +51,9 @@ getJasmineRequireObj().Suite = function() {
 
   Suite.prototype.execute = function(onComplete) {
     var self = this;
+
+    this.onStart(this);
+
     if (this.disabled) {
       complete();
       return;
@@ -61,8 +64,6 @@ getJasmineRequireObj().Suite = function() {
     for (var i = 0; i < this.children.length; i++) {
       allFns.push(wrapChildAsAsync(this.children[i]));
     }
-
-    this.onStart(this);
 
     this.queueRunner({
       fns: allFns,


### PR DESCRIPTION
A disabled suite should still call its `onStart` callback like spec.
