### PR TITLE
Support `jasmine.getEnv().done()` to mark an async test as done outside of the current test lexical scope

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -450,6 +450,7 @@ getJasmineRequireObj().Env = function(j$) {
     var runnableResources = {};
 
     var currentSpec = null;
+    var currentQueueRunner = null;
     var currentlyExecutingSuites = [];
     var currentDeclarationSuite = null;
 
@@ -605,7 +606,8 @@ getJasmineRequireObj().Env = function(j$) {
       options.timer = {setTimeout: realSetTimeout, clearTimeout: realClearTimeout};
       options.fail = self.fail;
 
-      new j$.QueueRunner(options).execute();
+      currentQueueRunner = new j$.QueueRunner(options);
+      currentQueueRunner.execute();
     };
 
     var topSuite = new j$.Suite({
@@ -620,6 +622,10 @@ getJasmineRequireObj().Env = function(j$) {
 
     this.topSuite = function() {
       return topSuite;
+    };
+
+    this.done = function() {
+      return currentQueueRunner.done.apply(currentQueueRunner, arguments);
     };
 
     this.execute = function(runnablesToRun) {
@@ -1779,6 +1785,8 @@ getJasmineRequireObj().QueueRunner = function(j$) {
         self.fail.apply(null, arguments);
         next();
       };
+
+      self.done = next;
 
       if (queueableFn.timeout) {
         timeoutId = Function.prototype.apply.apply(self.timer.setTimeout, [j$.getGlobal(), [function() {

--- a/spec/core/QueueRunnerSpec.js
+++ b/spec/core/QueueRunnerSpec.js
@@ -115,6 +115,24 @@ describe("QueueRunner", function() {
       expect(queueableFn2.fn).toHaveBeenCalled();
     });
 
+    it("explicitly moves to the next test when public method done() is called on the QueueRunner interface", function() {
+      var queueableFn1 = { fn: function(done) {
+          setTimeout(function() { queueRunner.done(); }, 50);
+        } },
+        queueableFn2 = { fn: jasmine.createSpy('fn2') },
+        queueRunner = new j$.QueueRunner({
+          queueableFns: [queueableFn1, queueableFn2]
+        });
+
+      queueRunner.execute();
+
+      expect(queueableFn2.fn).not.toHaveBeenCalled();
+
+      jasmine.clock().tick(100);
+
+      expect(queueableFn2.fn).toHaveBeenCalled();
+    });
+
     it("sets a timeout if requested for asynchronous functions so they don't go on forever", function() {
       var timeout = 3,
         beforeFn = { fn: function(done) { }, type: 'before', timeout: function() { return timeout; } },

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -888,6 +888,34 @@ describe("Env integration", function() {
       env.execute();
     });
 
+    it("should proceed if done is called on the environment using jasmine.getEnv().done()", function(done) {
+      var env = new j$.Env(),
+          reporter = jasmine.createSpyObj('fakeReport', ['specDone']),
+          passed = [];
+
+      reporter.specDone.and.callFake(function(results) {
+        if (results.status === 'passed') { passed.push(results); }
+        if (passed.length == 2) { done(); }
+      });
+
+      env.addReporter(reporter);
+      j$.DEFAULT_TIMEOUT_INTERVAL = 3000;
+
+      env.describe('a suite', function() {
+        env.it('async with environment done()', function(done) {
+          expect(true).toBe(true);
+          env.done();
+        });
+
+        env.it('async with argument done', function(done) {
+          expect(true).toBe(true);
+          done();
+        })
+      });
+
+      env.execute();
+    });
+
     it('should wait a custom interval before reporting async functions that fail to call done', function(done) {
       var env = new j$.Env(),
           reporter = jasmine.createSpyObj('fakeReport', ['jasmineDone', 'suiteDone', 'specDone']);

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -17,6 +17,7 @@ getJasmineRequireObj().Env = function(j$) {
     var runnableResources = {};
 
     var currentSpec = null;
+    var currentQueueRunner = null;
     var currentlyExecutingSuites = [];
     var currentDeclarationSuite = null;
 
@@ -172,7 +173,8 @@ getJasmineRequireObj().Env = function(j$) {
       options.timer = {setTimeout: realSetTimeout, clearTimeout: realClearTimeout};
       options.fail = self.fail;
 
-      new j$.QueueRunner(options).execute();
+      currentQueueRunner = new j$.QueueRunner(options);
+      currentQueueRunner.execute();
     };
 
     var topSuite = new j$.Suite({
@@ -187,6 +189,10 @@ getJasmineRequireObj().Env = function(j$) {
 
     this.topSuite = function() {
       return topSuite;
+    };
+
+    this.done = function() {
+      return currentQueueRunner.done.apply(currentQueueRunner, arguments);
     };
 
     this.execute = function(runnablesToRun) {

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -70,6 +70,8 @@ getJasmineRequireObj().QueueRunner = function(j$) {
         next();
       };
 
+      self.done = next;
+
       if (queueableFn.timeout) {
         timeoutId = Function.prototype.apply.apply(self.timer.setTimeout, [j$.getGlobal(), [function() {
           var error = new Error('Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.');


### PR DESCRIPTION
There are numerous examples where an external bit of Javascript knows the test has failed and wants the test to fail immediately.  The `jasmine.getEnv().fail()` command is useful, however it does not cause an async test to stop so you have to wait for it to timeout.  This is incredibly inefficient for large test suites.

This fork is now being used locally and it has had my test suite far less verbose because my `fail()` handler called from anywhere can instruct the currently running async methods to be marked as done.