### PR TITLE
Report skipped specs for disabled suites

### DIFF
--- a/spec/core/SuiteSpec.js
+++ b/spec/core/SuiteSpec.js
@@ -145,7 +145,7 @@ describe("Suite", function() {
 
   it("can be disabled, but still calls callbacks", function() {
     var env = new j$.Env(),
-      fakeQueueRunner = jasmine.createSpy('fake queue runner'),
+      fakeQueueRunner = function(attrs) { attrs.onComplete(); },
       onStart = jasmine.createSpy('onStart'),
       resultCallback = jasmine.createSpy('resultCallback'),
       onComplete = jasmine.createSpy('onComplete'),
@@ -163,7 +163,6 @@ describe("Suite", function() {
 
     suite.execute(onComplete);
 
-    expect(fakeQueueRunner).not.toHaveBeenCalled();
     expect(onStart).toHaveBeenCalled();
     expect(resultCallback).toHaveBeenCalled();
     expect(onComplete).toHaveBeenCalled();
@@ -303,7 +302,7 @@ describe("Suite", function() {
     });
   });
 
-  it("calls a provided result callback with status being disabled when disabled and done", function() {
+  it("calls a provided result callback with status being disabled when suite is disabled and done", function() {
     var env = new j$.Env(),
       suiteResultsCallback = jasmine.createSpy('suite result callback'),
       fakeQueueRunner = function(attrs) { attrs.onComplete(); },
@@ -314,12 +313,17 @@ describe("Suite", function() {
         resultCallback: suiteResultsCallback
       }),
       fakeSpec1 = {
-        execute: jasmine.createSpy('fakeSpec1')
+          disable: jasmine.createSpy('fakeSpec1 disable'),
+          isExecutable: jasmine.createSpy('fakeSpec1 isExecutable').and.returnValue(false)
       };
 
+    suite.addChild(fakeSpec1);
+    
     suite.disable();
 
     suite.execute();
+    
+    expect(fakeSpec1.disable).toHaveBeenCalled();
 
     expect(suiteResultsCallback).toHaveBeenCalledWith({
       id: suite.id,

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -1177,8 +1177,11 @@ describe("Env integration", function() {
         totalSpecsDefined: 1
       });
 
-      expect(reporter.specDone).not.toHaveBeenCalled();
-      expect(reporter.suiteDone.calls.count()).toBe(3);
+      expect(reporter.specDone.calls.count()).toBe(1);
+      var specResult = reporter.specDone.calls.mostRecent().args[0];
+      expect(specResult.status).toBe("disabled");
+      
+      expect(reporter.suiteDone.calls.count()).toBe(4);
 
       done();
     });
@@ -1188,9 +1191,11 @@ describe("Env integration", function() {
     env.describe("A Suite", function() {
       env.describe("nested", function() {
         env.xdescribe("xd out", function() {
-          env.it("with a spec", function() {
-            env.expect(true).toBe(false);
-          });
+          env.describe('nested again', function() {
+            env.it("with a spec", function() {
+              env.expect(true).toBe(false);
+            });
+          })
         });
       });
     });

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -83,15 +83,14 @@ getJasmineRequireObj().Suite = function() {
 
     this.onStart(this);
 
-    if (this.disabled) {
-      complete();
-      return;
-    }
-
     var allFns = [];
 
     for (var i = 0; i < this.children.length; i++) {
-      allFns.push(wrapChildAsAsync(this.children[i]));
+      var child = this.children[i];
+      if (this.disabled) {
+        child.disable();
+      }
+      allFns.push(wrapChildAsAsync(child));
     }
 
     if (this.isExecutable()) {


### PR DESCRIPTION
My attempt at addressing #774 as I too would like to be able to report which specs are skipped as the result of an `xdescribe`.