### PR TITLE
toEqual reports detailed comparison of objects and arrays

### DIFF
--- a/spec/core/matchers/matchersUtilSpec.js
+++ b/spec/core/matchers/matchersUtilSpec.js
@@ -382,4 +382,103 @@ describe("matchersUtil", function() {
       expect(message).toEqual("Expected 'foo' to bar 'quux', 'corge'.");
     });
   });
+
+  describe("diffStringArrays", function() {
+    it("should show no difference between empty arrays", function() {
+      var result = jasmineUnderTest.matchersUtil.diffStringArrays([], []);
+      expect(result.none).toBe(true);
+      expect(result.extra).toEqual([]);
+      expect(result.missing).toEqual([]);
+    });
+
+    it("should show no difference between equal arrays", function() {
+      var result = jasmineUnderTest.matchersUtil.diffStringArrays(['a'], ['a']);
+      expect(result.none).toBe(true);
+      expect(result.extra).toEqual([]);
+      expect(result.missing).toEqual([]);
+    });
+
+    it("lists missing items", function() {
+      var actual = ['hello'],
+        expected = ['hello', 'goodbye'];
+
+      var result = jasmineUnderTest.matchersUtil.diffStringArrays(actual, expected);
+
+      expect(result.none).toBe(false);
+      expect(result.extra).toEqual([]);
+      expect(result.missing).toEqual(['goodbye']);
+    });
+
+    it("lists extra items", function() {
+      var actual = ['hello'],
+        expected = [];
+
+      var result = jasmineUnderTest.matchersUtil.diffStringArrays(actual, expected);
+
+      expect(result.none).toBe(false);
+      expect(result.extra).toEqual(['hello']);
+      expect(result.missing).toEqual([]);
+    });
+
+    it("handles complex cases", function() {
+      var actual = ['a', 'b', 'c', 'd', 'e'],
+        expected = ['e', 'f', 'a'];
+
+      var result = jasmineUnderTest.matchersUtil.diffStringArrays(actual, expected);
+
+      expect(result.none).toBe(false);
+      expect(result.extra).toEqual(['b', 'c', 'd']);
+      expect(result.missing).toEqual(['f']);
+    });
+  });
+
+  describe("keys", function() {
+    it("returns an empty array for an empty object", function() {
+      var util = jasmineUnderTest.matchersUtil;
+      expect(util.keys({})).toEqual([]);
+    });
+
+    it("returns the keys for an object with properties", function() {
+      var util = jasmineUnderTest.matchersUtil;
+      expect(util.keys({a: 1})).toEqual(['a']);
+    });
+  });
+
+  describe("isObject", function() {
+    it("returns true when passed an object", function() {
+      var util = jasmineUnderTest.matchersUtil;
+      expect(util.isObject({})).toBe(true);
+    });
+
+    it("returns false when passed anything else", function() {
+      var util = jasmineUnderTest.matchersUtil;
+      expect(util.isObject()).toBe(false);
+      expect(util.isObject(null)).toBe(false);
+      expect(util.isObject(1)).toBe(false);
+      expect(util.isObject(0/0)).toBe(false);
+      expect(util.isObject(1/0)).toBe(false);
+      expect(util.isObject('hello')).toBe(false);
+      expect(util.isObject(/hello/)).toBe(false);
+      expect(util.isObject([])).toBe(false);
+    });
+  });
+
+  describe("isArray", function() {
+    it("returns true when passed an array", function () {
+      var util = jasmineUnderTest.matchersUtil;
+      expect(util.isArray([])).toBe(true);
+    });
+
+    it("returns false when passed anything else", function() {
+      var util = jasmineUnderTest.matchersUtil;
+      expect(util.isArray()).toBe(false);
+      expect(util.isArray(null)).toBe(false);
+      expect(util.isArray(1)).toBe(false);
+      expect(util.isArray(0/0)).toBe(false);
+      expect(util.isArray(1/0)).toBe(false);
+      expect(util.isArray('hello')).toBe(false);
+      expect(util.isArray(/hello/)).toBe(false);
+      expect(util.isArray({})).toBe(false);
+    });
+  });
 });

