### PR TITLE
Make `toEqual` pass for arrays with equivalent properties

### DIFF
--- a/spec/core/matchers/matchersUtilSpec.js
+++ b/spec/core/matchers/matchersUtilSpec.js
@@ -75,6 +75,16 @@ describe("matchersUtil", function() {
       expect(jasmineUnderTest.matchersUtil.equals(one, two)).toBe(false);
     });
 
+    it("passes for Arrays with equivalent contents and properties", function() {
+      var one = [1,2,3],
+          two = [1,2,3];
+
+      one.foo = 'bar';
+      two.foo = 'bar';
+
+      expect(jasmineUnderTest.matchersUtil.equals(one, two)).toBe(true);
+    });
+
     it("passes for Errors that are the same type and have the same message", function() {
       expect(jasmineUnderTest.matchersUtil.equals(new Error("foo"), new Error("foo"))).toBe(true);
     });

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -225,7 +225,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       var extraKeys = [];
       for (var i in allKeys) {
         if (!allKeys[i].match(/^[0-9]+$/)) {
-          extraKeys.push(key);
+          extraKeys.push(allKeys[i]);
         }
       }
 


### PR DESCRIPTION
I think this was a bug—arrays with equivalent properties and contents were treated as different by `eq`.

The `keys` function is inside `eq`'s scope when it doesn't have to be, which created an opportunity for the bug to exist. I think `keys`, `has`, and `isFunction` could be moved out of `eq` with no ill effect. If the project maintainers agree, I'll open another PR that moves those functions.
