### PR TITLE
a disabled suite should call resultCallback with status being disabled

### DIFF
--- a/spec/core/SuiteSpec.js
+++ b/spec/core/SuiteSpec.js
@@ -179,4 +179,30 @@ describe("Suite", function() {
       fullName: "with a child suite"
     });
   });
+
+  it("calls a provided result callback with status being disabled when disabled and done", function() {
+    var env = new j$.Env(),
+      suiteResultsCallback = jasmine.createSpy('suite result callback'),
+      fakeQueueRunner = function(attrs) { attrs.onComplete(); },
+      suite = new j$.Suite({
+        env: env,
+        description: "with a child suite",
+        queueRunner: fakeQueueRunner,
+        resultCallback: suiteResultsCallback
+      }),
+      fakeSpec1 = {
+        execute: jasmine.createSpy('fakeSpec1')
+      };
+
+    suite.disable();
+
+    suite.execute();
+
+    expect(suiteResultsCallback).toHaveBeenCalledWith({
+      id: suite.id,
+      status: 'disabled',
+      description: "with a child suite",
+      fullName: "with a child suite"
+    });
+  });
 });

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -23,6 +23,10 @@ getJasmineRequireObj().Suite = function() {
     };
   }
 
+  Suite.prototype.status = function() {
+    return this.disabled ? 'disabled' : '';
+  };
+
   Suite.prototype.getFullName = function() {
     var fullName = this.description;
     for (var parentSuite = this.parentSuite; parentSuite; parentSuite = parentSuite.parentSuite) {
@@ -70,6 +74,7 @@ getJasmineRequireObj().Suite = function() {
     });
 
     function complete() {
+      self.result.status = self.status();
       self.resultCallback(self.result);
 
       if (onComplete) {


### PR DESCRIPTION
The reporter can know whether the suite is normal or disabled.

Do we also need to update status of result before calling `onStart` callback? And spec?
