### PR TITLE
Random tests

### DIFF
--- a/grunt/config/concat.js
+++ b/grunt/config/concat.js
@@ -26,6 +26,7 @@ module.exports = {
       'src/core/base.js',
       'src/core/util.js',
       'src/core/Spec.js',
+      'src/core/Order.js',
       'src/core/Env.js',
       'src/core/JsApiReporter.js',
       'src/core/PrettyPrinter',

--- a/lib/jasmine-core/boot.js
+++ b/lib/jasmine-core/boot.js
@@ -85,6 +85,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     env: env,
     onRaiseExceptionsClick: function() { queryString.navigateWithNewParam("catch", !env.catchingExceptions()); },
     onThrowExpectationsClick: function() { queryString.navigateWithNewParam("throwFailures", !env.throwingExpectationFailures()); },
+    onRandomClick: function() { queryString.navigateWithNewParam("random", !env.randomTests()); },
     addToExistingQueryString: function(key, value) { return queryString.fullStringWithNewParam(key, value); },
     getContainer: function() { return document.body; },
     createElement: function() { return document.createElement.apply(document, arguments); },

--- a/lib/jasmine-core/boot/boot.js
+++ b/lib/jasmine-core/boot/boot.js
@@ -55,6 +55,14 @@
   var throwingExpectationFailures = queryString.getParam("throwFailures");
   env.throwOnExpectationFailure(throwingExpectationFailures);
 
+  var random = queryString.getParam("random");
+  env.randomizeTests(random);
+
+  var seed = queryString.getParam("seed");
+  if (seed) {
+    env.seed(seed);
+  }
+
   /**
    * ## Reporters
    * The `HtmlReporter` builds all of the HTML UI for the runner page. This reporter paints the dots, stars, and x's for specs, as well as all spec names and all failures (if any).
@@ -63,6 +71,7 @@
     env: env,
     onRaiseExceptionsClick: function() { queryString.navigateWithNewParam("catch", !env.catchingExceptions()); },
     onThrowExpectationsClick: function() { queryString.navigateWithNewParam("throwFailures", !env.throwingExpectationFailures()); },
+    onRandomClick: function() { queryString.navigateWithNewParam("random", !env.randomTests()); },
     addToExistingQueryString: function(key, value) { return queryString.fullStringWithNewParam(key, value); },
     getContainer: function() { return document.body; },
     createElement: function() { return document.createElement.apply(document, arguments); },

--- a/spec/core/TreeProcessorSpec.js
+++ b/spec/core/TreeProcessorSpec.js
@@ -690,4 +690,67 @@ describe("TreeProcessor", function() {
     queueableFns[10].fn();
     expect(leaf11.execute).toHaveBeenCalled();
   });
+
+  it("runs nodes in a custom order when orderChildren is overrided", function() {
+    var leaf1 = new Leaf(),
+        leaf2 = new Leaf(),
+        leaf3 = new Leaf(),
+        leaf4 = new Leaf(),
+        leaf5 = new Leaf(),
+        leaf6 = new Leaf(),
+        leaf7 = new Leaf(),
+        leaf8 = new Leaf(),
+        leaf9 = new Leaf(),
+        leaf10 = new Leaf(),
+        leaf11 = new Leaf(),
+        root = new Node({ children: [leaf1, leaf2, leaf3, leaf4, leaf5, leaf6, leaf7, leaf8, leaf9, leaf10, leaf11] }),
+        queueRunner = jasmine.createSpy('queueRunner'),
+        processor = new j$.TreeProcessor({
+          tree: root,
+          runnableIds: [root.id],
+          queueRunnerFactory: queueRunner,
+          orderChildren: function(node) {
+            var children = node.children.slice();
+            return children.reverse();
+          }
+        });
+
+    processor.execute();
+    var queueableFns = queueRunner.calls.mostRecent().args[0].queueableFns;
+    expect(queueableFns.length).toBe(11);
+
+    queueableFns[0].fn();
+    expect(leaf11.execute).toHaveBeenCalled();
+
+    queueableFns[1].fn();
+    expect(leaf10.execute).toHaveBeenCalled();
+
+    queueableFns[2].fn();
+    expect(leaf9.execute).toHaveBeenCalled();
+
+    queueableFns[3].fn();
+    expect(leaf8.execute).toHaveBeenCalled();
+
+    queueableFns[4].fn();
+    expect(leaf7.execute).toHaveBeenCalled();
+
+    queueableFns[5].fn();
+    expect(leaf6.execute).toHaveBeenCalled();
+
+    queueableFns[6].fn();
+    expect(leaf5.execute).toHaveBeenCalled();
+
+    queueableFns[7].fn();
+    expect(leaf4.execute).toHaveBeenCalled();
+
+    queueableFns[8].fn();
+    expect(leaf3.execute).toHaveBeenCalled();
+
+    queueableFns[9].fn();
+    expect(leaf2.execute).toHaveBeenCalled();
+
+    queueableFns[10].fn();
+    expect(leaf1.execute).toHaveBeenCalled();
+
+  });
 });

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -207,7 +207,6 @@ describe("Env integration", function() {
     var env = new j$.Env();
 
     env.addReporter({jasmineDone: done});
-
     env.describe("tests", function() {
       var firstTimeThrough = true, firstSpecContext, secondSpecContext;
 

--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -556,6 +556,142 @@ describe("New HtmlReporter", function() {
       });
     });
 
+    describe("UI for running tests in random order", function() {
+      it("should be unchecked if not randomizing", function() {
+        var env = new j$.Env(),
+          container = document.createElement("div"),
+          getContainer = function() {
+            return container;
+          },
+          reporter = new j$.HtmlReporter({
+            env: env,
+            getContainer: getContainer,
+            createElement: function() {
+              return document.createElement.apply(document, arguments);
+            },
+            createTextNode: function() {
+              return document.createTextNode.apply(document, arguments);
+            }
+          });
+
+        reporter.initialize();
+        reporter.jasmineDone({});
+
+        var randomUI = container.querySelector(".jasmine-random");
+        expect(randomUI.checked).toBe(false);
+      });
+
+      it("should be checked if randomizing", function() {
+        var env = new j$.Env(),
+          container = document.createElement("div"),
+          getContainer = function() {
+            return container;
+          },
+          reporter = new j$.HtmlReporter({
+            env: env,
+            getContainer: getContainer,
+            createElement: function() {
+              return document.createElement.apply(document, arguments);
+            },
+            createTextNode: function() {
+              return document.createTextNode.apply(document, arguments);
+            }
+          });
+
+        env.randomizeTests(true);
+        reporter.initialize();
+        reporter.jasmineDone({});
+
+        var throwingExpectationsUI = container.querySelector(".jasmine-random");
+        expect(throwingExpectationsUI.checked).toBe(true);
+      });
+
+      it("should affect the query param for random tests", function() {
+        var env = new j$.Env(),
+          container = document.createElement("div"),
+          randomHandler = jasmine.createSpy('randomHandler'),
+          getContainer = function() {
+            return container;
+          },
+          reporter = new j$.HtmlReporter({
+            env: env,
+            getContainer: getContainer,
+            onRandomClick: randomHandler,
+            createElement: function() {
+              return document.createElement.apply(document, arguments);
+            },
+            createTextNode: function() {
+              return document.createTextNode.apply(document, arguments);
+            }
+          });
+
+        reporter.initialize();
+        reporter.jasmineDone({});
+
+        var randomUI = container.querySelector(".jasmine-random");
+        randomUI.click();
+
+        expect(randomHandler).toHaveBeenCalled();
+      });
+
+      it("should show the seed bar if randomizing", function() {
+        var env = new j$.Env(),
+            container = document.createElement("div"),
+            getContainer = function() {
+              return container;
+            },
+            reporter = new j$.HtmlReporter({
+              env: env,
+              getContainer: getContainer,
+              createElement: function() {
+                return document.createElement.apply(document, arguments);
+              },
+              createTextNode: function() {
+                return document.createTextNode.apply(document, arguments);
+              }
+            });
+
+        reporter.initialize();
+        reporter.jasmineDone({
+          order: {
+            random: true,
+            seed: '424242'
+          }
+        });
+
+        var seedBar = container.querySelector(".jasmine-seed-bar");
+        var seedBarText = 'textContent' in seedBar ? seedBar.textContent : seedBar.innerText;
+        expect(seedBarText).toBe(', randomized with seed 424242');
+        var seedLink = container.querySelector(".jasmine-seed-bar a");
+        expect(seedLink.getAttribute('href')).toBe('?seed=424242');
+      });
+
+      it("should not show the current seed bar if not randomizing", function() {
+        var env = new j$.Env(),
+            container = document.createElement("div"),
+            getContainer = function() {
+              return container;
+            },
+            reporter = new j$.HtmlReporter({
+              env: env,
+              getContainer: getContainer,
+              createElement: function() {
+                return document.createElement.apply(document, arguments);
+              },
+              createTextNode: function() {
+                return document.createTextNode.apply(document, arguments);
+              }
+            });
+
+        reporter.initialize();
+        reporter.jasmineDone();
+
+        var seedBar = container.querySelector(".jasmine-seed-bar");
+        expect(seedBar).toBeNull();
+      });
+
+    });
+
     it("shows a message if no specs are run", function(){
       var env, container, reporter;
       env = new j$.Env();

--- a/src/core/Order.js
+++ b/src/core/Order.js
@@ -1,0 +1,46 @@
+/*jshint bitwise: false*/
+
+getJasmineRequireObj().Order = function() {
+  function Order(options) {
+    this.random = 'random' in options ? options.random : true;
+    var seed = this.seed = options.seed || generateSeed();
+    this.sort = this.random ? randomOrder : naturalOrder;
+
+    function naturalOrder(items) {
+      return items;
+    }
+
+    function randomOrder(items) {
+      var copy = items.slice();
+      copy.sort(function(a, b) {
+        return jenkinsHash(seed + a.id) - jenkinsHash(seed + b.id);
+      });
+      return copy;
+    }
+
+    function generateSeed() {
+      return String(Math.random()).slice(-5);
+    }
+
+    // Bob Jenkins One-at-a-Time Hash algorithm is a non-cryptographic hash function
+    // used to get a different output when the key changes slighly.
+    // We use your return to sort the children randomly in a consistent way when
+    // used in conjunction with a seed
+
+    function jenkinsHash(key) {
+      var hash, i;
+      for(hash = i = 0; i < key.length; ++i) {
+        hash += key.charCodeAt(i);
+        hash += (hash << 10);
+        hash ^= (hash >> 6);
+      }
+      hash += (hash << 3);
+      hash ^= (hash >> 11);
+      hash += (hash << 15);
+      return hash;
+    }
+
+  }
+
+  return Order;
+};

--- a/src/core/TreeProcessor.js
+++ b/src/core/TreeProcessor.js
@@ -5,6 +5,7 @@ getJasmineRequireObj().TreeProcessor = function() {
         queueRunnerFactory = attrs.queueRunnerFactory,
         nodeStart = attrs.nodeStart || function() {},
         nodeComplete = attrs.nodeComplete || function() {},
+        orderChildren = attrs.orderChildren || function(node) { return node.children; },
         stats = { valid: true },
         processed = false,
         defaultMin = Infinity,
@@ -68,8 +69,10 @@ getJasmineRequireObj().TreeProcessor = function() {
       } else {
         var hasExecutableChild = false;
 
-        for (var i = 0; i < node.children.length; i++) {
-          var child = node.children[i];
+        var orderedChildren = orderChildren(node);
+
+        for (var i = 0; i < orderedChildren.length; i++) {
+          var child = orderedChildren[i];
 
           processNode(child, parentEnabled);
 
@@ -86,7 +89,7 @@ getJasmineRequireObj().TreeProcessor = function() {
           executable: hasExecutableChild
         };
 
-        segmentChildren(node, stats[node.id], executableIndex);
+        segmentChildren(node, orderedChildren, stats[node.id], executableIndex);
 
         if (!node.canBeReentered() && stats[node.id].segments.length > 1) {
           stats = { valid: false };
@@ -102,11 +105,11 @@ getJasmineRequireObj().TreeProcessor = function() {
       return executableIndex === undefined ? defaultMax : executableIndex;
     }
 
-    function segmentChildren(node, nodeStats, executableIndex) {
+    function segmentChildren(node, orderedChildren, nodeStats, executableIndex) {
       var currentSegment = { index: 0, owner: node, nodes: [], min: startingMin(executableIndex), max: startingMax(executableIndex) },
           result = [currentSegment],
           lastMax = defaultMax,
-          orderedChildSegments = orderChildSegments(node.children);
+          orderedChildSegments = orderChildSegments(orderedChildren);
 
       function isSegmentBoundary(minIndex) {
         return lastMax !== defaultMax && minIndex !== defaultMin && lastMax < minIndex - 1;

--- a/src/core/requireCore.js
+++ b/src/core/requireCore.js
@@ -50,6 +50,7 @@ var getJasmineRequireObj = (function (jasmineGlobal) {
     j$.Timer = jRequire.Timer();
     j$.TreeProcessor = jRequire.TreeProcessor();
     j$.version = jRequire.version();
+    j$.Order = jRequire.Order();
 
     j$.matchers = jRequire.requireMatchers(jRequire, j$);
 

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -12,6 +12,7 @@ jasmineRequire.HtmlReporter = function(j$) {
       createTextNode = options.createTextNode,
       onRaiseExceptionsClick = options.onRaiseExceptionsClick || function() {},
       onThrowExpectationsClick = options.onThrowExpectationsClick || function() {},
+      onRandomClick = options.onRandomClick || function() {},
       addToExistingQueryString = options.addToExistingQueryString || defaultQueryString,
       timer = options.timer || noopTimer,
       results = [],
@@ -117,9 +118,10 @@ jasmineRequire.HtmlReporter = function(j$) {
       }
     };
 
-    this.jasmineDone = function() {
+    this.jasmineDone = function(doneResult) {
       var banner = find('.jasmine-banner');
       var alert = find('.jasmine-alert');
+      var order = doneResult && doneResult.order;
       alert.appendChild(createDom('span', {className: 'jasmine-duration'}, 'finished in ' + timer.elapsed() / 1000 + 's'));
 
       banner.appendChild(
@@ -139,7 +141,14 @@ jasmineRequire.HtmlReporter = function(j$) {
                 id: 'jasmine-throw-failures',
                 type: 'checkbox'
               }),
-              createDom('label', { className: 'jasmine-label', 'for': 'jasmine-throw-failures' }, 'stop spec on expectation failure'))
+              createDom('label', { className: 'jasmine-label', 'for': 'jasmine-throw-failures' }, 'stop spec on expectation failure')),
+            createDom('div', { className: 'jasmine-random-order' },
+              createDom('input', {
+                className: 'jasmine-random',
+                id: 'jasmine-random-order',
+                type: 'checkbox'
+              }),
+              createDom('label', { className: 'jasmine-label', 'for': 'jasmine-random-order' }, 'run tests in random order'))
           )
         ));
 
@@ -151,6 +160,10 @@ jasmineRequire.HtmlReporter = function(j$) {
       var throwCheckbox = find('#jasmine-throw-failures');
       throwCheckbox.checked = env.throwingExpectationFailures();
       throwCheckbox.onclick = onThrowExpectationsClick;
+
+      var randomCheckbox = find('#jasmine-random-order');
+      randomCheckbox.checked = env.randomTests();
+      randomCheckbox.onclick = onRandomClick;
 
       var optionsMenu = find('.jasmine-run-options'),
           optionsTrigger = optionsMenu.querySelector('.jasmine-trigger'),
@@ -185,7 +198,15 @@ jasmineRequire.HtmlReporter = function(j$) {
         statusBarMessage += 'No specs found';
       }
 
-      alert.appendChild(createDom('span', {className: statusBarClassName}, statusBarMessage));
+      var seedBar;
+      if (order && order.random) {
+        seedBar = createDom('span', {class: 'jasmine-seed-bar'},
+          ', randomized with seed ',
+          createDom('a', {title: 'randomized with seed ' + order.seed, href: seedHref(order.seed)}, order.seed)
+        );
+      }
+
+      alert.appendChild(createDom('span', {className: statusBarClassName}, statusBarMessage, seedBar));
 
       for(i = 0; i < failedSuites.length; i++) {
         var failedSuite = failedSuites[i];
@@ -314,6 +335,10 @@ jasmineRequire.HtmlReporter = function(j$) {
 
     function specHref(result) {
       return addToExistingQueryString('spec', result.fullName);
+    }
+
+    function seedHref(seed) {
+      return addToExistingQueryString('seed', seed);
     }
 
     function defaultQueryString(key, value) {


### PR DESCRIPTION
This is a ~~WIP~~ PR which enables random tests. Everything is working fine in the browser, I just need to add more tests. And also when running in the node console, display the seed used.

In the `HTMLReporter` a new option was added called `run tests in random order` and it's checked by default. This behavior is also handled by query params when `?random=true`.

In order to reproduce a random order in a consistent way, a seed is generated each time the tests run and passing `seed=myseed` will keep the order, like rspec does.

Let me know if you agree with these changes, and feel free to suggest changes.