### PR TITLE
xdescribe marks pending, plus associated tests.

### DIFF
--- a/spec/core/SuiteSpec.js
+++ b/spec/core/SuiteSpec.js
@@ -90,6 +90,21 @@ describe("Suite", function() {
     expect(suite.getResult().status).toBe('disabled');
   });
 
+  it("retrieves a result with pending status", function() {
+    var suite = new j$.Suite({});
+    suite.pend();
+
+    expect(suite.getResult().status).toBe('pending');
+  });
+
+  it("priviledges a disabled status over pending status", function() {
+    var suite = new j$.Suite({});
+    suite.disable();
+    suite.pend();
+
+    expect(suite.getResult().status).toBe('disabled');
+  });
+
   it("is executable if not disabled", function() {
     var suite = new j$.Suite({});
 

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -261,13 +261,17 @@ getJasmineRequireObj().Env = function(j$) {
 
     this.describe = function(description, specDefinitions) {
       var suite = suiteFactory(description);
+      if (currentDeclarationSuite.markedPending) {
+        suite.pend();
+      }
       addSpecsToSuite(suite, specDefinitions);
       return suite;
     };
 
     this.xdescribe = function(description, specDefinitions) {
-      var suite = this.describe(description, specDefinitions);
-      suite.disable();
+      var suite = suiteFactory(description);
+      suite.pend();
+      addSpecsToSuite(suite, specDefinitions);
       return suite;
     };
 
@@ -373,6 +377,9 @@ getJasmineRequireObj().Env = function(j$) {
 
     this.it = function(description, fn, timeout) {
       var spec = specFactory(description, fn, currentDeclarationSuite, timeout);
+      if (currentDeclarationSuite.markedPending) {
+        spec.pend();
+      }
       currentDeclarationSuite.addChild(spec);
       return spec;
     };
@@ -383,9 +390,9 @@ getJasmineRequireObj().Env = function(j$) {
       return spec;
     };
 
-    this.fit = function(){
-      var spec = this.it.apply(this, arguments);
-
+    this.fit = function(description, fn, timeout){
+      var spec = specFactory(description, fn, currentDeclarationSuite, timeout);
+      currentDeclarationSuite.addChild(spec);
       focusedRunnables.push(spec.id);
       unfocusAncestor();
       return spec;

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -42,6 +42,10 @@ getJasmineRequireObj().Suite = function(j$) {
     this.disabled = true;
   };
 
+  Suite.prototype.pend = function(message) {
+    this.markedPending = true;
+  };
+
   Suite.prototype.beforeEach = function(fn) {
     this.beforeFns.unshift(fn);
   };
@@ -65,6 +69,10 @@ getJasmineRequireObj().Suite = function(j$) {
   Suite.prototype.status = function() {
     if (this.disabled) {
       return 'disabled';
+    }
+
+    if (this.markedPending) {
+      return 'pending';
     }
 
     if (this.result.failedExpectations.length > 0) {


### PR DESCRIPTION
As discussed in issue https://github.com/jasmine/jasmine/issues/855.

Suites have a `.pend()` method, and pending propagates down to children (until hitting a focused item).  This is handled within `env`.  I did wonder if it should be handled by `TreeProcessor`?