### PR TITLE
Fix toEqual() make freezing MicrosoftEdge browser issue

### DIFF
--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -175,21 +175,20 @@ getJasmineRequireObj().matchersUtil = function(j$) {
           return false;
         }
       }
+
       // Deep compare objects.
-      for (var key in a) {
-        if (has(a, key)) {
-          // Count the expected number of properties.
-          size++;
-          // Deep compare each member.
-          if (!(result = has(b, key) && eq(a[key], b[key], aStack, bStack, customTesters))) { break; }
+      var aKeys = keys(a), size = aKeys.length, key;
+      // Ensure that both objects contain the same number of properties before comparing deep equality.
+      if (keys(b).length !== size) { return false; }
+
+      while (size--) {
+        key = aKeys[size];
+        // Deep compare each member
+        result = has(b, key) && eq(a[key], b[key], aStack, bStack, customTesters);
+
+        if (!result) {
+            return false;
         }
-      }
-      // Ensure that both objects contain the same number of properties.
-      if (result) {
-        for (key in b) {
-          if (has(b, key) && !(size--)) { break; }
-        }
-        result = !size;
       }
     }
     // Remove the first object from the stack of traversed objects.
@@ -197,6 +196,19 @@ getJasmineRequireObj().matchersUtil = function(j$) {
     bStack.pop();
 
     return result;
+
+    function keys(obj) {
+      return Object.keys ? Object.keys(obj) :
+        (function(o) {
+            var keys = [];
+            for (var key in o) {
+                if (has(o, key)) {
+                    keys.push(key);
+                }
+            }
+            return keys;
+        })(obj);
+    }
 
     function has(obj, key) {
       return Object.prototype.hasOwnProperty.call(obj, key);

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -177,7 +177,9 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       }
 
       // Deep compare objects.
-      var aKeys = keys(a), size = aKeys.length, key;
+      var aKeys = keys(a), key;
+      size = aKeys.length;
+
       // Ensure that both objects contain the same number of properties before comparing deep equality.
       if (keys(b).length !== size) { return false; }
 


### PR DESCRIPTION
Repeatedly invoke of toEqual() to compare large object make MS Edge browser freezing.

matchersUtil.js line 184: calculating size with equality check in one `for` syntax make freezing MS Edge browser.

So i fix split it to other loop. please check attached gif images.



### BEFORE

![jasmine](https://cloud.githubusercontent.com/assets/1061205/12809519/2aa764ae-cb63-11e5-9d14-0355d81db011.gif)


### AFTER

![jasmine-b](https://cloud.githubusercontent.com/assets/1061205/12809559/6779ead2-cb63-11e5-941a-49d6f6f15b33.gif)


