### PR TITLE
An order-independent Array matcher

### DIFF
--- a/spec/core/matchers/toContainAllSpec.js
+++ b/spec/core/matchers/toContainAllSpec.js
@@ -1,0 +1,107 @@
+describe("toContainAll", function () {
+  it("passes when all items are present", function () {
+    var util = { equals: j$.matchersUtil.equals };
+    var matcher = j$.matchers.toContainAll(util);
+
+    var result = matcher.compare([1, 2, 3], 1, 2, 3);
+    expect(result.pass).toBe(true);
+  });
+
+  it("passes with shuffled arrays", function () {
+    var util = { equals: j$.matchersUtil.equals };
+    var matcher = j$.matchers.toContainAll(util);
+
+    var result = matcher.compare([1, 2, 3], 3, 2, 1);
+    expect(result.pass).toBe(true);
+  });
+
+  it("passes with a valid subset", function () {
+    var util = { equals: j$.matchersUtil.equals };
+    var matcher = j$.matchers.toContainAll(util);
+    var result;
+
+    result = matcher.compare([1, 2, 3], 1, 2, 3);
+    expect(result.pass).toBe(true);
+
+    result = matcher.compare([1, 2, 3], 3, 1);
+    expect(result.pass).toBe(true);
+
+    result = matcher.compare([1, 2, 3], 2);
+    expect(result.pass).toBe(true);
+
+    result = matcher.compare([1, 2, 3]);
+    expect(result.pass).toBe(true);
+  });
+
+  it("handles arrays of mixed types", function () {
+    var util = { equals: j$.matchersUtil.equals };
+    var matcher = j$.matchers.toContainAll(util);
+    var result;
+
+    result = matcher.compare([10, /fuzzy/, "pickles"], /fuzzy/, 10);
+    expect(result.pass).toBe(true);
+
+    result = matcher.compare([1, '2', '3'], '2', '3', 1);
+    expect(result.pass).toBe(true);
+
+    result = matcher.compare([1, {foo: 2}, 3], 3, {foo: 2}, 1);
+    expect(result.pass).toBe(true);
+  });
+
+  it("handles duplicates", function () {
+    var util = { equals: j$.matchersUtil.equals };
+    var matcher = j$.matchers.toContainAll(util);
+    var result;
+
+    result = matcher.compare([1, 2, 3], 3, 3);
+    expect(result.pass).toBe(false);
+
+    result = matcher.compare([1, 2, 1, 2], 2, 2, 1);
+    expect(result.pass).toBe(true);
+  });
+
+  it("handles empty actual", function () {
+    var util = { equals: j$.matchersUtil.equals };
+    var matcher = j$.matchers.toContainAll(util);
+
+    var result = matcher.compare([], 3);
+    expect(result.pass).toBe(false);
+  });
+
+  it("handles captured arguments", function() {
+    var util = { equals: j$.matchersUtil.equals };
+    var matcher = j$.matchers.toContainAll(util);
+    var capturedArguments;
+
+    (function () {
+      capturedArguments = arguments;
+    })(1, 2);
+
+    var result = matcher.compare(capturedArguments, 1, 2);
+    expect(result.pass).toBe(true);
+  });
+
+  it("uses custom equality testers, if present", function () {
+    var util = { equals: j$.matchersUtil.equals };
+    var matcher = j$.matchers.toContainAll(util, [customTester]);
+    var actual = [{foo: 'bar'}];
+
+    function customTester(first, second) {
+      return first.bar === second.bar;
+    }
+
+    var result = matcher.compare(actual, {foo: 'bar', baz: 'quux'});
+    expect(result.pass).toBe(true);
+  });
+
+  it("throws an Error if passed a non-array actual", function () {
+    var util = { equals: j$.matchersUtil.equals };
+    var matcher = j$.matchers.toContainAll(util);
+
+    function bogusComparison() {
+      return matcher.compare('not an array', 1);
+    }
+
+    expect(bogusComparison).toThrowError("Expected an Array but got 'not an array'");
+  });
+});

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -29,6 +29,10 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
     return j$.isA_('Number', value);
   };
 
+  j$.isArguments_ = function(value) {
+    return j$.isA_('Arguments', value);
+  };
+
   j$.isA_ = function(typeName, value) {
     return Object.prototype.toString.apply(value) === '[object ' + typeName + ']';
   };

--- a/src/core/matchers/requireMatchers.js
+++ b/src/core/matchers/requireMatchers.js
@@ -11,6 +11,7 @@ getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
       'toBeTruthy',
       'toBeUndefined',
       'toContain',
+      'toContainAll',
       'toEqual',
       'toHaveBeenCalled',
       'toHaveBeenCalledWith',

