### PR TITLE
Suggestion: Insert separators in spec names

### DIFF
--- a/spec/core/SuiteSpec.js
+++ b/spec/core/SuiteSpec.js
@@ -34,7 +34,7 @@ describe("Suite", function() {
         parentSuite: parentSuite
       });
 
-    expect(suite.getFullName()).toEqual("I am a parent suite I am a suite");
+    expect(suite.getFullName()).toEqual("I am a parent suite, I am a suite");
   });
 
   it("adds before functions in order of needed execution", function() {

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -878,23 +878,23 @@ describe("Env integration", function() {
           reporter = jasmine.createSpyObj('fakeReport', ['jasmineDone', 'suiteDone', 'specDone']);
 
       reporter.jasmineDone.and.callFake(function() {
-        expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite beforeAll times out', [
+        expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite, beforeAll: times out', [
           (/^Error: Timeout - Async callback was not invoked within timeout specified by jasmine\.DEFAULT_TIMEOUT_INTERVAL\./)
         ]);
 
-        expect(reporter.suiteDone).toHaveFailedExpecationsForRunnable('suite afterAll', [
+        expect(reporter.suiteDone).toHaveFailedExpecationsForRunnable('suite, afterAll', [
           (/^Error: Timeout - Async callback was not invoked within timeout specified by jasmine\.DEFAULT_TIMEOUT_INTERVAL\./)
         ]);
 
-        expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite beforeEach times out', [
+        expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite, beforeEach: times out', [
           (/^Error: Timeout - Async callback was not invoked within timeout specified by jasmine\.DEFAULT_TIMEOUT_INTERVAL\./)
         ]);
 
-        expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite afterEach times out', [
+        expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite, afterEach: times out', [
           (/^Error: Timeout - Async callback was not invoked within timeout specified by jasmine\.DEFAULT_TIMEOUT_INTERVAL\./)
         ]);
 
-        expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite it times out', [
+        expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite: times out', [
           (/^Error: Timeout - Async callback was not invoked within timeout specified by jasmine\.DEFAULT_TIMEOUT_INTERVAL\./)
         ]);
 
@@ -941,7 +941,7 @@ describe("Env integration", function() {
           env.it('times out', function() {});
         });
 
-        env.it('it times out', function(innerDone) {
+        env.it('times out', function(innerDone) {
           jasmine.clock().tick(6001);
           innerDone();
         }, 6000);
@@ -1130,9 +1130,9 @@ describe("Env integration", function() {
       });
     });
 
-    expect(topLevelSpec.getFullName()).toBe("my tests are sometimes top level");
-    expect(nestedSpec.getFullName()).toBe("my tests are sometimes singly nested");
-    expect(doublyNestedSpec.getFullName()).toBe("my tests are sometimes even doubly nested");
+    expect(topLevelSpec.getFullName()).toBe("my tests: are sometimes top level");
+    expect(nestedSpec.getFullName()).toBe("my tests, are sometimes: singly nested");
+    expect(doublyNestedSpec.getFullName()).toBe("my tests, are sometimes, even: doubly nested");
   });
 
   it("Custom equality testers should be per spec", function(done) {

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -126,7 +126,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     var getSpecName = function(spec, suite) {
-      return suite.getFullName() + ' ' + spec.description;
+      return suite.getFullName() + ': ' + spec.description;
     };
 
     // TODO: we may just be able to pass in the fn instead of wrapping here

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -35,7 +35,7 @@ getJasmineRequireObj().Suite = function() {
     var fullName = this.description;
     for (var parentSuite = this.parentSuite; parentSuite; parentSuite = parentSuite.parentSuite) {
       if (parentSuite.parentSuite) {
-        fullName = parentSuite.description + ' ' + fullName;
+        fullName = parentSuite.description + ', ' + fullName;
       }
     }
     return fullName;


### PR DESCRIPTION
When suites are nested, the concatenated spec names can become hard to follow, e.g. when a failing spec is presented by a reporter. Including a separator can help understanding the scenario under test and finding the failing spec more quickly.

For example, change this:

```
Events when listener is added and added again and removed once is not notified anymore
```

to:

```
Events, when listener is added, and added again, and removed once: is not notified anymore
```
