### PR TITLE
Persist randomize param in 'run all' links

### DIFF
--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -690,6 +690,45 @@ describe("New HtmlReporter", function() {
         expect(seedBar).toBeNull();
       });
 
+      it("should include the random query param in the jasmine-skipped link when randomizing", function(){
+        var env, container, reporter;
+        env = new jasmineUnderTest.Env();
+        container = document.createElement("div");
+        var getContainer = function() { return container; },
+        reporter = new jasmineUnderTest.HtmlReporter({
+          env: env,
+          getContainer: getContainer,
+          createElement: function() { return document.createElement.apply(document, arguments); },
+          createTextNode: function() { return document.createTextNode.apply(document, arguments); }
+        });
+
+        reporter.initialize();
+        reporter.jasmineStarted({ totalSpecsDefined: 1 });
+        reporter.jasmineDone({ order: { random: true } });
+
+        var skippedLink = container.querySelector(".jasmine-skipped a");
+        expect(skippedLink.getAttribute('href')).toEqual('?random=true');
+      });
+
+      it("should not include the random query param in the jasmine-skipped link when not randomizing", function(){
+        var env, container, reporter;
+        env = new jasmineUnderTest.Env();
+        container = document.createElement("div");
+        var getContainer = function() { return container; },
+        reporter = new jasmineUnderTest.HtmlReporter({
+          env: env,
+          getContainer: getContainer,
+          createElement: function() { return document.createElement.apply(document, arguments); },
+          createTextNode: function() { return document.createTextNode.apply(document, arguments); }
+        });
+
+        reporter.initialize();
+        reporter.jasmineStarted({ totalSpecsDefined: 1 });
+        reporter.jasmineDone();
+
+        var skippedLink = container.querySelector(".jasmine-skipped a");
+        expect(skippedLink.getAttribute('href')).toEqual('?');
+      });
     });
 
     it("shows a message if no specs are run", function(){

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -180,9 +180,10 @@ jasmineRequire.HtmlReporter = function(j$) {
 
       if (specsExecuted < totalSpecsDefined) {
         var skippedMessage = 'Ran ' + specsExecuted + ' of ' + totalSpecsDefined + ' specs - run all';
+        var skippedLink = order && order.random ? '?random=true' : '?';
         alert.appendChild(
           createDom('span', {className: 'jasmine-bar jasmine-skipped'},
-            createDom('a', {href: '?', title: 'Run all specs'}, skippedMessage)
+            createDom('a', {href: skippedLink, title: 'Run all specs'}, skippedMessage)
           )
         );
       }


### PR DESCRIPTION
I would expect that if I am running jasmine with random=true then any 'run all' links should persist that param.  This PR adds that behavior.