### PR TITLE
Remove an extra `topSuite` `queueRunner` construction parameter

### DIFF
--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -198,8 +198,7 @@ getJasmineRequireObj().Env = function(j$) {
     var topSuite = new j$.Suite({
       env: this,
       id: getNextSuiteId(),
-      description: 'Jasmine__TopLevel__Suite',
-      queueRunner: queueRunnerFactory
+      description: 'Jasmine__TopLevel__Suite'
     });
     runnableLookupTable[topSuite.id] = topSuite;
     defaultResourcesForRunnable(topSuite.id);


### PR DESCRIPTION
The `Suite` constructor function does not expect or use its `attrs` parameter's `queueRunner` attribute, so setting it serves no purpose and only clutters the code and makes it more difficult to understand.

This is a pure refactoring commit with no functional changes.