### PR TITLE
Add ES6 Symbol Support to objectContaining

### DIFF
--- a/spec/core/asymmetric_equality/ObjectContainingSpec.js
+++ b/spec/core/asymmetric_equality/ObjectContainingSpec.js
@@ -86,4 +86,40 @@ describe("ObjectContaining", function() {
 
     expect(containing.asymmetricMatch(obj)).toBe(true);
   });
+
+  it("does match when the Symbol is present in the actual", function() {
+    var expected = {};
+    expected[Symbol.for('foo')] = 'fooVal';
+
+    var actual = {};
+    actual[Symbol.for('foo')] = 'fooVal';
+
+    var containing = new j$.ObjectContaining(expected);
+
+    expect(containing.asymmetricMatch(actual)).toBe(true);
+  });
+
+  it("does not match when the Symbol is present but the value is different in the actual", function() {
+    var expected = {};
+    expected[Symbol.for('foo')] = 'fooVal';
+
+    var actual = {};
+    actual[Symbol.for('foo')] = 'barVal';
+
+    var containing = new j$.ObjectContaining(expected);
+
+    expect(containing.asymmetricMatch(actual)).toBe(false);
+  });
+
+  it("does not match when the Symbol is not present in the actual", function() {
+    var expected = {};
+    expected[Symbol.for('foo')] = 'fooVal';
+
+    var actual = {};
+    actual['foo'] = 'fooVal';
+
+    var containing = new j$.ObjectContaining(expected);
+
+    expect(containing.asymmetricMatch(actual)).toBe(false);
+  });
 });

--- a/src/core/asymmetric_equality/ObjectContaining.js
+++ b/src/core/asymmetric_equality/ObjectContaining.js
@@ -28,10 +28,28 @@ getJasmineRequireObj().ObjectContaining = function(j$) {
     return hasProperty(getPrototype(obj), property);
   }
 
+  function getAllProperties(target) {
+    var properties = [];
+
+    for (var property in target) {
+      properties.push(property);
+    }
+
+    if (typeof Object.getOwnPropertySymbols === 'function') {
+      properties = properties.concat(Object.getOwnPropertySymbols(target));
+    }
+
+    return properties;
+  }
+
   ObjectContaining.prototype.asymmetricMatch = function(other) {
     if (typeof(this.sample) !== 'object') { throw new Error('You must provide an object to objectContaining, not \''+this.sample+'\'.'); }
 
-    for (var property in this.sample) {
+    var properties = getAllProperties(this.sample);
+
+    for (var i = 0; i < properties.length; i++) {
+      var property = properties[i];
+
       if (!hasProperty(other, property) ||
           !j$.matchersUtil.equals(this.sample[property], other[property])) {
         return false;


### PR DESCRIPTION
objectContaining will not detect ES6 Symbols in the expected object and use them for comparison