### PR TITLE
Check for child before accessing property

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -2145,7 +2145,7 @@ getJasmineRequireObj().Suite = function(j$) {
   };
 
   function isAfterAll(children) {
-    return children && children[0].result.status;
+    return children && children[0] && children[0].result.status;
   }
 
   function isFailure(args) {


### PR DESCRIPTION
I'm encountering a crash in jasmine when there is no 0th child element. It should be checked before accessing the element.