### PR TITLE
Update FakeDate to pass any number of args to Date

### DIFF
--- a/spec/core/MockDateSpec.js
+++ b/spec/core/MockDateSpec.js
@@ -77,6 +77,14 @@ describe("FakeDate", function() {
     expect(new fakeGlobal.Date()).toEqual(jasmine.any(Date));
   });
 
+  it("does not break new Date(ms) while installed", function() {
+    var fakeGlobal = { Date: Date },
+      mockDate = new j$.MockDate(fakeGlobal);
+
+    mockDate.install();
+    expect(new fakeGlobal.Date(1234567890000).toString()).not.toEqual("Invalid Date");
+  });
+
   it("fakes current time when using Date.now()", function() {
     var globalDate = jasmine.createSpy("global Date").and.callFake(function() {
         return {

--- a/src/core/MockDate.js
+++ b/src/core/MockDate.js
@@ -40,8 +40,8 @@ getJasmineRequireObj().MockDate = function() {
       if (arguments.length === 0) {
         return new GlobalDate(currentTime);
       } else {
-        return new GlobalDate(arguments[0], arguments[1], arguments[2],
-          arguments[3], arguments[4], arguments[5], arguments[6]);
+        var Constructor = GlobalDate.bind.apply(GlobalDate, arguments);
+        return new Constructor();
       }
     }
 


### PR DESCRIPTION
Fixes bug in which mocking out Date and calling `new Date(132456)`
returns "Invalid Date".
