### PR TITLE
Make the Bower package use browser-friendly files.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   ],
   "license": "MIT",
   "moduleType": "globals",
-  "main": "lib/jasmine-core.js",
+  "main": "lib/jasmine-core/jasmine.js",
   "ignore": [
     "**/.*",
     "dist",


### PR DESCRIPTION
The reason I am submitting this pull request is that release v2.3.0 caused Jasmine not to load at all in my project.

I'm using [Rails Assets](https://rails-assets.org/), which is basically a proxy that makes Ruby gems out of Bower packages. Part of the way it works is using the `main` field in `bower.json` to determine which files should be included in the package. If the field is absent, it tries to detect the files automatically.

Now, #827 pointed `bower.json`'s `main` field to `lib/jasmine-core.js`, which is not meant to be used with browsers, with all its `module.exports` and `fs` stuff. I believe that it is incorrect, given that Bower is a strongly front-end oriented package manager. And because there are so many ways to develop front-end stuff, it should (and does) not assume anything about the development pipeline.

With all that in mind, I propose to change the `main` field to `lib/jasmine-core/jasmine.js`. It allows to use Jasmine directly with browsers, fitting well into the Bower ecosystem. In addition to that, this will fix the Rails Assets package, allowing its users to just `//= require jasmine`.