### PR TITLE
Avoid overriding 'expect' messages when 'expect' passes

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1556,7 +1556,7 @@ getJasmineRequireObj().buildExpectationResult = function() {
     return result;
 
     function message() {
-      if (options.passed) {
+      if (options.passed && !options.message) {
         return 'Passed.';
       } else if (options.message) {
         return options.message;


### PR DESCRIPTION
When using jasmine reporters it would be nice if we could also see the messages from those 'expects' that passed. 

In case that the 'expect' doesn't provide a message, we could set it to 'Passed.' (current behaviour for all passed 'expects') but if message is provided we should populate it instead of overriding it with 'Passed'.