### PR TITLE
Correctly teardown spies on inherited methods

### DIFF
--- a/spec/core/SpyRegistrySpec.js
+++ b/spec/core/SpyRegistrySpec.js
@@ -89,5 +89,22 @@ describe("SpyRegistry", function() {
 
       expect(subject.spiedFunc).toBe(originalFunction);
     });
+
+    it("does not add a property that the spied-upon object didn't originally have", function() {
+      var spies = [],
+        spyRegistry = new jasmineUnderTest.SpyRegistry({currentSpies: function() { return spies; }}),
+        originalFunction = function() {},
+        subjectParent = {spiedFunc: originalFunction};
+
+      var subject = Object.create(subjectParent);
+
+      expect(subject.hasOwnProperty('spiedFunc')).toBe(false);
+
+      spyRegistry.spyOn(subject, 'spiedFunc');
+      spyRegistry.clearSpies();
+
+      expect(subject.hasOwnProperty('spiedFunc')).toBe(false);
+      expect(subject.spiedFunc).toBe(originalFunction);
+    })
   });
 });

--- a/src/core/SpyRegistry.js
+++ b/src/core/SpyRegistry.js
@@ -33,25 +33,34 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
         throw new Error(methodName + ' is not declared writable or has no setter');
       }
 
-      var spy = j$.createSpy(methodName, obj[methodName]);
+      var originalMethod = obj[methodName],
+        spiedMethod = j$.createSpy(methodName, originalMethod),
+        restoreStrategy;
+
+      if (Object.prototype.hasOwnProperty.call(obj, methodName)) {
+        restoreStrategy = function() {
+          obj[methodName] = originalMethod;
+        };
+      } else {
+        restoreStrategy = function() {
+          delete obj[methodName];
+        };
+      }
 
       currentSpies().push({
-        spy: spy,
-        baseObj: obj,
-        methodName: methodName,
-        originalValue: obj[methodName]
+        restoreObjectToOriginalState: restoreStrategy
       });
 
-      obj[methodName] = spy;
+      obj[methodName] = spiedMethod;
 
-      return spy;
+      return spiedMethod;
     };
 
     this.clearSpies = function() {
       var spies = currentSpies();
       for (var i = 0; i < spies.length; i++) {
         var spyEntry = spies[i];
-        spyEntry.baseObj[spyEntry.methodName] = spyEntry.originalValue;
+        spyEntry.restoreObjectToOriginalState();
       }
     };
   }


### PR DESCRIPTION
Fixes issue  #737.

Currently, when a spied method is inherited from a prototype, the original method implementation is added as an own property of the spied-upon object during spy teardown. This can cause test order dependencies if the spied-upon object is not local to the test.

This PR fixes the issue by checking whether the spied method is an own property of the object and doing the appropriate teardown based on that.
