### PR TITLE
add support for transformStackTrace hook to HtmlReporter

### DIFF
--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -11,6 +11,8 @@ jasmineRequire.HtmlReporter = function(j$) {
       createElement = options.createElement,
       createTextNode = options.createTextNode,
       onRaiseExceptionsClick = options.onRaiseExceptionsClick || function() {},
+      transformStackTrace = options.transformStackTrace || 
+        function(stackTrace, done) { done(stackTrace); },
       timer = options.timer || noopTimer,
       results = [],
       specsExecuted = 0,
@@ -97,7 +99,10 @@ jasmineRequire.HtmlReporter = function(j$) {
         for (var i = 0; i < result.failedExpectations.length; i++) {
           var expectation = result.failedExpectations[i];
           messages.appendChild(createDom('div', {className: 'result-message'}, expectation.message));
-          messages.appendChild(createDom('div', {className: 'stack-trace'}, expectation.stack));
+          transformStackTrace(expectation.stack, function(result) {
+            messages.appendChild(createDom('div', {className: 'stack-trace'}, 
+              result));
+          }
         }
 
         failures.push(failure);


### PR DESCRIPTION
Support for an asynchronous transformStackTrace hook for HtmlReporter, to support applying sourcemaps (or other async-doing things) to the stack trace output. 

See #491
