### PR TITLE
createSpyObj may use object for method->response shorthand

### DIFF
--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -60,6 +60,17 @@ describe('Spies', function () {
   });
 
   describe("createSpyObj", function() {
+    it("should create an object with spy methods and corresponding return values when you call jasmine.createSpyObj() with an object", function () {
+      var spyObj = jasmineUnderTest.createSpyObj('BaseName', {'method1': 42, 'method2': 'special sauce' });
+
+      expect(spyObj.method1()).toEqual(42);
+      expect(spyObj.method1.and.identity()).toEqual('BaseName.method1');
+
+      expect(spyObj.method2()).toEqual('special sauce');
+      expect(spyObj.method2.and.identity()).toEqual('BaseName.method2');
+    });
+
+
     it("should create an object with a bunch of spy methods when you call jasmine.createSpyObj()", function() {
       var spyObj = jasmineUnderTest.createSpyObj('BaseName', ['method1', 'method2']);
 
@@ -76,10 +87,22 @@ describe('Spies', function () {
       expect(spyObj.method2.and.identity()).toEqual('unknown.method2');
     });
 
-    it("should throw if you do not pass an array argument", function() {
+    it("should throw if you do not pass an array or object argument", function() {
       expect(function() {
         jasmineUnderTest.createSpyObj('BaseName');
-      }).toThrow("createSpyObj requires a non-empty array of method names to create spies for");
+      }).toThrow("createSpyObj requires a non-empty array or object of method names to create spies for");
+    });
+
+    it("should throw if you pass an empty array argument", function() {
+      expect(function() {
+        jasmineUnderTest.createSpyObj('BaseName', []);
+      }).toThrow("createSpyObj requires a non-empty array or object of method names to create spies for");
+    });
+
+    it("should throw if you pass an empty object argument", function() {
+      expect(function() {
+        jasmineUnderTest.createSpyObj('BaseName', {});
+      }).toThrow("createSpyObj requires a non-empty array or object of method names to create spies for");
     });
   });
 });

--- a/spec/core/UtilSpec.js
+++ b/spec/core/UtilSpec.js
@@ -15,6 +15,22 @@ describe("jasmineUnderTest.util", function() {
     });
   });
 
+  describe("isObject_", function() {
+    it("should return true if the argument is an object", function() {
+      expect(jasmineUnderTest.isObject_({})).toBe(true);
+      expect(jasmineUnderTest.isObject_({an: "object"})).toBe(true);
+    });
+
+    it("should return false if the argument is not an object", function() {
+      expect(jasmineUnderTest.isObject_(undefined)).toBe(false);
+      expect(jasmineUnderTest.isObject_([])).toBe(false);
+      expect(jasmineUnderTest.isObject_(function() {})).toBe(false);
+      expect(jasmineUnderTest.isObject_('foo')).toBe(false);
+      expect(jasmineUnderTest.isObject_(5)).toBe(false);
+      expect(jasmineUnderTest.isObject_(null)).toBe(false);
+    });
+  });
+
   describe("isUndefined", function() {
     it("reports if a variable is defined", function() {
       var a;

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -21,6 +21,10 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
     return j$.isA_('Array', value);
   };
 
+  j$.isObject_ = function(value) {
+    return j$.isA_('Object', value);
+  };
+
   j$.isString_ = function(value) {
     return j$.isA_('String', value);
   };
@@ -105,18 +109,35 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
   };
 
   j$.createSpyObj = function(baseName, methodNames) {
-    if (j$.isArray_(baseName) && j$.util.isUndefined(methodNames)) {
+    var baseNameIsCollection = j$.isObject_(baseName) || j$.isArray_(baseName);
+
+    if (baseNameIsCollection && j$.util.isUndefined(methodNames)) {
       methodNames = baseName;
       baseName = 'unknown';
     }
 
-    if (!j$.isArray_(methodNames) || methodNames.length === 0) {
-      throw 'createSpyObj requires a non-empty array of method names to create spies for';
-    }
     var obj = {};
-    for (var i = 0; i < methodNames.length; i++) {
-      obj[methodNames[i]] = j$.createSpy(baseName + '.' + methodNames[i]);
+    var spiesWereSet = false;
+
+    if (j$.isArray_(methodNames)) {
+      for (var i = 0; i < methodNames.length; i++) {
+        obj[methodNames[i]] = j$.createSpy(baseName + '.' + methodNames[i]);
+        spiesWereSet = true;
+      }
+    } else if (j$.isObject_(methodNames)) {
+      for (var key in methodNames) {
+        if (methodNames.hasOwnProperty(key)) {
+          obj[key] = j$.createSpy(baseName + '.' + key);
+          obj[key].and.returnValue(methodNames[key]);
+          spiesWereSet = true;
+        }
+      }
     }
+
+    if (!spiesWereSet) {
+      throw 'createSpyObj requires a non-empty array or object of method names to create spies for';
+    }
+
     return obj;
   };
 };


### PR DESCRIPTION
examples:

```JavaScript
var mySpy = jasmine.createSpyObj("mySpy", { getAge: 55, getLanguage: "JavaScrizzle" });

var age = mySpy.getAge();

expect(age).toEqual(55);
expect(mySpy.getAge).toHaveBeenCalled();
```

Also does:

Add "isObject_" method to utils to make it easier for "createSpy" to support an array or object of stubs