--- a/spec/core/matchers/toEqualSpec.js
+++ b/spec/core/matchers/toEqualSpec.js
@@ -1,4 +1,19 @@
 describe("toEqual", function() {
+  "use strict";
+
+  function compareEquals(actual, expected) {
+    var util = jasmineUnderTest.matchersUtil,
+      matcher = jasmineUnderTest.matchers.toEqual(util);
+
+    spyOn(util, 'buildFailureMessage').and.returnValue('fail!');
+
+    var result = matcher.compare(actual, expected);
+
+    expect(util.buildFailureMessage).toHaveBeenCalledWith('toEqual', false, actual, expected);
+
+    return result;
+  }
+
   it("delegates to equals function", function() {
     var util = {
         equals: jasmine.createSpy('delegated-equals').and.returnValue(true)
@@ -25,4 +40,273 @@ describe("toEqual", function() {
     expect(util.equals).toHaveBeenCalledWith(1, 1, ['a', 'b']);
     expect(result.pass).toBe(true);
   });
+
+  it("reports the difference between objects that are not equal", function() {
+    var actual = {x: 1, y: 3},
+      expected = {x: 2, y: 3},
+      message =
+        "fail!\n" +
+        "    Expected $.x = 1 to equal 2";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports the difference between nested objects that are not equal", function() {
+    var actual = {x: {y: 1}},
+      expected = {x: {y: 2}},
+      message =
+        "fail!\n" +
+        "    Expected $.x.y = 1 to equal 2";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports missing properties", function() {
+    var actual = {x: {}},
+      expected = {x: {y: 1}},
+      message =
+        "fail!\n" +
+        "    Expected $.x to have properties\n" +
+        "        y: 1";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports extra properties", function() {
+    var actual = {x: {y: 1, z: 2}},
+      expected = {x: {}},
+      message =
+        "fail!\n" +
+        "    Expected $.x not to have properties\n" +
+        "        y: 1\n" +
+        "        z: 2";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports extra and missing properties together", function() {
+    var actual = {x: {y: 1, z: 2, f: 4}},
+      expected = {x: {y: 1, z: 2, g: 3}},
+      message =
+        "fail!\n" +
+        "    Expected $.x to have properties\n" +
+        "        g: 3\n" +
+        "    Expected $.x not to have properties\n" +
+        "        f: 4";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("formats values in extra/missing properties", function() {
+    var actual = {x: {y: 1, z: 2, f: "a"}},
+      expected = {x: {y: 1, z: 2, g: []}},
+      message =
+        "fail!\n" +
+        "    Expected $.x to have properties\n" +
+        "        g: [object Array]\n" +
+        "    Expected $.x not to have properties\n" +
+        "        f: \"a\"";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports multiple incorrect values", function() {
+    var actual = {x: 1, y: 2},
+      expected = {x: 3, y: 4},
+      message =
+        "fail!\n" +
+        "    Expected $.x = 1 to equal 3\n" +
+        "    Expected $.y = 2 to equal 4";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports mismatch between actual child object and expected child number", function() {
+    var actual = {x: {y: 2}},
+      expected = {x: 1},
+      message =
+        "fail!\n" +
+        "    Expected $.x = [object Object] to equal 1";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("uses the default failure message if actual is not an object", function() {
+    var actual = 1,
+      expected = {x: {}},
+      message = "fail!";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("uses the default failure message if expected is not an object", function() {
+    var actual = {x: {}},
+      expected = 1,
+      message = "fail!";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports a mismatch between arrays of different lengths", function() {
+    var actual = [1, 2],
+      expected = [1, 2, 3],
+      message =
+        "fail!\n" +
+        "    Expected $ = Array[2] to have length 3";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports a mismatch between elements of equal-length arrays", function() {
+    var actual = [1, 2, 5],
+      expected = [1, 2, 3],
+      message =
+        "fail!\n" +
+        "    Expected $[2] = 5 to equal 3";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports a mismatch between properties of objects in arrays", function() {
+    var actual = [{x: 1}],
+      expected = [{x: 2}],
+      message =
+        "fail!\n" +
+        "    Expected $[0].x = 1 to equal 2";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports a mismatch between arrays in objects", function() {
+    var actual = {x: [1]},
+      expected = {x: [2]},
+      message =
+        "fail!\n" +
+        "    Expected $.x[0] = 1 to equal 2";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports mismatches between nested arrays", function() {
+    var actual = [[1]],
+      expected = [[2]],
+      message =
+        "fail!\n" +
+        "    Expected $[0][0] = 1 to equal 2";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports mismatches involving NaN", function() {
+    var actual = {x: 0},
+      expected = {x: 0/0},
+      message =
+        "fail!\n" +
+        "    Expected $.x = 0 to equal NaN";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports mismatches involving regular expressions", function() {
+    var actual = {x: '1'},
+      expected = {x: /1/},
+      message =
+        "fail!\n" +
+        '    Expected $.x = "1" to equal /1/';
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports mismatches involving infinities", function() {
+    var actual = {x: 0},
+      expected = {x: 1/0},
+      message =
+        "fail!\n" +
+        "    Expected $.x = 0 to equal Infinity";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports mismatches involving booleans", function() {
+    var actual = {x: false},
+      expected = {x: true},
+      message =
+        "fail!\n" +
+        "    Expected $.x = false to equal true";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports mismatches involving undefined", function() {
+    var actual = {x: void 0},
+      expected = {x: 0},
+      message =
+        "fail!\n" +
+        "    Expected $.x = undefined to equal 0";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("reports mismatches involving null", function() {
+    var actual = {x: null},
+      expected = {x: 0},
+      message =
+        "fail!\n" +
+        "    Expected $.x = null to equal 0";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
+  it("works on big complex stuff", function() {
+    var actual = {
+      foo: [
+        {bar: 1, things: ['a', 'b']},
+        {bar: 2, things: ['a', 'b']}
+      ],
+      baz: [
+        {a: {b: 1}}
+      ],
+      quux: 1,
+      nan: 0,
+      aRegexp: 'hi',
+      inf: -1/0,
+      boolean: false,
+      notDefined: 0,
+      aNull: void 0
+    }
+
+    var expected = {
+      foo: [
+        {bar: 2, things: ['a', 'b', 'c']},
+        {bar: 2, things: ['a', 'd']}
+      ],
+      baz: [
+        {a: {b: 1, c: 1}}
+      ],
+      quux: [],
+      nan: 0/0,
+      aRegexp: /hi/,
+      inf: 1/0,
+      boolean: true,
+      notDefined: void 0,
+      aNull: null
+    }
+
+    var message =
+      'fail!\n' +
+      '    Expected $.foo[0].bar = 1 to equal 2\n' +
+      '    Expected $.foo[0].things = Array[2] to have length 3\n' +
+      '    Expected $.foo[1].things[1] = "b" to equal "d"\n' +
+      '    Expected $.baz[0].a to have properties\n' +
+      '        c: 1\n' +
+      '    Expected $.quux = 1 to equal [object Array]\n' +
+      '    Expected $.nan = 0 to equal NaN\n' +
+      '    Expected $.aRegexp = "hi" to equal /hi/\n' +
+      '    Expected $.inf = -Infinity to equal Infinity\n' +
+      '    Expected $.boolean = false to equal true\n' +
+      '    Expected $.notDefined = 0 to equal undefined\n' +
+      '    Expected $.aNull = undefined to equal null'
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  })
 });

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -48,6 +48,52 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       }
 
       return message + '.';
+    },
+
+    diffStringArrays: function(actual, expected) {
+      var difference = {
+        none: true,
+        extra: [],
+        missing: []
+      };
+
+      var item, i;
+
+      for (i = 0; i < expected.length; i++) {
+        item = expected[i];
+
+        if (actual.indexOf(item) === -1) {
+          difference.missing.push(item);
+        }
+      }
+
+      for (i = 0; i < actual.length; i++) {
+        item = actual[i];
+
+        if (expected.indexOf(item) === -1) {
+          difference.extra.push(item);
+        }
+      }
+
+      difference.none = difference.extra.length === 0 && difference.missing.length === 0;
+
+      return difference;
+    },
+
+    keys: function(object) {
+      var keys = [], key;
+      for (key in object) {
+        keys.push(key);
+      }
+      return keys;
+    },
+
+    isObject: function(allegedObject) {
+      return Object.prototype.toString.call(allegedObject) === '[object Object]';
+    },
+
+    isArray: function(allegedArray) {
+      return Object.prototype.toString.call(allegedArray) === '[object Array]';
     }
   };
 

--- a/src/core/matchers/toEqual.js
+++ b/src/core/matchers/toEqual.js
@@ -1,4 +1,5 @@
 getJasmineRequireObj().toEqual = function() {
+  'use strict';
 
   function toEqual(util, customEqualityTesters) {
     customEqualityTesters = customEqualityTesters || [];
@@ -11,9 +12,126 @@ getJasmineRequireObj().toEqual = function() {
 
         result.pass = util.equals(actual, expected, customEqualityTesters);
 
+        if (!result.pass) {
+          result.message = buildMessage(actual, expected);
+        }
+
         return result;
       }
     };
+
+    function buildMessage(actual, expected) {
+      var defaultMessage = util.buildFailureMessage('toEqual', false, actual, expected),
+        lineSeparator = '\n    ',
+        keyPathRoot = '$';
+
+      var messages = [defaultMessage];
+
+      if (bothAreObjects(actual, expected)) {
+        messages = messages.concat(findObjectProblems(actual, expected, keyPathRoot));
+      } else if (bothAreArrays(actual, expected)) {
+        messages = messages.concat(findArrayProblems(actual, expected, keyPathRoot));
+      }
+
+      return messages.join(lineSeparator);
+    }
+
+    function findObjectProblems(actual, expected, keyPath) {
+      var problems = [],
+        diff = diffKeySets(actual, expected);
+
+      if (diff.missing.length > 0) {
+        problems.push('Expected ' + keyPath + ' to have properties');
+        problems = problems.concat(fieldSetMismatches(diff.missing, expected));
+      }
+
+      if (diff.extra.length > 0) {
+        problems.push('Expected ' + keyPath + ' not to have properties');
+        problems = problems.concat(fieldSetMismatches(diff.extra, actual));
+      }
+
+      if (diff.none) {
+        for (var key in expected) {
+          problems = problems.concat(recurseIntoSubObject(actual[key], expected[key], keyPath + '.' + key));
+        }
+      }
+
+      return problems;
+    }
+
+    function findArrayProblems(actual, expected, keyPath) {
+      var problems = [];
+
+      if (actual.length != expected.length) {
+        return ['Expected ' + keyPath + ' = Array[' + actual.length + '] to have length ' + expected.length];
+      }
+
+      for (var i = 0; i < actual.length; i++) {
+        problems = problems.concat(recurseIntoSubObject(actual[i], expected[i], keyPath + '[' + i + ']'));
+      }
+
+      return problems;
+    }
+
+    function recurseIntoSubObject(actual, expected, keyPath) {
+      var problems = [];
+
+      if (util.equals(actual, expected)) {
+        return problems;
+      }
+
+      if (bothAreObjects(actual, expected)) {
+        problems = problems.concat(findObjectProblems(actual, expected, keyPath));
+      } else if (bothAreArrays(actual, expected)) {
+        problems = problems.concat(findArrayProblems(actual, expected, keyPath));
+      } else {
+        problems.push('Expected ' + keyPath + ' = ' + render(actual) + ' to equal ' + render(expected));
+      }
+
+      return problems;
+    }
+
+    function bothAreArrays(a, b) {
+      return util.isArray(a) && util.isArray(b);
+    }
+
+    function bothAreObjects(a, b) {
+      return util.isObject(a) && util.isObject(b);
+    }
+
+    function diffKeySets(actual, expected) {
+      return util.diffStringArrays(
+        util.keys(actual),
+        util.keys(expected)
+      );
+    }
+  }
+
+  function fieldSetMismatches(difference, basisObject) {
+    return map(difference, function(key) {
+      return '    ' + key + ': ' + render(basisObject[key]);
+    });
+  }
+
+  function render(object) {
+    switch(Object.prototype.toString.call(object)) {
+      case '[object String]':
+        return '"' + object + '"';
+      case '[object Array]':
+        return '[object Array]';
+      default:
+        return object;
+    }
+  }
+
+  function map(array, fn) {
+    var accumulator = [], i;
+
+    for (i = 0; i < array.length; i++) {
+      accumulator.push(fn(array[i]));
+    }
+
+    return accumulator;
   }
 
   return toEqual;


### PR DESCRIPTION
This is a fix for issue #675. It causes the `toEqual` matcher to pinpoint mismatches in its failure message when the items being compared are `Object`s or `Array`s.

The output from comparing these objects...

```javascript
var actual = {
      foo: [
        {bar: 1, things: ['a', 'b']},
        {bar: 2, things: ['a', 'b']}
      ],
      baz: [
        {a: {b: 1}}
      ]
    }

var expected = {
      foo: [
        {bar: 2, things: ['a', 'b', 'c']},
        {bar: 2, things: ['a', 'd']}
      ],
      baz: [
        {a: {b: 1, c: 1}}
      ]
    }
```

...looks like this:

```
Expected { ... } to equal { ... }.
    Expected $.foo[0].bar = 1 to equal 2
    Expected $.foo[0].things = Array[2] to have length 3
    Expected $.foo[1].things[1] = "b" to equal "d"
    Expected $.baz[0].a to have properties
        c: 1
```

(`{...}` above is a placeholder for the entire pretty-printed object—i.e. what's currently displayed in the output.)