### PR TITLE
Don't use hardcoded temporary directory paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "grunt-contrib-jshint": "~0.7.0",
     "jasmine": "https://github.com/jasmine/jasmine-npm/archive/master.tar.gz",
     "load-grunt-tasks": "^0.4.0",
-    "shelljs": "~0.1.4"
+    "shelljs": "~0.1.4",
+    "temp": "~0.8.1"
   }
 }

--- a/spec/npmPackage/npmPackageSpec.js
+++ b/spec/npmPackage/npmPackageSpec.js
@@ -1,5 +1,6 @@
 describe('npm package', function() {
   var path = require('path'),
+      temp = require('temp').track(),
       fs = require('fs');
 
   beforeAll(function() {
@@ -7,9 +8,7 @@ describe('npm package', function() {
         pack = shell.exec('npm pack', { silent: true });
 
     this.tarball = pack.output.split('\n')[0];
-    this.tmpDir = '/tmp/jasmine-core';
-
-    fs.mkdirSync(this.tmpDir);
+    this.tmpDir = temp.mkdirSync(); // automatically deleted on exit
 
     var untar = shell.exec('tar -xzf ' + this.tarball + ' -C ' + this.tmpDir, { silent: true });
     expect(untar.code).toBe(0);
@@ -44,8 +43,6 @@ describe('npm package', function() {
     };
 
     fs.unlink(this.tarball);
-    fs.readdirSync(this.tmpDir).forEach(cleanup.bind(null, this.tmpDir));
-    fs.rmdirSync(this.tmpDir);
   });
 
   it('has a root path', function() {


### PR DESCRIPTION
npmPackageSpec.js used a hardcoded temporary directory path /tmp/jasmine-core. That caused the specs to fail if Jasmine was killed during a previous run. 