### PR TITLE
Remove dead CSS class styles

### DIFF
--- a/src/html/_HTMLReporter.scss
+++ b/src/html/_HTMLReporter.scss
@@ -255,38 +255,6 @@ body {
     margin-top: $line-height;
   }
 
-  //--- Results menu ---//
-
-  &.showDetails {
-
-    .summaryMenuItem {
-      font-weight: normal;
-      text-decoration: inherit;
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
-
-    .detailsMenuItem {
-      font-weight: bold;
-      text-decoration: underline;
-    }
-
-    .summary {
-      display: none;
-    }
-
-    #details {
-      display: block;
-    }
-  }
-
-  .summaryMenuItem {
-    font-weight: bold;
-    text-decoration: underline;
-  }
-
   //--- Results summary: Suites and Specs names/links ---//
 
   .summary {


### PR DESCRIPTION
I removed the `.showDetails` and `.summaryMenuItem` styles from the Sass
file because I believe that no HTML elements with those classes will
ever be generated by Jasmine and that they are dead code that someone
forgot to remove.

This is my first contribution to the Jasmine project and so I might be
doing something wrong, but I believe just this one change will propagate
to all the generated code when it is built, and that I should not be
altering any other code in any other place to accomplish the change I
intend.

This is related to Jasmine Issue 847:
https://github.com/jasmine/jasmine/issues/847