### PR TITLE
Postpone find() until it is needed

### DIFF
--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -36,8 +36,6 @@ jasmineRequire.HtmlReporter = function(j$) {
         )
       );
       getContainer().appendChild(htmlReporterMain);
-
-      symbols = find('.jasmine-symbol-summary');
     };
 
     var totalSpecsDefined;
@@ -82,6 +80,10 @@ jasmineRequire.HtmlReporter = function(j$) {
         specsExecuted++;
       }
 
+      if (!symbols){
+        symbols = find('.jasmine-symbol-summary');
+      }
+      
       symbols.appendChild(createDom('li', {
           className: noExpectations(result) ? 'jasmine-empty' : 'jasmine-' + result.status,
           id: 'spec_' + result.id,


### PR DESCRIPTION
This is a fix for issue #917.

It seems that 'symbols' was originally included as a performance optimization, to avoid repeated find() calls for '.jasmine-symbol-summary'. However this find() occasionally fails during initialize if the dom has not loaded completely.

This change will not affect performance, as symbols is still cached. However it improves upon the original code in that the find happens at a stage much later than initialize.