### PR TITLE
Fix invalid bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "jasmine-core.gemspec",
     "*.sh",
     "*.py",
-    "Gruntfile.js"
+    "Gruntfile.js",
     "lib/jasmine-core.rb",
     "lib/jasmine-core/boot/",
     "lib/jasmine-core/spec",


### PR DESCRIPTION
This just broke Bower installation on a project of mine. :frowning: 

Maybe adding a JSON lint step to the build would be help prevent issues like this in the future?