--- a/src/core/matchers/toContainAll.js
+++ b/src/core/matchers/toContainAll.js
@@ -1,0 +1,57 @@
+getJasmineRequireObj().toContainAll = function() {
+  function toContainAll(util, customEqualityTesters) {
+    customEqualityTesters = customEqualityTesters || [];
+
+    return {
+      compare: function(actual) {
+        var expected = Array.prototype.slice.call(arguments, 1);
+
+        if (j$.isArguments_(actual)) {
+          actual = Array.prototype.slice.call(actual);
+        }
+
+        if (!j$.isArray_(actual)) {
+          throw new Error('Expected an Array but got ' + j$.pp(actual));
+        }
+
+        return {
+          pass: containsAll(actual, expected, customEqualityTesters)
+        };
+      }
+    };
+
+    function containsAll(haystack, needles, customEqualityTesters) {
+      var needle, hay;
+
+      if (needles.length > haystack.length) {
+        return false;
+      }
+
+      haystack = haystack.slice(0);
+
+      for (var n = 0; n < needles.length; n++) {
+        needle = needles[n];
+
+        for (var h = 0; h < haystack.length; h++) {
+          hay = haystack[h];
+          if (util.equals(hay, needle, customEqualityTesters)) {
+            deleteAtIndex(h, haystack);
+            break;
+          }
+          if (h === haystack.length - 1) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    }
+
+    function deleteAtIndex(index, arr) {
+      arr.splice(index, 1);
+      return arr;
+    }
+  }
+
+  return toContainAll;
+};


### PR DESCRIPTION
I was reading the discussion between @slackersoft, @logankd and others on #769 and became interested in a matcher that doesn't care about the order of items in an Array.  This type of matcher would be useful any time a person is dealing with an array holding a set-like collection of data.  Since JavaScript doesn't have a native set implementation, I find myself in this situation somewhat often.

Right now we have a few options for testing an Array being used as a set of items.  First, we can assert equality with the entire array.  This makes the spec brittle to implementation changes.  It also means we have to be thinking about initialization state while writing a spec about the side effects of a different method. In this example, "can load passengers" is trying to assert that Luke and Obi-Wan were loaded properly. We don't really care about the other people who were already on board.

``` javascript
describe("MilleniumFalcon", function() {
  beforeEach(function() {
    var ship = new MilleniumFalcon();
    expect(ship.peopleOnBoard()).toEqual(["Han", "Chewie"]);
  });

  it("can load passengers", function() {
    ship.loadPassenger("Luke");
    ship.loadPassenger("Obi-Wan");

    // This test needs to know the order of the people array, and will break
    // if that order changes in the future
    expect(ship.peopleOnBoard()).toEqual(["Han", "Chewie", "Luke", "Obi-Wan"]);
  });
});
```

To express this idea in a less brittle way, right now we need to write a long series of `toContain` expectations.  This works but is a lot of typing.

``` javascript
// How you might write the test today if you don't care about order
describe("MilleniumFalcon", function() {
  beforeEach(function() {
    var ship = new MilleniumFalcon();
    expect(ship.peopleOnBoard()).toContain("Han");
    expect(ship.peopleOnBoard()).toContain("Chewie");
  });

  it("can load passengers", function() {
    ship.loadPassenger("Luke");
    ship.loadPassenger("Obi-Wan");

    expect(ship.peopleOnBoard()).toContain("Luke");
    expect(ship.peopleOnBoard()).toContain("Obi-Wan");
  });
});

```

I would prefer to write something like this, with an order-independent array matcher:

``` javascript
describe("MilleniumFalcon", function() {
  beforeEach(function() {
    var ship = new MilleniumFalcon();
    expect(ship.peopleOnBoard()).toContainAll("Han", "Chewie");
  });

  it("can load passengers", function() {
    ship.loadPassenger("Luke");
    ship.loadPassenger("Obi-Wan");

    expect(ship.peopleOnBoard()).toContainAll("Luke", "Obi-Wan");

    // Some other valid statements might be:
    expect(ship.peopleOnBoard()).toContainAll("Luke", "Chewie", "Obi-Wan", "Han");
    expect(ship.peopleOnBoard()).toContainAll("Luke", "Chewie");
    expect(ship.peopleOnBoard()).toContainAll("Obi-Wan", "Luke");
  });
});
```

One especially concerning thing is that if you had a need like this and guessed that `toContain` accepts multiple arguments you would get **false positives**.  The current implementation ignores additional arguments.  To me, that's a pretty big violation of my expectations.

``` javascript
describe("Misleading toContain", function() {
  it("false positives", function() {
    expect([1,2,3]).toContain(1, 2, 3, 4); // landmine!
  });
});
```
### Specifically looking for feedback on these points

This PR is my work in progress.  I'm sure you'll have feedback, but I'm specifically looking for input on the following:
1. What should this be named? I've been using the working title `toContainAll`, but the more I think about it the more it feels like an extension of the current functionality in `toContain`.  I'd love to be able to write `expect([1,2,3]).toContain(3, 1)` and have it work in the expected way.  
   
   One drawback of changing/extending the behavior of the existing `toContain` matcher is that people working with legacy versions of jasmine may see examples of the new usage, try the new multi-argument syntax in their project, and think it's working for them when really they are getting the false-positive behavior described above.
   
   We might also want to think about how the name we choose might suggest related matchers in the future the way `toHaveBeenCalled` and `toHaveBeenCalledWith` naturally go together.
2. How should duplicates be handled? Keeping track of which items have already been _seen_ makes the implementation more difficult than simply mapping over the actual with `util.contains`, but I think it produces the least surprising results.

``` javascript
describe("duplicate handling", function() {
  it("should not allow double-counting", function() {
    expect([1,1]).toContainAll(1, 1);
    expect([1]).not.toContainAll(1,1);
  });
});
```
