### PR TITLE
toContain works with array-like objects (Arguments, HTMLCollections, etc...)

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -2195,7 +2195,12 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         }
         return false;
       }
-      return !!haystack && haystack.indexOf(needle) >= 0;
+      if (!haystack) {
+        return false;
+      } else {
+        var indexOf = haystack.indexOf || Array.prototype.indexOf;
+        return indexOf.call(haystack, needle) >= 0;
+      }
     },
 
     buildFailureMessage: function() {

--- a/spec/core/matchers/matchersUtilSpec.js
+++ b/spec/core/matchers/matchersUtilSpec.js
@@ -207,6 +207,15 @@ describe("matchersUtil", function() {
     it("fails when actual is null", function() {
       expect(j$.matchersUtil.contains(null, 'A')).toBe(false);
     });
+
+    it("passes with array-like objects", function() {
+      var capturedArgs;
+      function testFunction(){
+        capturedArgs = arguments;
+      }
+      testFunction('foo', 'bar');
+      expect(capturedArgs).toContain('bar');
+    });
   });
 
   describe("buildMessage", function() {


### PR DESCRIPTION
toContain only works with proper Arrays and strings (or other things that implement `indexOf`). It can work with HTML Collections and Arguments lists using Array.prototype.indexOf. Behavior is unchanged for objects that already have `indexOf`
