### PR TITLE
toContain works with array-like objects (Arguments, HTMLCollections, etc)

### DIFF
--- a/spec/core/matchers/matchersUtilSpec.js
+++ b/spec/core/matchers/matchersUtilSpec.js
@@ -177,6 +177,10 @@ describe("matchersUtil", function() {
       expect(j$.matchersUtil.contains("ABC", "B")).toBe(true);
     });
 
+    it("passes when expected is a multi-character substring of actual", function() {
+      expect(j$.matchersUtil.contains("ABC", "BC")).toBe(true);
+    });
+
     it("fails when expected is a not substring of actual", function() {
       expect(j$.matchersUtil.contains("ABC", "X")).toBe(false);
     });

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -11,14 +11,18 @@ getJasmineRequireObj().matchersUtil = function(j$) {
     contains: function(haystack, needle, customTesters) {
       customTesters = customTesters || [];
 
-      if (!!haystack && (haystack.length > 0)) {
+      if ((Object.prototype.toString.apply(haystack) === '[object Array]') ||
+        (!!haystack && !haystack.indexOf))
+      {
         for (var i = 0; i < haystack.length; i++) {
           if (eq(haystack[i], needle, [], [], customTesters)) {
             return true;
           }
         }
+        return false;
       }
-      return false;
+
+      return !!haystack && haystack.indexOf(needle) >= 0;
     },
 
     buildFailureMessage: function() {


### PR DESCRIPTION
Take 2, mostly following the directions this time...

toContain only works with proper Arrays and strings (or other things that implement indexOf). It can work with HTML Collections and Arguments lists using Array.prototype.indexOf. Behavior is unchanged for objects that already have indexOf
