### PR TITLE
Added returnValues functionality to spy strategy

### DIFF
--- a/spec/core/SpyStrategySpec.js
+++ b/spec/core/SpyStrategySpec.js
@@ -46,6 +46,19 @@ describe("SpyStrategy", function() {
     expect(returnValue).toEqual(17);
   });
 
+  it("can return specified values in order specified when executed", function() {
+    var originalFn = jasmine.createSpy("original"),
+        spyStrategy = new j$.SpyStrategy({fn: originalFn});
+
+    spyStrategy.returnValues('value1', 'value2', 'value3');
+
+    expect(spyStrategy.exec()).toEqual('value1');
+    expect(spyStrategy.exec()).toEqual('value2');
+    expect(spyStrategy.exec()).toBe('value3');
+    expect(spyStrategy.exec()).toBeUndefined();
+    expect(originalFn).not.toHaveBeenCalled();
+  });
+
   it("allows an exception to be thrown when executed", function() {
     var originalFn = jasmine.createSpy("original"),
         spyStrategy = new j$.SpyStrategy({fn: originalFn});

--- a/src/core/SpyStrategy.js
+++ b/src/core/SpyStrategy.js
@@ -1,4 +1,4 @@
-getJasmineRequireObj().SpyStrategy = function() {
+getJasmineRequireObj().SpyStrategy = function () {
 
   function SpyStrategy(options) {
     options = options || {};
@@ -28,7 +28,15 @@ getJasmineRequireObj().SpyStrategy = function() {
       return getSpy();
     };
 
-    this.throwError = function(something) {
+    this.returnValues = function () {
+      var values = Array.prototype.slice.call(arguments);
+      plan = function () {
+        return values.shift();
+      };
+      return getSpy();
+    };
+
+    this.throwError = function (something) {
       var error = (something instanceof Error) ? something : new Error(something);
       plan = function() {
         throw error;


### PR DESCRIPTION
This pull request addresses issue #660 The intention was first to update returnValue method to accept varargs and return them one by one on subsequent calls. However, it will not allow a single return value to be specified for all calls to the spied method.
Hence, a new method; returnValues().

It takes the varargs parameters and return them one by one till all are over and then returns undefined for subsequent calls to the method.
