### PR TITLE
Simplifies SpecRunner.html

### DIFF
--- a/grunt/templates/SpecRunner.html.jst
+++ b/grunt/templates/SpecRunner.html.jst
@@ -1,23 +1,23 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta charset="utf-8">
   <title>Jasmine Spec Runner v<%= jasmineVersion %></title>
 
   <link rel="shortcut icon" type="image/png" href="lib/jasmine-<%= jasmineVersion %>/jasmine_favicon.png">
-  <link rel="stylesheet" type="text/css" href="lib/jasmine-<%= jasmineVersion %>/jasmine.css">
+  <link rel="stylesheet" href="lib/jasmine-<%= jasmineVersion %>/jasmine.css">
 
-  <script type="text/javascript" src="lib/jasmine-<%= jasmineVersion %>/jasmine.js"></script>
-  <script type="text/javascript" src="lib/jasmine-<%= jasmineVersion %>/jasmine-html.js"></script>
-  <script type="text/javascript" src="lib/jasmine-<%= jasmineVersion %>/boot.js"></script>
+  <script src="lib/jasmine-<%= jasmineVersion %>/jasmine.js"></script>
+  <script src="lib/jasmine-<%= jasmineVersion %>/jasmine-html.js"></script>
+  <script src="lib/jasmine-<%= jasmineVersion %>/boot.js"></script>
 
   <!-- include source files here... -->
-  <script type="text/javascript" src="src/Player.js"></script>
-  <script type="text/javascript" src="src/Song.js"></script>
+  <script src="src/Player.js"></script>
+  <script src="src/Song.js"></script>
 
   <!-- include spec files here... -->
-  <script type="text/javascript" src="spec/SpecHelper.js"></script>
-  <script type="text/javascript" src="spec/PlayerSpec.js"></script>
+  <script src="spec/SpecHelper.js"></script>
+  <script src="spec/PlayerSpec.js"></script>
 
 </head>
 


### PR DESCRIPTION
No need to specify type="text/javascript" for script tag
No need to specify type="text/css" for link tag with rel="stylesheet"

Less bytes and improved readability is always better :) IE8 also happy

Sources:
- [Why write script type=“text/javascript”](http://stackoverflow.com/questions/2706290)
- [meta charset='utf-8' vs meta http-equiv='Content-Type'](http://stackoverflow.com/questions/4696499)
- [Do we need type=“text/css” for link in HTML5](http://stackoverflow.com/questions/7715953)
