### PR TITLE
Allow a fake default empty function for SpyStrategy.callFake()

### DIFF
--- a/spec/core/SpyStrategySpec.js
+++ b/spec/core/SpyStrategySpec.js
@@ -92,6 +92,19 @@ describe("SpyStrategy", function() {
     expect(returnValue).toEqual(67);
   });
 
+  it("allows a fake default empty function after another strategy", function () {
+    var originalFn = jasmine.createSpy("original"),
+        spyStrategy = new j$.SpyStrategy({fn: originalFn}),
+        returnValue;
+
+    spyStrategy.returnValue(135);
+    spyStrategy.callFake();
+    returnValue = spyStrategy.exec();
+
+    expect(originalFn).not.toHaveBeenCalled();
+    expect(returnValue).toBeUndefined();
+  });
+
   it("allows a return to plan stubbing after another strategy", function() {
     var originalFn = jasmine.createSpy("original"),
         fakeFn = jasmine.createSpy("fake").and.returnValue(67),

--- a/src/core/SpyStrategy.js
+++ b/src/core/SpyStrategy.js
@@ -45,7 +45,7 @@ getJasmineRequireObj().SpyStrategy = function() {
     };
 
     this.callFake = function(fn) {
-      plan = fn;
+      plan = fn || function() {};
       return getSpy();
     };
 


### PR DESCRIPTION
This change allows you to use the `callFake` spy strategy parameterless. A default empty function (which is also the default spy strategy) is used instead. 