### PR TITLE
Abort spying when the target cannot be spied on

### DIFF
--- a/spec/core/SpyRegistrySpec.js
+++ b/spec/core/SpyRegistrySpec.js
@@ -37,6 +37,32 @@ describe("SpyRegistry", function() {
       }).toThrowError(/has already been spied upon/);
     });
 
+    it("checks if it can be spied upon", function() {
+      var scope = {};
+
+      function myFunc() {
+        return 1;
+      }
+
+      Object.defineProperty(scope, 'myFunc', {
+        get: function() {
+          return myFunc;
+        }
+      });
+
+      var spies = [],
+        spyRegistry = new j$.SpyRegistry({currentSpies: function() { return spies; }}),
+        subject = { spiedFunc: scope.myFunc };
+
+      expect(function() {
+        spyRegistry.spyOn(scope, 'myFunc');
+      }).toThrowError(/is not declared writable or has no setter/);
+
+      expect(function() {
+        spyRegistry.spyOn(subject, 'spiedFunc');
+      }).not.toThrowError(/is not declared writable or has no setter/);
+    });
+
     it("overrides the method on the object and returns the spy", function() {
       var originalFunctionWasCalled = false,
         spyRegistry = new j$.SpyRegistry(),

--- a/src/core/SpyRegistry.js
+++ b/src/core/SpyRegistry.js
@@ -22,6 +22,11 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
         throw new Error(methodName + ' has already been spied upon');
       }
 
+      var descriptor = Object.getOwnPropertyDescriptor(obj, methodName);
+      if (!(descriptor.writable || descriptor.set)) {
+        throw new Error(methodName + ' is not declared writable or has no setter');
+      }
+
       var spy = j$.createSpy(methodName, obj[methodName]);
 
       currentSpies().push({


### PR DESCRIPTION
Adds a check for issue #948 and assures that the system does not hang on a TypeError.