### PR TITLE
Use new jasmine github repo url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-gem "jasmine", :git => 'https://github.com/pivotal/jasmine-gem.git'
+gem "jasmine", :git => 'https://github.com/jasmine/jasmine-gem.git'
 # gem "jasmine", path: "../jasmine-gem"
 
 gemspec

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -61,7 +61,7 @@ Probably only need to do this when releasing a minor version, and not a patch ve
 
 ### Finally
 
-1. Visit the [Releases page for Jasmine](https://github.com/pivotal/jasmine/releases), find the tag just pushed.
+1. Visit the [Releases page for Jasmine](https://github.com/jasmine/jasmine/releases), find the tag just pushed.
  1. Paste in a link to the correct release notes for this release. The link should reference the blob and tag correctly, and the markdown file for the notes.
  1. If it is a pre-release, mark it as such.
  1. Attach the standalone zipfile

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.1.3",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pivotal/jasmine.git"
+    "url": "https://github.com/jasmine/jasmine.git"
   },
   "description": "Official packaging of Jasmine's core files for use by Node.js projects.",
   "homepage": "http://jasmine.github.io",
@@ -17,7 +17,7 @@
     "grunt-contrib-compress": "~0.5.2",
     "shelljs": "~0.1.4",
     "glob": "~3.2.9",
-    "jasmine": "https://github.com/pivotal/jasmine-npm/archive/master.tar.gz",
+    "jasmine": "https://github.com/jasmine/jasmine-npm/archive/master.tar.gz",
     "load-grunt-tasks": "^0.4.0"
   }
 }


### PR DESCRIPTION
I've skipped release notes because the `pivotal/jasmine` link redirects and archival purposes I guess. Also CodeClimate is set up to point `pivotal/jasmine` which I guess redirects and everything works? There is also no CodeClimate setup for `jasmine/jasmine`. I guess it will be good to set up with the right repo to avoid future confusion and possible link breaking.