### PR TITLE
Use badges from shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a name="README">[<img src="https://rawgithub.com/jasmine/jasmine/master/images/jasmine-horizontal.svg" width="400px" />](http://jasmine.github.io)</a>
 
-[![Build Status](https://travis-ci.org/jasmine/jasmine.png?branch=master)](https://travis-ci.org/jasmine/jasmine) [![Code Climate](https://codeclimate.com/github/pivotal/jasmine.png)](https://codeclimate.com/github/pivotal/jasmine)
+[![Build Status][travis-image]][travis-url] [![Code Climate][codeclimate-image]][codeclimate-url]
 
 =======
 
@@ -71,3 +71,9 @@ Jasmine tests itself across many browsers (Safari, Chrome, Firefox, PhantomJS, a
 * Sheel Choksi
 
 Copyright (c) 2008-2015 Pivotal Labs. This software is licensed under the MIT License.
+
+
+[travis-url]: https://travis-ci.org/jasmine/jasmine
+[travis-image]: https://img.shields.io/travis/jasmine/jasmine.svg
+[codeclimate-url]: https://codeclimate.com/github/pivotal/jasmine
+[codeclimate-image]: https://img.shields.io/codeclimate/github/pivotal/jasmine.svg


### PR DESCRIPTION
This change is mostly just switching to svg, which looks much better on HiDPI screens.
Also using shields.io for consistency.

A bit low-res screenshot, but a difference can be seen

![image](https://cloud.githubusercontent.com/assets/1404810/9149268/dcf54dc8-3da2-11e5-9ab6-1c9e2e2314b9.png)

![image](https://cloud.githubusercontent.com/assets/1404810/9149270/f01e0c6e-3da2-11e5-8e07-db315ed6f17c.png)

