### PR TITLE
Proposed fix for issue #1010

### DIFF
--- a/spec/core/SpyRegistrySpec.js
+++ b/spec/core/SpyRegistrySpec.js
@@ -89,5 +89,24 @@ describe("SpyRegistry", function() {
 
       expect(subject.spiedFunc).toBe(originalFunction);
     });
+
+    it("restores the original functions, even when that spy has been replace and re-spied upon", function() {
+      var spies = [],
+        spyRegistry = new jasmineUnderTest.SpyRegistry({currentSpies: function() { return spies; }}),
+        originalFunction = function() {},
+        subject = { spiedFunc: originalFunction };
+
+      spyRegistry.spyOn(subject, 'spiedFunc');
+
+      // replace the original spy with some other function
+      subject.spiedFunc = function() {};
+
+      // spy on the function in that location again
+      spyRegistry.spyOn(subject, 'spiedFunc');
+
+      spyRegistry.clearSpies();
+
+      expect(subject.spiedFunc).toBe(originalFunction);
+    });
   });
 });

--- a/src/core/SpyRegistry.js
+++ b/src/core/SpyRegistry.js
@@ -49,7 +49,7 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
 
     this.clearSpies = function() {
       var spies = currentSpies();
-      for (var i = 0; i < spies.length; i++) {
+      for (var i = spies.length - 1; i >= 0; i--) {
         var spyEntry = spies[i];
         spyEntry.baseObj[spyEntry.methodName] = spyEntry.originalValue;
       }


### PR DESCRIPTION
This is a proposed fix for issue #1010

ORIGINAL PROBLEM
---
If one has a function somewhere, then spies on it, then the code under test replaces that function and the test then re-spies on the function, when Jasmine cleans up the spies, it will leave the wrong function in place.

(we've encountered this in a case we have. We have to spy on $.ajax in the base/top-level beforeEach() for other reasons. Our code under may replace that spy with its own code (this code can't know about Jasmine, so it just blithely replaces $.ajax). Our tests then need to spy on this, so set up the spy.  When cleanup happens, we do not restore the original jQuery $.ajax function correctly).

FIX
---
The fix here is delightfully simple.  We simply reverse the order that spies are cleared in SpyRegistry.js #clearSpies . This seems generally good hygiene for any kind of situation like this since spies are added to the currentSpies array in the order they are created, and so undoing this seems like it should always go in the reverse order, assuring that any contorted use of spies will be undone sequentially.

TESTING
---
I have followed the requests for development and testing, to the best of my current ability, in: https://github.com/bodawei/jasmine/blob/master/CONTRIBUTING.md

Specifically:
* Tested with node v4.2.2 on a mac
* Tested with Chrome 47.0.2526.106 on a mac
* Tested with Firefox 42 on a mac
* Tested with Safari 9.0.2 on a mac
* ran grunt jshint
* ran grunt buildDistribution
* Re-ran all the above tests

I did not test with IE. Oddly, as far as I can tell the web server being run by bundle exec rake jasmine was not accessible from a Windows VirtualBox VM (other web servers I ran on my system were, so I assume this is somehow only bound to 127.0.0.1:8888???). I also tried with Firefox 3, but I got some errors implying that some of the current jasmine html code won't run that far back.

Please let me know anything else you would like to have checked.
