### PR TITLE
Explicitly state the main JS

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
   ],
   "license": "MIT",
   "moduleType": "globals",
+  "main": "lib/jasmine-core.js",
   "ignore": [
     "**/.*",
     "dist",


### PR DESCRIPTION
# Problem

To bring this lib in using Sprockets, you must do this:

```javascript
//= require jasmine/lib/jasmine-core
```

Sprockets can read `bower.json` and, if `main` is explicitly stated in the file, you can do the much more future-proof and compact:


```javascript
//= require jasmine
```

# Solution

Explicitly specify it.

# Caveats

I am not super-versed in Bower or JS packaging, so this is proposed in the vein of "this fixes my problem and seems consistent with other JS libs I've looked at", but I'm open to other solutions.