### PR TITLE
Fix #915 - Make DelayedFunctionScheduler update the mockDate

### DIFF
--- a/spec/core/ClockSpec.js
+++ b/spec/core/ClockSpec.js
@@ -652,4 +652,23 @@ describe("Clock (acceptance)", function() {
 
     expect(timeoutDate).toEqual(baseTime.getTime() + 150);
   });
+  
+  it("mocks the Date object and updates the date per delayed function", function () {
+    var delayedFunctionScheduler = new j$.DelayedFunctionScheduler(),
+      global = {Date: Date},
+      mockDate = new j$.MockDate(global),
+      clock = new j$.Clock({setTimeout: setTimeout}, function () { return delayedFunctionScheduler; }, mockDate),
+      baseTime = new Date();
+      
+    clock.install().mockDate(baseTime);
+    
+    var actualTimes = [];
+    var pushCurrentTime = function() { actualTimes.push(global.Date().getTime()); };
+    delayedFunctionScheduler.scheduleFunction(pushCurrentTime);
+    delayedFunctionScheduler.scheduleFunction(pushCurrentTime, 1);
+    
+    clock.tick(1);
+    
+    expect(actualTimes).toEqual([baseTime.getTime(), baseTime.getTime() + 1]);
+  })
 });

--- a/spec/core/DelayedFunctionSchedulerSpec.js
+++ b/spec/core/DelayedFunctionSchedulerSpec.js
@@ -251,5 +251,23 @@ describe("DelayedFunctionScheduler", function() {
     expect(fn).toHaveBeenCalled();
     expect(fn.calls.count()).toBe(1);
   });
+  
+  it("updates the mockDate per scheduled time", function () {
+    var scheduler = new j$.DelayedFunctionScheduler(),
+      fakeGlobal = { Date: Date },
+      mockDate = new j$.MockDate(fakeGlobal),
+      baseTime = new Date();
+      
+      mockDate.install(baseTime);
+      
+      var actualTimes = [];
+      var pushCurrentTime = function() { actualTimes.push(fakeGlobal.Date().getTime()); };
+      scheduler.scheduleFunction(pushCurrentTime);
+      scheduler.scheduleFunction(pushCurrentTime, 1);
+      
+      scheduler.tick(1, mockDate);
+      
+      expect(actualTimes).toEqual([baseTime.getTime(), baseTime.getTime() + 1]);
+  })
 });
 

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -82,8 +82,7 @@ getJasmineRequireObj().Clock = function() {
 
     self.tick = function(millis) {
       if (installed) {
-        mockDate.tick(millis);
-        delayedFunctionScheduler.tick(millis);
+        delayedFunctionScheduler.tick(millis, mockDate);
       } else {
         throw new Error('Mock clock is not installed, use jasmine.clock().install()');
       }

--- a/src/core/DelayedFunctionScheduler.js
+++ b/src/core/DelayedFunctionScheduler.js
@@ -6,11 +6,11 @@ getJasmineRequireObj().DelayedFunctionScheduler = function() {
     var currentTime = 0;
     var delayedFnCount = 0;
 
-    self.tick = function(millis) {
+    self.tick = function(millis, mockDate) {
       millis = millis || 0;
       var endTime = currentTime + millis;
 
-      runScheduledFunctions(endTime);
+      runScheduledFunctions(endTime, mockDate);
       currentTime = endTime;
     };
 
@@ -113,13 +113,17 @@ getJasmineRequireObj().DelayedFunctionScheduler = function() {
       }
     }
 
-    function runScheduledFunctions(endTime) {
+    function runScheduledFunctions(endTime, mockDate) {
       if (scheduledLookup.length === 0 || scheduledLookup[0] > endTime) {
+        updateMockDate(mockDate, endTime);
         return;
       }
 
       do {
-        currentTime = scheduledLookup.shift();
+        var newCurrentTime = scheduledLookup.shift();
+        updateMockDate(mockDate, newCurrentTime);
+        
+        currentTime = newCurrentTime;
 
         var funcsToRun = scheduledFunctions[currentTime];
         delete scheduledFunctions[currentTime];
@@ -138,6 +142,13 @@ getJasmineRequireObj().DelayedFunctionScheduler = function() {
               // scheduled in a funcToRun from forcing an extra iteration
                  currentTime !== endTime  &&
                  scheduledLookup[0] <= endTime);
+    }
+    
+    function updateMockDate(mockDate, newCurrentTime) {
+      if (mockDate) {
+        var millis = newCurrentTime - currentTime;
+        mockDate.tick(millis);
+      }
     }
   }
 


### PR DESCRIPTION
Quick fix for #915 by making the DelayedFunctionScheduler in charge of updating the mockDate. Included specs to test as well.

With this implementation the mockDate parameter to DelayedFunctionScheduler.tick is optional. It will update the mockDate object only if it is given. The rest of the tick function behaves as expected.