### PR TITLE
Prettyprint objects whose constructors have custom toString method

### DIFF
--- a/spec/core/PrettyPrintSpec.js
+++ b/spec/core/PrettyPrintSpec.js
@@ -189,6 +189,26 @@ describe("jasmineUnderTest.pp", function () {
     expect(jasmineUnderTest.pp(obj)).toEqual("my toString");
   });
 
+  it("should stringify objects from named constructors with custom toString", function () {
+    var MyNamedConstructor = function MyNamedConstructor () {};
+    MyNamedConstructor.toString = function () { return ""; };
+
+    var a = {};
+    a.constructor = MyNamedConstructor;
+
+    expect(jasmineUnderTest.pp(a)).toEqual("MyNamedConstructor({ constructor: Function })");
+  });
+
+  it("should stringify objects from anonymous constructors with custom toString", function () {
+    var MyAnonymousConstructor = function () {};
+    MyAnonymousConstructor.toString = function () { return ""; };
+
+    var a = {};
+    a.constructor = MyAnonymousConstructor;
+
+    expect(jasmineUnderTest.pp(a)).toEqual("<anonymous>({ constructor: Function })");
+  });
+
   it("should handle objects with null prototype", function() {
     if (jasmine.getEnv().ieVersion < 9) { return; }
 

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -38,7 +38,12 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
   };
 
   j$.fnNameFor = function(func) {
-    return func.name || func.toString().match(/^\s*function\s*(\w*)\s*\(/)[1];
+    if (func.name) {
+      return func.name;
+    }
+
+    var matches = func.toString().match(/^\s*function\s*(\w*)\s*\(/);
+    return matches ? matches[1] : '<anonymous>';
   };
 
   j$.any = function(clazz) {


### PR DESCRIPTION
- when the constructor has a name, print the name
- when the constructor does not have a name, print `<anonymous>`

[Fixes issue #1019](https://github.com/jasmine/jasmine/issues/1019)

(Note: changes to lib/jasmine-core/jasmine.js have been reverted, per contributor guidelines.)

