### PR TITLE
Update ExceptionHandler for errors in form of objects

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1469,7 +1469,12 @@ getJasmineRequireObj().ExceptionFormatter = function() {
       if (error.name && error.message) {
         message += error.name + ': ' + error.message;
       } else {
-        message += error.toString() + ' thrown';
+        try {
+          message += JSON.stringify(error) + ' thrown';
+        }
+        catch {
+          message += error.toString() + ' thrown';
+        }
       }
 
       if (error.fileName || error.sourceURL) {


### PR DESCRIPTION
Whenever an object is thrown (by for example a library you do not control), you see a very general message : 

'[Object object] thrown', which is obviously not very helpful.

This makes it more explicit whenever the error object is not recursive (in that case, the catch statement will be executed)
