### PR TITLE
Error for incorrect spy return value

### DIFF
--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -99,5 +99,11 @@ describe('Spies', function () {
     itThrowsAMeaningfulErrorWhenChainedWith_and('throwError');
     itThrowsAMeaningfulErrorWhenChainedWith_and('callFake');
     itThrowsAMeaningfulErrorWhenChainedWith_and('stub');
+
+    it("still creates a spy if an and method is specified", function () {
+        var spy = j$.createSpyObj('testSpy', ['and']);
+        spy.and.and.returnValue('eggs');
+        expect(spy.and()).toEqual('eggs');
+    });
   });
 });

--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -63,7 +63,7 @@ describe('Spies', function () {
     it("should create an object with a bunch of spy methods when you call jasmine.createSpyObj()", function() {
       var spyObj = j$.createSpyObj('BaseName', ['method1', 'method2']);
 
-      expect(spyObj).toEqual({ method1: jasmine.any(Function), method2: jasmine.any(Function)});
+      expect(spyObj).toEqual(jasmine.objectContaining({ method1: jasmine.any(Function), method2: jasmine.any(Function)}));
       expect(spyObj.method1.and.identity()).toEqual('BaseName.method1');
       expect(spyObj.method2.and.identity()).toEqual('BaseName.method2');
     });
@@ -71,7 +71,7 @@ describe('Spies', function () {
     it("should allow you to omit the baseName", function() {
       var spyObj = j$.createSpyObj(['method1', 'method2']);
 
-      expect(spyObj).toEqual({ method1: jasmine.any(Function), method2: jasmine.any(Function)});
+      expect(spyObj).toEqual(jasmine.objectContaining({ method1: jasmine.any(Function), method2: jasmine.any(Function)}));
       expect(spyObj.method1.and.identity()).toEqual('unknown.method1');
       expect(spyObj.method2.and.identity()).toEqual('unknown.method2');
     });
@@ -81,5 +81,23 @@ describe('Spies', function () {
         j$.createSpyObj('BaseName');
       }).toThrow("createSpyObj requires a non-empty array of method names to create spies for");
     });
+
+    var itThrowsAMeaningfulErrorWhenChainedWith_and = function (methodName) {
+      describe(".and." + methodName, function () {
+        it("throws a meaningful error", function () {
+          expect(j$.createSpyObj('...', ['...']).and[methodName])
+            .toThrowError("and-style chaining cannot be used with createSpyObj, use createSpy instead");
+        });
+      });
+    };
+
+    itThrowsAMeaningfulErrorWhenChainedWith_and('identity');
+    itThrowsAMeaningfulErrorWhenChainedWith_and('exec');
+    itThrowsAMeaningfulErrorWhenChainedWith_and('callThrough');
+    itThrowsAMeaningfulErrorWhenChainedWith_and('returnValue');
+    itThrowsAMeaningfulErrorWhenChainedWith_and('returnValues');
+    itThrowsAMeaningfulErrorWhenChainedWith_and('throwError');
+    itThrowsAMeaningfulErrorWhenChainedWith_and('callFake');
+    itThrowsAMeaningfulErrorWhenChainedWith_and('stub');
   });
 });

--- a/src/core/InvalidSpyStrategy.js
+++ b/src/core/InvalidSpyStrategy.js
@@ -1,0 +1,20 @@
+getJasmineRequireObj().InvalidSpyStrategy = function() {
+    var InvalidSpyStrategy = function () {
+        var raiseImproperUsage = function () {
+          throw Error('and-style chaining cannot be used with createSpyObj, use createSpy instead');
+        };
+
+        return {
+            identity: raiseImproperUsage,
+            exec: raiseImproperUsage,
+            callThrough: raiseImproperUsage,
+            returnValue: raiseImproperUsage,
+            returnValues: raiseImproperUsage,
+            throwError: raiseImproperUsage,
+            callFake: raiseImproperUsage,
+            stub: raiseImproperUsage
+        };
+    };
+
+    return InvalidSpyStrategy;
+};

--- a/src/core/InvalidSpyStrategy.js
+++ b/src/core/InvalidSpyStrategy.js
@@ -1,7 +1,7 @@
 getJasmineRequireObj().InvalidSpyStrategy = function() {
     var InvalidSpyStrategy = function () {
         var raiseImproperUsage = function () {
-          throw Error('and-style chaining cannot be used with createSpyObj, use createSpy instead');
+          throw new Error('and-style chaining cannot be used with createSpyObj, use createSpy instead');
         };
 
         return {

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -117,6 +117,8 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
     for (var i = 0; i < methodNames.length; i++) {
       obj[methodNames[i]] = j$.createSpy(baseName + '.' + methodNames[i]);
     }
+
+    obj.and = obj.and || new j$.InvalidSpyStrategy();
     return obj;
   };
 };

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -117,7 +117,6 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
     for (var i = 0; i < methodNames.length; i++) {
       obj[methodNames[i]] = j$.createSpy(baseName + '.' + methodNames[i]);
     }
-
     obj.and = obj.and || new j$.InvalidSpyStrategy();
     return obj;
   };

--- a/src/core/requireCore.js
+++ b/src/core/requireCore.js
@@ -40,6 +40,7 @@ var getJasmineRequireObj = (function (jasmineGlobal) {
     j$.Spec = jRequire.Spec(j$);
     j$.SpyRegistry = jRequire.SpyRegistry(j$);
     j$.SpyStrategy = jRequire.SpyStrategy();
+    j$.InvalidSpyStrategy = jRequire.InvalidSpyStrategy();
     j$.StringMatching = jRequire.StringMatching(j$);
     j$.Suite = jRequire.Suite();
     j$.Timer = jRequire.Timer();


### PR DESCRIPTION
When testing I frequently find myself accidentally writing:
```javascript
... jasmine.createSpyObj('...', [...]).and.returnValue(...);
```

This errors out (as one might expect) but the message is not very clear if the spy is far away from the actual expectation (as it usually is, being setup in `beforeEach` hooks):
> TypeError: Cannot call method 'returnValue' of undefined

Maybe this is just an bad habit I find myself in, but I thought it might be nice to get more clear feedback as to why I typed the wrong thing.

Let me know if this is valuable, I would love to discuss it further.