### PR TITLE
Correctly pretty print objects from other contexts (e.g. iframes) and which do not override toString

### DIFF
--- a/spec/core/PrettyPrintSpec.js
+++ b/spec/core/PrettyPrintSpec.js
@@ -187,6 +187,15 @@ describe("jasmineUnderTest.pp", function () {
     };
 
     expect(jasmineUnderTest.pp(obj)).toEqual("my toString");
+
+    // Simulate object from another global context (e.g. an iframe or Web Worker) that does not actually have a custom
+    // toString despite obj.toString !== Object.prototype.toString
+    var objFromOtherContext = {
+      foo: 'bar',
+      toString: function () { return Object.prototype.toString.call(this); }
+    };
+
+    expect(jasmineUnderTest.pp(objFromOtherContext)).toEqual("Object({ foo: 'bar', toString: Function })");
   });
 
   it("should handle objects with null prototype", function() {

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -5,6 +5,12 @@ getJasmineRequireObj().pp = function(j$) {
     this.seen = [];
   }
 
+  function hasCustomToString(value) {
+    // value.toString !== Object.prototype.toString if value has no custom toString but is from another context (e.g.
+    // iframe, web worker)
+    return value.toString !== Object.prototype.toString && (value.toString() !== Object.prototype.toString.call(value));
+  }
+
   PrettyPrinter.prototype.format = function(value) {
     this.ppNestLevel_++;
     try {
@@ -30,7 +36,7 @@ getJasmineRequireObj().pp = function(j$) {
         this.emitScalar('HTMLNode');
       } else if (value instanceof Date) {
         this.emitScalar('Date(' + value + ')');
-      } else if (value.toString && typeof value === 'object' && !(value instanceof Array) && value.toString !== Object.prototype.toString) {
+      } else if (value.toString && typeof value === 'object' && !j$.isArray_(value) && hasCustomToString(value)) {
         this.emitScalar(value.toString());
       } else if (j$.util.arrayContains(this.seen, value)) {
         this.emitScalar('<circular reference: ' + (j$.isArray_(value) ? 'Array' : 'Object') + '>');


### PR DESCRIPTION
Fixes #1087

The issue in question was caused by globals (including prototypes and functions on them) having different identities in different contexts (e.g. iframes and web workers), therefore making `value.toString !== Object.prototype.toString` where value is from another context. The approach taken here is to compare the result of the value's toString with Object.prototype.toString to see if they _really_ are different. If they differ, then the value definitely has a custom toString.