### PR TITLE
Reverse suite afterEach behavior to match semantics?

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -558,7 +558,7 @@ getJasmineRequireObj().Env = function(j$) {
 
         while(suite) {
           befores = befores.concat(suite.beforeFns);
-          afters = afters.concat(suite.afterFns);
+          afters = afters.concat(suite.afterFns.reverse());
 
           suite = suite.parentSuite;
         }

--- a/spec/core/integration/SpecRunningSpec.js
+++ b/spec/core/integration/SpecRunningSpec.js
@@ -217,10 +217,10 @@ describe("jasmine spec running", function () {
         "beforeEach1",
         "beforeEach2",
         "outer it 1",
-        "afterEach2",
         "afterEach1",
-        "runner afterEach2",
-        "runner afterEach1"
+        "afterEach2",
+        "runner afterEach1",
+        "runner afterEach2"
       ];
       expect(actions).toEqual(expected);
       done();

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -108,7 +108,7 @@ getJasmineRequireObj().Env = function(j$) {
 
         while(suite) {
           befores = befores.concat(suite.beforeFns);
-          afters = afters.concat(suite.afterFns);
+          afters = afters.concat(suite.afterFns.reverse());
 
           suite = suite.parentSuite;
         }


### PR DESCRIPTION
Hi, thanks for the great library! I've noticed something which I have a question about.

If there are multiple `afterEach`es in a suite, they get run in reverse order of declaration. The current test `spec/core/integration/SpecRunningSpec.js` appends `afterEach2` before `afterEach1`, which is counter-intuitive to me since the test is named `"should run multiple befores and afters in the order they are declared"`.

I've made changes to the `Env` src file and the corresponding spec - what do you think about this behavior change?