### PR TITLE
afterEach blocks are not aborted after a timeout in waitsFor

### DIFF
--- a/spec/core/SpecRunningSpec.js
+++ b/spec/core/SpecRunningSpec.js
@@ -1287,5 +1287,30 @@ describe("jasmine spec running", function () {
         'Result: Passed.'
       ));
   });
+  
+  it("should not abort queue after waitsFor timeout", function() {
+    var insideAfter = false,
+        insideRun = false;
+    
+    var suite = env.describe("spec timing out", function() {
+      this.afterEach(function() { insideAfter = true });
+      
+      env.it("should time out", function() {
+        this.waitsFor(function() {}, 'timeout', 10);
+        
+        // This block is necessary to highlight the test goal; otherwise next_()
+        // works by accident when waitsFor() happens to be the last block
+        // in the queue before any ensured (afterEach) blocks. The block itself
+        // should not run however.
+        this.runs(function() { insideRun = true });
+      });
+    });
+    
+    suite.execute();
+    fakeTimer.tick(10);
+    
+    expect(insideRun).toBe(false);
+    expect(insideAfter).toBe(true);
+  });
 
 });

--- a/src/core/Queue.js
+++ b/src/core/Queue.js
@@ -58,7 +58,7 @@ jasmine.Queue.prototype.next_ = function() {
   while (goAgain) {
     goAgain = false;
     
-    if (self.index < self.blocks.length && !(this.abort && !this.ensured[self.index])) {
+    if (self.index < self.blocks.length) {
       var calledSynchronously = true;
       var completedSynchronously = false;
 
@@ -89,7 +89,12 @@ jasmine.Queue.prototype.next_ = function() {
           }
         }
       };
-      self.blocks[self.index].execute(onComplete);
+      
+      if (!this.abort || this.ensured[self.index]) {
+        self.blocks[self.index].execute(onComplete);
+      } else {
+        onComplete();
+      }
 
       calledSynchronously = false;
       if (completedSynchronously) {


### PR DESCRIPTION
Previously a timeout in `waitsFor` caused the block queue for a spec to be aborted, and if `whatsFor` block happened not to be the last one before "ensured" `afterEach` blocks they were never executed. This is a bug.

With this fix, the queue will continue to run until all blocks are exhausted but only "ensured" blocks are executed when abort condition is met.