### PR TITLE
Fixed path to src files in node_example

### DIFF
--- a/lib/jasmine-core/example/node_example/spec/PlayerSpec.js
+++ b/lib/jasmine-core/example/node_example/spec/PlayerSpec.js
@@ -1,6 +1,6 @@
 describe("Player", function() {
-  var Player = require('../../jasmine_examples/Player.js');
-  var Song = require('../../jasmine_examples/Song.js');
+  var Player = require('../src/Player.js');
+  var Song = require('../src/Song.js');
   var player;
   var song;
 


### PR DESCRIPTION
There's no such folder as 'jasmine_examples'
