### PR TITLE
Raise an error when jasmine.any() isn't passed a constructor

### DIFF
--- a/spec/core/asymmetric_equality/AnySpec.js
+++ b/spec/core/asymmetric_equality/AnySpec.js
@@ -42,4 +42,11 @@ describe("Any", function() {
     expect(any.jasmineToString()).toEqual('<jasmine.any(Number)>');
   });
 
+  describe("when called without an argument", function() {
+    it("tells the user to pass a constructor or use jasmine.anything()", function() {
+      expect(function() {
+        new j$.Any();
+      }).toThrowError(TypeError, /constructor.*anything/);
+    });
+  });
 });

--- a/src/core/asymmetric_equality/Any.js
+++ b/src/core/asymmetric_equality/Any.js
@@ -1,6 +1,12 @@
 getJasmineRequireObj().Any = function(j$) {
 
   function Any(expectedObject) {
+    if (typeof expectedObject === 'undefined') {
+      throw new TypeError(
+        'jasmine.any() expects to be passed a constructor function. ' +
+        'Please pass one or use jasmine.anything() to match any object.'
+      );
+    }
     this.expectedObject = expectedObject;
   }
 


### PR DESCRIPTION
This PR gives a more helpful error message when specs call `jasmine.any()` without passing a constructor function.  This is in relation to #852.

I think I followed contributing.md but let me know if I slipped up.