### PR TITLE
throwOnExpectationFailure works with an async function

### DIFF
--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -67,7 +67,13 @@ getJasmineRequireObj().QueueRunner = function(j$) {
         timeoutId;
 
       next.fail = function() {
-        self.fail.apply(null, arguments);
+        try {
+          self.fail.apply(null, arguments);
+        } catch (e) {
+          // this was either a j$.errors.ExpectationFailed or a fatal error adding a failed expectation
+          // in either case we skip all subsequent queued functions
+          iterativeIndex = length;
+        }
         next();
       };
 


### PR DESCRIPTION
How to reproduce:
* `mkdir demo`
* `npm install jasmine`
* `$(npm bin)/jasmine init`
* Edit `spec/support/jasmine.json` and set `stopSpecOnExpectationFailure=true`
* Run an async test which calls `done.fail()` from within a promise callback

Expected behaviour:
* The test stops immediately
* The failure message is printed to the console

Actual behaviour:
* The test hangs until the timeout expires
* The failure message is printed to the console along with the "Async callback was not invoked within timeout" error


Here's an example spec you can use to see the problem. The change in this PR makes it behave as expected. It also passes the test suite locally in Node and in Firefox.

```
describe('demo', () => {

    beforeEach((done) => {
        Promise.resolve().then(() => {
            console.log('calling done.fail');
            done.fail('this should stop the test immediately, but it does not');
        });
    });

    it('demo', () => {
        console.log('does not get here!');
    });

});
```

Thanks :)