### PR TITLE
calling fail() with an Error should not create a new Error

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1015,7 +1015,7 @@ getJasmineRequireObj().Env = function(j$) {
         actual: '',
         message: message,
         error: error && error.message ? error : null
-      });
+      }, error instanceof Error);
     };
   }
 


### PR DESCRIPTION
When an error has been thrown in an async function there is no way to let jasmine print it stack, the current implementation will throw a new Error which which has a different Error.stack
