### PR TITLE
noTryCatch option to disable try/catch around spec functions

### DIFF
--- a/spec/core/QueueRunnerSpec.js
+++ b/spec/core/QueueRunnerSpec.js
@@ -234,6 +234,26 @@ describe("QueueRunner", function() {
       queueRunner.execute();
       expect(doneReturn).toBe(null);
     });
+
+    it("does not try catch an fn if told to", function() {
+      var queueableFn = {
+            fn: function (done) {
+              throw new Error('no try catch error');
+            }
+          },
+          queueRunner = new jasmineUnderTest.QueueRunner({
+            queueableFns: [queueableFn],
+            noTryCatch: true
+          });
+
+      try {
+        queueRunner.execute();
+        fail("should have thrown an exception");
+      } catch (e) {
+        expect(e.message).toBe('no try catch error');
+        expect(e.caughtByJasmine).toBeUndefined();
+      }
+    });
   });
 
   it("calls exception handlers when an exception is thrown in a fn", function() {
@@ -252,18 +272,43 @@ describe("QueueRunner", function() {
     expect(onExceptionCallback).toHaveBeenCalledWith(jasmine.any(Error));
   });
 
+  it("does not try catch an fn if told to", function() {
+    var queueableFn = {
+          fn: function () {
+            throw new Error('no try catch error');
+          }
+        },
+        queueRunner = new jasmineUnderTest.QueueRunner({
+          queueableFns: [queueableFn],
+          noTryCatch: true
+        });
+
+    try {
+      queueRunner.execute();
+      fail("should have thrown an exception");
+    } catch (e) {
+      expect(e.message).toBe('no try catch error');
+      expect(e.caughtByJasmine).toBeUndefined();
+    }
+  });
+
+
   it("rethrows an exception if told to", function() {
     var queueableFn = { fn: function() {
-        throw new Error('fake error');
+        throw new Error('rethrow exception error');
       } },
       queueRunner = new jasmineUnderTest.QueueRunner({
         queueableFns: [queueableFn],
         catchException: function(e) { return false; }
       });
 
-    expect(function() {
+    try {
       queueRunner.execute();
-    }).toThrowError('fake error');
+      fail("should have rethrown exception");
+    } catch(e) {
+      expect(e.message).toBe('rethrow exception error');
+      expect(e.caughtByJasmine).toBeTruthy();
+    }
   });
 
   it("continues running the functions even after an exception is thrown in an async spec", function() {

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -19,6 +19,7 @@ getJasmineRequireObj().Env = function(j$) {
     var currentlyExecutingSuites = [];
     var currentDeclarationSuite = null;
     var throwOnExpectationFailure = false;
+    var noTryCatch = false;
     var random = false;
     var seed = null;
 
@@ -176,6 +177,14 @@ getJasmineRequireObj().Env = function(j$) {
       return throwOnExpectationFailure;
     };
 
+    this.noTryCatch = function(value) {
+      noTryCatch = !!value;
+    };
+
+    this.noTryCatching = function() {
+      return noTryCatch;
+    };
+
     this.randomizeTests = function(value) {
       random = !!value;
     };
@@ -196,6 +205,7 @@ getJasmineRequireObj().Env = function(j$) {
       options.clearStack = options.clearStack || clearStack;
       options.timeout = {setTimeout: realSetTimeout, clearTimeout: realClearTimeout};
       options.fail = self.fail;
+      options.noTryCatch = !!noTryCatch;
 
       new j$.QueueRunner(options).execute();
     };


### PR DESCRIPTION
Addressing https://github.com/jasmine/jasmine/issues/1174

Add Env noTryCatch option which allows us to NOT use the try/catch block around executing spec functions in QueueRunner.execute. This allows exceptions to throw immediately and enhances the in-browser debugging experience by placing the debugger at the point of exception instead of at the point of re-throwing as in the case of catchException/QueueRunner.handleException which will lose the context of the exception.
