### PR TITLE
remove unused code from Env

### DIFF
--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -13,7 +13,6 @@ getJasmineRequireObj().Env = function(j$) {
     var realClearTimeout = j$.getGlobal().clearTimeout;
     this.clock = new j$.Clock(global, function () { return new j$.DelayedFunctionScheduler(); }, new j$.MockDate(global));
 
-    var runnableLookupTable = {};
     var runnableResources = {};
 
     var currentSpec = null;
@@ -208,7 +207,6 @@ getJasmineRequireObj().Env = function(j$) {
       expectationFactory: expectationFactory,
       expectationResultFactory: expectationResultFactory
     });
-    runnableLookupTable[topSuite.id] = topSuite;
     defaultResourcesForRunnable(topSuite.id);
     currentDeclarationSuite = topSuite;
 
@@ -306,7 +304,6 @@ getJasmineRequireObj().Env = function(j$) {
         throwOnExpectationFailure: throwOnExpectationFailure
       });
 
-      runnableLookupTable[suite.id] = suite;
       return suite;
     };
 
@@ -407,8 +404,6 @@ getJasmineRequireObj().Env = function(j$) {
         },
         throwOnExpectationFailure: throwOnExpectationFailure
       });
-
-      runnableLookupTable[spec.id] = spec;
 
       if (!self.specFilter(spec)) {
         spec.disable();


### PR DESCRIPTION
`runnableLookupTable` is only ever written to, the information in it is never used.

Looks like its behavior ended up being subsumed into the `runnableResources` object.