### PR TITLE
Fix issue with initialising date object using only 1 argument

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1354,6 +1354,8 @@ getJasmineRequireObj().MockDate = function() {
     function FakeDate() {
       if (arguments.length === 0) {
         return new GlobalDate(currentTime);
+	  } else if (arguments.length === 1) {
+        return new GlobalDate(arguments[0]);
       } else {
         return new GlobalDate(arguments[0], arguments[1], arguments[2],
           arguments[3], arguments[4], arguments[5], arguments[6]);


### PR DESCRIPTION
When using new Date(MILLISECONDS) as a value date on both chrome and safari comes up as invalid due to the constructor being called with 7 arguments at all times, Just catch single case and only call with 1 argument.

This fixes invalid date when trying to initialise a date using a
integer value i.e. valueOf from another date object.
