### PR TITLE
Adding support to a fallback report in case of no added reports

### DIFF
--- a/spec/core/ReportDispatcherSpec.js
+++ b/spec/core/ReportDispatcherSpec.js
@@ -37,4 +37,27 @@ describe("ReportDispatcher", function() {
       dispatcher.foo(123, 456);
     }).not.toThrow();
   });
+
+  it("allows providing a fallback reporter in case there's no other report", function() {
+    var dispatcher = new jasmineUnderTest.ReportDispatcher(['foo', 'bar']),
+      reporter = jasmine.createSpyObj('reporter', ['foo', 'bar']);
+
+    dispatcher.provideFallbackReporter(reporter);
+    dispatcher.foo(123, 456);
+    expect(reporter.foo).toHaveBeenCalledWith(123, 456);
+
+  });
+  it("does not call fallback reporting methods when another report is provided", function() {
+    var dispatcher = new jasmineUnderTest.ReportDispatcher(['foo', 'bar']),
+      reporter = jasmine.createSpyObj('reporter', ['foo', 'bar']),
+      fallbackReporter = jasmine.createSpyObj('otherReporter', ['foo', 'bar']);
+
+    dispatcher.provideFallbackReporter(fallbackReporter);
+    dispatcher.addReporter(reporter);
+    dispatcher.foo(123, 456);
+
+    expect(reporter.foo).toHaveBeenCalledWith(123, 456);
+    expect(fallbackReporter.foo).not.toHaveBeenCalledWith(123, 456);
+
+  });
 });

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -1282,6 +1282,30 @@ describe("Env integration", function() {
     env.execute();
   });
 
+  it('should report using fallback report', function(done) {
+    var env = new jasmineUnderTest.Env(),
+        reporter = jasmine.createSpyObj('fakeReporter', [
+          'specDone',
+          'jasmineDone'
+        ]);
+
+    reporter.jasmineDone.and.callFake(function() {
+      var specStatus = reporter.specDone.calls.argsFor(0)[0];
+
+      expect(specStatus.pendingReason).toBe('with a message');
+
+      done();
+    });
+
+    env.provideFallbackReporter(reporter);
+
+    env.it('will be pending', function() {
+      env.pending('with a message');
+    });
+
+    env.execute();
+  });
+
   it('should report xdescribes as expected', function(done) {
     var env = new jasmineUnderTest.Env(),
         reporter = jasmine.createSpyObj('fakeReporter', [

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -263,6 +263,10 @@ getJasmineRequireObj().Env = function(j$) {
       reporter.addReporter(reporterToAdd);
     };
 
+    this.provideFallbackReporter = function(reporterToAdd) {
+      reporter.provideFallbackReporter(reporterToAdd);
+    };
+
     var spyRegistry = new j$.SpyRegistry({currentSpies: function() {
       if(!currentRunnable()) {
         throw new Error('Spies must be created in a before function or a spec');

--- a/src/core/ReportDispatcher.js
+++ b/src/core/ReportDispatcher.js
@@ -13,14 +13,23 @@ getJasmineRequireObj().ReportDispatcher = function() {
     }
 
     var reporters = [];
+    var fallbackReporter = null;
 
     this.addReporter = function(reporter) {
       reporters.push(reporter);
     };
+    
+    this.provideFallbackReporter = function(reporter) {
+      fallbackReporter = reporter;
+    };
+
 
     return this;
 
     function dispatch(method, args) {
+      if (reporters.length === 0 && fallbackReporter !== null) {
+          reporters.push(fallbackReporter);
+      }
       for (var i = 0; i < reporters.length; i++) {
         var reporter = reporters[i];
         if (reporter[method]) {


### PR DESCRIPTION
Hi,

I'm struggling with the following. Using jasmine on node, when I try to add a custom report through a helper using:

```node
jasmine.getEnv().addReport(myReportObject);
```
When jasmine executes, it outputs my custom report and also the default one.

I'd like to complement the solution proposed in https://github.com/jasmine/jasmine-npm/issues/21 with a support for a single fallback instead of a default report in jasmine-core. It would solve this problem, which I've seen in some blogs that is a common problem and people prefer to workaround it.

Having this pull request approved, I'd like to submit another one th jasmine-npm, regarding the usage of fallbackReport while loading the default one.

Sorry if I'm missing the point here. Thanks and regards