### PR TITLE
add toHaveBeenCalledLastTimeWith matcher

### DIFF
--- a/spec/core/matchers/toHaveBeenCalledLastTimeWithSpec.js
+++ b/spec/core/matchers/toHaveBeenCalledLastTimeWithSpec.js
@@ -1,0 +1,66 @@
+describe("toHaveBeenCalledLastTimeWith", function() {
+  it("passes when the actual was called with matching parameters", function() {
+    var util = {
+          equals: jasmine.createSpy('delegated-equals').and.returnValue(true)
+        },
+        matcher = j$.matchers.toHaveBeenCalledLastTimeWith(util),
+        calledSpy = j$.createSpy('called-spy'),
+        result;
+
+    calledSpy('a', 'b');
+    result = matcher.compare(calledSpy, 'a', 'b');
+
+    expect(result.pass).toBe(true);
+    expect(result.message()).toEqual("Expected spy called-spy not to have been called last time with [ 'a', 'b' ] but it was.");
+  });
+
+  it("passes through the custom equality testers", function() {
+    var util = {
+          equals: jasmine.createSpy('delegated-equals').and.returnValue(true)
+        },
+        customEqualityTesters = [function() { return true; }],
+        matcher = j$.matchers.toHaveBeenCalledLastTimeWith(util, customEqualityTesters),
+        calledSpy = j$.createSpy('called-spy');
+
+    calledSpy('a', 'b');
+    matcher.compare(calledSpy, 'a', 'b');
+
+    expect(util.equals).toHaveBeenCalledWith(['a', 'b'], ['a', 'b'], customEqualityTesters);
+  });
+
+  it("fails when the actual was not called", function() {
+    var util = {
+          equals: jasmine.createSpy('delegated-equals').and.returnValue(false)
+        },
+        matcher = j$.matchers.toHaveBeenCalledLastTimeWith(util),
+        uncalledSpy = j$.createSpy('uncalled spy'),
+        result;
+
+    result = matcher.compare(uncalledSpy);
+    expect(result.pass).toBe(false);
+    expect(result.message()).toEqual("Expected spy uncalled spy to have been called last time with [  ] but it was never called.");
+  });
+
+  it("fails when the actual was called with different parameters", function() {
+    var util = {
+          equals: jasmine.createSpy('delegated-equals').and.returnValue(false)
+        },
+        matcher = j$.matchers.toHaveBeenCalledLastTimeWith(util),
+        calledSpy = j$.createSpy('called spy'),
+        result;
+
+    calledSpy('a', 'b');
+    calledSpy('c', 'd');
+    result = matcher.compare(calledSpy, 'a', 'b');
+
+    expect(result.pass).toBe(false);
+    expect(result.message()).toEqual("Expected spy called spy to have been called last time with [ 'a', 'b' ] but actual call was [ 'c', 'd' ].");
+  });
+
+  it("throws an exception when the actual is not a spy", function() {
+    var matcher = j$.matchers.toHaveBeenCalledLastTimeWith(),
+        fn = function() {};
+
+    expect(function() { matcher.compare(fn) }).toThrow(new Error("Expected a spy, but got Function."));
+  });
+});

--- a/src/core/matchers/requireMatchers.js
+++ b/src/core/matchers/requireMatchers.js
@@ -14,6 +14,7 @@ getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
       'toEqual',
       'toHaveBeenCalled',
       'toHaveBeenCalledWith',
+      'toHaveBeenCalledLastTimeWith',
       'toMatch',
       'toThrow',
       'toThrowError'

--- a/src/core/matchers/toHaveBeenCalledLastTimeWith.js
+++ b/src/core/matchers/toHaveBeenCalledLastTimeWith.js
@@ -1,0 +1,35 @@
+getJasmineRequireObj().toHaveBeenCalledLastTimeWith = function(j$) {
+
+  function toHaveBeenCalledLastTimeWith(util, customEqualityTesters) {
+    return {
+      compare: function() {
+        var args = Array.prototype.slice.call(arguments, 0),
+          actual = args[0],
+          expectedArgs = args.slice(1),
+          result = { pass: false },
+          lastCallArgs;
+
+        if (!j$.isSpy(actual)) {
+          throw new Error('Expected a spy, but got ' + j$.pp(actual) + '.');
+        }
+
+        if (!actual.calls.any()) {
+          result.message = function() { return 'Expected spy ' + actual.and.identity() + ' to have been called last time with ' + j$.pp(expectedArgs) + ' but it was never called.'; };
+          return result;
+        }
+
+        lastCallArgs = actual.calls.argsFor(actual.calls.count() - 1);
+        if (util.equals(lastCallArgs, expectedArgs, customEqualityTesters)) {
+          result.pass = true;
+          result.message = function() { return 'Expected spy ' + actual.and.identity() + ' not to have been called last time with ' + j$.pp(expectedArgs) + ' but it was.'; };
+        } else {
+          result.message = function() { return 'Expected spy ' + actual.and.identity() + ' to have been called last time with ' + j$.pp(expectedArgs) + ' but actual call was ' + j$.pp(lastCallArgs) + '.'; };
+        }
+
+        return result;
+      }
+    };
+  }
+
+  return toHaveBeenCalledLastTimeWith;
+};


### PR DESCRIPTION
This matcher is similar to existing 'toHaveBeenCalledWith' but compares arguments only with the last call of a spy.
