### PR TITLE
Allow `xit` to take an optional message to display to the user

### DIFF
--- a/spec/core/EnvSpec.js
+++ b/spec/core/EnvSpec.js
@@ -19,6 +19,35 @@ describe("Env", function() {
     });
   });
 
+  describe('#xit', function() {
+    var spyPend, spyIt, pendingReason;
+    beforeEach(function() {
+      spyPend = jasmine.createSpy('pend');
+      spyIt = spyOn(env, 'it').and.returnValue({pend: spyPend});
+      pendingReason = 'pending spec reason';
+    });
+
+    it('can take a message argument and passes it to spec.pend', function() {
+      env.xit('pending spec description', function() {
+        expect(true).toEqual(true);
+      }, pendingReason);
+
+      expect(spyPend).toHaveBeenCalledWith(pendingReason);
+    });
+
+    it('can take a timeout and message', function() {
+      var pendingSpecDescription = 'pending spec description';
+      var timeout = 1000;
+      var specdFunction = function() {
+        expect(true).toEqual(true);
+      };
+      env.xit(pendingSpecDescription, specdFunction, timeout, pendingReason);
+
+      expect(spyIt).toHaveBeenCalledWith(pendingSpecDescription, specdFunction, timeout);
+      expect(spyPend).toHaveBeenCalledWith(pendingReason);
+    });
+  });
+
   describe("#topSuite", function() {
     it("returns the Jasmine top suite for users to traverse the spec tree", function() {
       var suite = env.topSuite();

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -385,8 +385,23 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.xit = function() {
-      var spec = this.it.apply(this, arguments);
-      spec.pend();
+      var description, fn, timeout, pendingReason;
+      description = arguments[0];
+      fn = arguments[1];
+
+      if(arguments.length === 3) {
+        if(typeof arguments[2] === 'string') {
+          pendingReason = arguments[2];
+        } else {
+          timeout = arguments[2];
+        }
+      } else if(arguments.length === 4) {
+        timeout = arguments[2];
+        pendingReason = arguments[3];
+      }
+
+      var spec = this.it.call(this, description, fn, timeout);
+      spec.pend(pendingReason);
       return spec;
     };
 


### PR DESCRIPTION
See #912.

This commit allows `xit` to take an optional message to display to the user. It also changes the default message for a pending spec from 'No reason given' to 'Temporarily disabled with xit.'

For example:
```
xit('pending spec', 'function() {
  expect(foo).toEqual(true)
}, 'Waiting on an implementation of `foo`');
```
would print
```
1) pending spec
  Waiting on an implementation of `foo`
```