### PR TITLE
fallback on assignment when a spy cannot be deleted

### DIFF
--- a/spec/core/SpyRegistrySpec.js
+++ b/spec/core/SpyRegistrySpec.js
@@ -127,6 +127,29 @@ describe("SpyRegistry", function() {
 
       expect(subject.hasOwnProperty('spiedFunc')).toBe(false);
       expect(subject.spiedFunc).toBe(originalFunction);
-    })
+    });
+
+    it("restores the original function when it\'s inherited and cannot be deleted", function() {
+      // IE 8 doesn't support `Object.create` or `Object.defineProperty`
+      if (jasmine.getEnv().ieVersion < 9) { return; }
+
+      var spies = [],
+        spyRegistry = new jasmineUnderTest.SpyRegistry({currentSpies: function() { return spies; }}),
+        originalFunction = function() {},
+        subjectParent = {spiedFunc: originalFunction};
+
+      var subject = Object.create(subjectParent);
+
+      spyRegistry.spyOn(subject, 'spiedFunc');
+
+      // simulate a spy that cannot be deleted
+      Object.defineProperty(subject, 'spiedFunc', {
+        configurable: false
+      });
+
+      spyRegistry.clearSpies();
+
+      expect(jasmineUnderTest.isSpy(subject.spiedFunc)).toBe(false);
+    });
   });
 });

--- a/src/core/SpyRegistry.js
+++ b/src/core/SpyRegistry.js
@@ -53,7 +53,9 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
         };
       } else {
         restoreStrategy = function() {
-          delete obj[methodName];
+          if (!delete obj[methodName]) {
+            obj[methodName] = originalMethod;
+          }
         };
       }
 


### PR DESCRIPTION
This PR fixes #1189.

I was seeing the same behavior in my test suite, but only when running it with PhantomJS. After some digging, I noticed that my `window.localStorage` spies could not be deleted during `clearSpies` which is the reason for errors like `<spyOn> : getItem has already been spied upon`. To get around this, I just wrapped the `delete` call in an if and fallback to the old behavior (re-assigning the property to the original function) when the delete fails.