### PR TITLE
Grunt task for compass should prefix command with 'bundle exec'

### DIFF
--- a/grunt/config/compass.js
+++ b/grunt/config/compass.js
@@ -5,6 +5,7 @@ module.exports = {
       sassDir: 'src/html',
       outputStyle: 'compact',
       noLineComments: true,
+      bundleExec: true
     }
   }
 };


### PR DESCRIPTION
- Since we're stating that compass is a development dependency in our gemspec, and we use bundle to install it, we should make sure that grunt is using the correct (bundled) version of compass.

- This is especially important since many of the older versions of compass are buggy (see https://github.com/gruntjs/grunt-contrib-compass/issues/204)