### PR TITLE
Alias toBeFalsy/toBeFalsey to allow for both wording styles.

### DIFF
--- a/spec/core/matchers/toBeFalsySpec.js
+++ b/spec/core/matchers/toBeFalsySpec.js
@@ -1,38 +1,46 @@
 describe("toBeFalsy", function() {
-  it("passes for 'falsy' values", function() {
-    var matcher = j$.matchers.toBeFalsy(),
-      result;
 
-    result = matcher.compare(false);
-    expect(result.pass).toBe(true);
+  function test(matcher) {
+    it("passes for 'falsy' values", function() {
+      var result;
 
-    result = matcher.compare(0);
-    expect(result.pass).toBe(true);
+      result = matcher.compare(false);
+      expect(result.pass).toBe(true);
 
-    result = matcher.compare('');
-    expect(result.pass).toBe(true);
+      result = matcher.compare(0);
+      expect(result.pass).toBe(true);
 
-    result = matcher.compare(null);
-    expect(result.pass).toBe(true);
+      result = matcher.compare('');
+      expect(result.pass).toBe(true);
 
-    result = matcher.compare(void 0);
-    expect(result.pass).toBe(true);
+      result = matcher.compare(null);
+      expect(result.pass).toBe(true);
+
+      result = matcher.compare(void 0);
+      expect(result.pass).toBe(true);
+    });
+
+    it("fails for 'truthy' values", function() {
+      var result;
+
+      result = matcher.compare(true);
+      expect(result.pass).toBe(false);
+
+      result = matcher.compare(1);
+      expect(result.pass).toBe(false);
+
+      result = matcher.compare("foo");
+      expect(result.pass).toBe(false);
+
+      result = matcher.compare({});
+      expect(result.pass).toBe(false);
+    });
+  }
+
+  test(j$.matchers.toBeFalsy());
+
+  describe('with toBeFalsey alias', function() {
+    test(j$.matchers.toBeFalsey());
   });
 
-  it("fails for 'truthy' values", function() {
-    var matcher = j$.matchers.toBeFalsy(),
-      result;
-
-    result = matcher.compare(true);
-    expect(result.pass).toBe(false);
-
-    result = matcher.compare(1);
-    expect(result.pass).toBe(false);
-
-    result = matcher.compare("foo");
-    expect(result.pass).toBe(false);
-
-    result = matcher.compare({});
-    expect(result.pass).toBe(false);
-  });
 });

--- a/src/core/matchers/requireMatchers.js
+++ b/src/core/matchers/requireMatchers.js
@@ -4,6 +4,7 @@ getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
       'toBeCloseTo',
       'toBeDefined',
       'toBeFalsy',
+      'toBeFalsey',
       'toBeGreaterThan',
       'toBeLessThan',
       'toBeNaN',

--- a/src/core/matchers/toBeFalsy.js
+++ b/src/core/matchers/toBeFalsy.js
@@ -11,3 +11,5 @@ getJasmineRequireObj().toBeFalsy = function() {
 
   return toBeFalsy;
 };
+
+getJasmineRequireObj().toBeFalsey = getJasmineRequireObj().toBeFalsy;


### PR DESCRIPTION
There are many developers who use the wording 'falsy' and many others who use the wording 'falsey'. 

* http://english.stackexchange.com/questions/109996/is-it-falsy-or-falsey
* https://gist.github.com/jfarmer/2647362

Jasmine provides a 'toBeFalsy' matcher. It's easy to get it wrong and expect 'toBeFalsey' to work as well. This pull is to allow either to be used in jasmine:

    toBeFalsy()
    toBeFalsey()
