### PR TITLE
Allow possible support for IE7

### DIFF
--- a/lib/jasmine-core/boot.js
+++ b/lib/jasmine-core/boot.js
@@ -147,8 +147,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     env: env,
     onRaiseExceptionsClick: function() { queryString.setParam("catch", !env.catchingExceptions()); },
     getContainer: function() { return document.body; },
-    createElement: function() { return document.createElement.apply(document, arguments); },
-    createTextNode: function() { return document.createTextNode.apply(document, arguments); },
+    createElement: function(tagName) { return document.createElement(tagName); },
+    createTextNode: function(data) { return document.createTextNode(data); },
     timer: new jasmine.Timer()
   });
 

--- a/lib/jasmine-core/boot/boot.js
+++ b/lib/jasmine-core/boot/boot.js
@@ -125,8 +125,8 @@
     env: env,
     onRaiseExceptionsClick: function() { queryString.setParam("catch", !env.catchingExceptions()); },
     getContainer: function() { return document.body; },
-    createElement: function() { return document.createElement.apply(document, arguments); },
-    createTextNode: function() { return document.createTextNode.apply(document, arguments); },
+    createElement: function(tagName) { return document.createElement(tagName); },
+    createTextNode: function(data) { return document.createTextNode(data); },
     timer: new jasmine.Timer()
   });
 


### PR DESCRIPTION
As it is, IE6 and IE7 will throw script errors from these two lines. After this change is made, all a tool such as grunt-contrib-jasmine would have to do is provide json2.js and a polyfill for querySelector, and then it will support Jasmine testing in IE7 no problem at all. I've got this hooked up locally and it works great using https://www.npmjs.org/package/polyfill-queryselector

I am also making a pr with grunt-contrib-jasmine for json2.js and the polyfill, but it will be much easier to push this effort forward once the core jasmine files are updated.

createTextNode only takes one arg, the text data so no need to use apply there. Same for createElement - it only takes one arg which is the tag name. For some reason IE6 and IE7 throw script errors when using apply with these two methods.
https://developer.mozilla.org/en-US/docs/Web/API/document.createTextNode
https://developer.mozilla.org/en-US/docs/Web/API/document.createElement
