### PR TITLE
add comment for external dependencies

### DIFF
--- a/grunt/templates/SpecRunner.html.jst
+++ b/grunt/templates/SpecRunner.html.jst
@@ -9,6 +9,9 @@
 
   <script src="lib/jasmine-<%= jasmineVersion %>/jasmine.js"></script>
   <script src="lib/jasmine-<%= jasmineVersion %>/jasmine-html.js"></script>
+
+  <!-- include external dependencies here... -->
+  
   <script src="lib/jasmine-<%= jasmineVersion %>/boot.js"></script>
 
   <!-- include source files here... -->


### PR DESCRIPTION
Show new users where to place libraries, such jQuery in SpecRunner.html.