### PR TITLE
Change #xit so that it will output a more BDD-style pending message

### DIFF
--- a/spec/core/EnvSpec.js
+++ b/spec/core/EnvSpec.js
@@ -45,4 +45,15 @@ describe("Env", function() {
       throwOnExpectationFailure: true
     }));
   });
+
+  describe('#xit', function() {
+    it('calls spec.pend with "Temporarily disabled with xit"', function() {
+      var pendSpy = jasmine.createSpy();
+      spyOn(env, 'it').and.returnValue({
+        pend: pendSpy
+      });
+      env.xit();
+      expect(pendSpy).toHaveBeenCalledWith('Temporarily disabled with xit');
+    });
+  });
 });

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -416,7 +416,7 @@ getJasmineRequireObj().Env = function(j$) {
 
     this.xit = function() {
       var spec = this.it.apply(this, arguments);
-      spec.pend();
+      spec.pend('Temporarily disabled with xit');
       return spec;
     };
 


### PR DESCRIPTION
Continuation of (#930)[https://github.com/jasmine/jasmine/pull/930].

I started this one line commit at Pivotal's hack day, like a month ago. Hopefully I've understood the feedback and made the right changes this time ;)

`#xit will now output 'Temporarily disabled with xit' as a pending message rather than 'No reason given.'
This PR does not change the behavior of #pend.`