### PR TITLE
When the HtmlReporter has a 'spec' query param, the spec list only shows matching specs/suites

### DIFF
--- a/lib/jasmine-core/boot/boot.js
+++ b/lib/jasmine-core/boot/boot.js
@@ -49,6 +49,8 @@
     getWindowLocation: function() { return window.location; }
   });
 
+  var filterSpecs = !!queryString.getParam("spec");
+
   var catchingExceptions = queryString.getParam("catch");
   env.catchExceptions(typeof catchingExceptions === "undefined" ? true : catchingExceptions);
 
@@ -76,7 +78,8 @@
     getContainer: function() { return document.body; },
     createElement: function() { return document.createElement.apply(document, arguments); },
     createTextNode: function() { return document.createTextNode.apply(document, arguments); },
-    timer: new jasmine.Timer()
+    timer: new jasmine.Timer(),
+    filterSpecs: filterSpecs
   });
 
   /**

--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -804,6 +804,64 @@ describe("New HtmlReporter", function() {
       });
     });
 
+    describe("and there are disabled specs", function() {
+      var env, container, reporter, reporterConfig, specStatus;
+      beforeEach(function() {
+        env = new jasmineUnderTest.Env();
+        container = document.createElement("div");
+        reporterConfig = {
+          env: env,
+          getContainer: function() { return container; },
+          createElement: function() { return document.createElement.apply(document, arguments); },
+          createTextNode: function() { return document.createTextNode.apply(document, arguments); }
+        };
+        specStatus = {
+          id: 123,
+          description: "with a disabled spec",
+          fullName: "A Suite with a disabled spec",
+          status: "disabled",
+          passedExpectations: [],
+          failedExpectations: []
+        };
+      });
+
+      describe("when the specs are not filtered", function() {
+        beforeEach(function() {
+          reporterConfig.filterSpecs = false;
+          reporter = new jasmineUnderTest.HtmlReporter(reporterConfig);
+          reporter.initialize();
+          reporter.jasmineStarted({ totalSpecsDefined: 1 });
+          reporter.specStarted(specStatus);
+          reporter.specDone(specStatus);
+          reporter.jasmineDone({});
+        });
+
+        it("shows the disabled spec in the spec list", function() {
+          var specList = container.querySelector(".jasmine-summary");
+
+          expect(specList.innerHTML).toContain('with a disabled spec');
+        });
+      });
+
+      describe("when the specs are filtered", function() {
+        beforeEach(function() {
+          reporterConfig.filterSpecs = true;
+          reporter = new jasmineUnderTest.HtmlReporter(reporterConfig);
+          reporter.initialize();
+          reporter.jasmineStarted({ totalSpecsDefined: 1 });
+          reporter.specStarted(specStatus);
+          reporter.specDone(specStatus);
+          reporter.jasmineDone({});
+        });
+
+        it("doesn't show the disabled spec in the spec list", function() {
+          var specList = container.querySelector(".jasmine-summary");
+
+          expect(specList.innerHTML).toEqual('');
+        });
+      });
+    });
+
     describe("and there are pending specs", function() {
       var env, container, reporter;
       beforeEach(function() {

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -14,6 +14,7 @@ jasmineRequire.HtmlReporter = function(j$) {
       onThrowExpectationsClick = options.onThrowExpectationsClick || function() {},
       onRandomClick = options.onRandomClick || function() {},
       addToExistingQueryString = options.addToExistingQueryString || defaultQueryString,
+      filterSpecs = options.filterSpecs,
       timer = options.timer || noopTimer,
       results = [],
       specsExecuted = 0,
@@ -234,6 +235,9 @@ jasmineRequire.HtmlReporter = function(j$) {
         var specListNode;
         for (var i = 0; i < resultsTree.children.length; i++) {
           var resultNode = resultsTree.children[i];
+          if (filterSpecs && !hasActiveSpec(resultNode)) {
+            continue;
+          }
           if (resultNode.type == 'suite') {
             var suiteListNode = createDom('ul', {className: 'jasmine-suite', id: 'suite-' + resultNode.result.id},
               createDom('li', {className: 'jasmine-suite-detail'},
@@ -360,6 +364,20 @@ jasmineRequire.HtmlReporter = function(j$) {
     function noExpectations(result) {
       return (result.failedExpectations.length + result.passedExpectations.length) === 0 &&
         result.status === 'passed';
+    }
+
+    function hasActiveSpec(resultNode) {
+      if (resultNode.type == 'spec' && resultNode.result.status != 'disabled') {
+        return true;
+      }
+
+      if (resultNode.type == 'suite') {
+        for (var i = 0, j = resultNode.children.length; i < j; i++) {
+          if (hasActiveSpec(resultNode.children[i])) {
+            return true;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
[Fixes #510]
- This implementation does not introduce a new option/checkbox, which I find to be unnecessary/undiscoverable. If a user has filtered their specs, the Spec List should only show matches. A concern with this approach is that specs might be missing due to syntax errors. If this is the case, the user will notice the discrepancy when running the full suite with no filters. I doubt many users of jasmine commit their changes after only running a filtered set of suites (I could be wrong though).
- This commit does not close github issue #510; it just implements a possible fix (suggested by github user 'callmevlad'). I'd like to discuss this implementation with the Jasmine maintainers before submitting a full patch with additional tests.
