### PR TITLE
Fix crash in Suite.prototype.onException() if no expectationResultFactory...

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -2180,7 +2180,7 @@ getJasmineRequireObj().Suite = function(j$) {
     this.parentSuite = attrs.parentSuite;
     this.description = attrs.description;
     this.expectationFactory = attrs.expectationFactory;
-    this.expectationResultFactory = attrs.expectationResultFactory;
+    this.expectationResultFactory = attrs.expectationResultFactory || function() { };
     this.throwOnExpectationFailure = !!attrs.throwOnExpectationFailure;
 
     this.beforeFns = [];

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -5,7 +5,7 @@ getJasmineRequireObj().Suite = function(j$) {
     this.parentSuite = attrs.parentSuite;
     this.description = attrs.description;
     this.expectationFactory = attrs.expectationFactory;
-    this.expectationResultFactory = attrs.expectationResultFactory;
+    this.expectationResultFactory = attrs.expectationResultFactory || function() {};
     this.throwOnExpectationFailure = !!attrs.throwOnExpectationFailure;
 
     this.beforeFns = [];


### PR DESCRIPTION
When using the jasmine test-runner internally here at Google, we were
getting this crash in Suite.prototype.onException():

——
TypeError: Cannot call method 'addExpectationResult' of undefined

node_modules/jasmine/node_modules/jasmine-core/lib/jasmine-core/jasmine.
js:2127

this.result.failedExpectations.push(this.expectationResultFactory(data))
;
——

The root cause is not having expectationResultFactory set to a valid
value (it was undefined in this case). When a specific type of exception is thrown by the test code, the jasmine code catches it in OnException, but then throws itself (due to the bug fixed in this PR), hiding the original exception.

Fixed by making sure expectationResultFactory is always defined, even
if it is to an empty anonymous function. Scanning for all instances of
where this is initialized, I found a pattern used in other cases, that
was not being used in the two error cases. I copied this pattern to the
two error cases, so now all spots that initialize the
expectationResultFactory now follow this pattern:

this.expectationResultFactory = attrs.expectationResultFactory ||
function() {};