### PR TITLE
Added "returnModified" spyStrategy

### DIFF
--- a/spec/core/SpyStrategySpec.js
+++ b/spec/core/SpyStrategySpec.js
@@ -46,6 +46,29 @@ describe("SpyStrategy", function() {
     expect(returnValue).toEqual(17);
   });
 
+  it("can return a modified result of original function when executed", function() {
+    var originalFn = jasmine.createSpy("original").and.returnValue({
+          a: 1,
+          b: 2
+        }),
+        spyStrategy = new j$.SpyStrategy({fn: originalFn}),
+        returnValue;
+
+    spyStrategy.returnModified(function(originalValue){
+      originalValue.a = 3;
+      originalValue.c = 1;
+      return originalValue;
+    });
+    returnValue = spyStrategy.exec();
+
+    expect(originalFn).toHaveBeenCalled();
+    expect(returnValue).toEqual({
+      a: 3,
+      b: 2,
+      c: 1
+    });
+  });
+
   it("can return specified values in order specified when executed", function() {
     var originalFn = jasmine.createSpy("original"),
         spyStrategy = new j$.SpyStrategy({fn: originalFn});

--- a/src/core/SpyStrategy.js
+++ b/src/core/SpyStrategy.js
@@ -36,6 +36,16 @@ getJasmineRequireObj().SpyStrategy = function() {
       return getSpy();
     };
 
+    this.returnModified = function(fn){
+      plan = function(){
+        var args = Array.prototype.slice.call(arguments),
+            originalReturnValue = originalFn.apply(this, args);
+
+        return fn(originalReturnValue);
+      };
+      return getSpy();
+    };
+
     this.throwError = function(something) {
       var error = (something instanceof Error) ? something : new Error(something);
       plan = function() {


### PR DESCRIPTION
While recently creating a lot of unit tests i lacked:
- ability to easily use original return value of function but with slight changes (and usually different over multiple tests)
- ... without additional (repeatable over tests) lines of code / pre-created mock data.

So I created it ;) 
And hope You will also like it.