### PR TITLE
Add env execution complete callback with execution result

### DIFF
--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -21,6 +21,8 @@ getJasmineRequireObj().Env = function(j$) {
     var throwOnExpectationFailure = false;
     var random = false;
     var seed = null;
+    var allPassed = true;
+    var onComplete = function () {};
 
     var currentSuite = function() {
       return currentlyExecutingSuites[currentlyExecutingSuites.length - 1];
@@ -214,6 +216,10 @@ getJasmineRequireObj().Env = function(j$) {
       return topSuite;
     };
 
+    this.onComplete = function(callback) {
+      onComplete = callback;
+    };
+
     this.execute = function(runnablesToRun) {
       if(!runnablesToRun) {
         if (focusedRunnables.length) {
@@ -267,6 +273,8 @@ getJasmineRequireObj().Env = function(j$) {
           order: order,
           failedExpectations: topSuite.result.failedExpectations
         });
+
+        onComplete(allPassed);
       });
     };
 
@@ -414,6 +422,7 @@ getJasmineRequireObj().Env = function(j$) {
       function specResultCallback(result) {
         clearResourcesForRunnable(spec.id);
         currentSpec = null;
+        allPassed = allPassed && result.failedExpectations.length === 0;
         reporter.specDone(result);
       }
 


### PR DESCRIPTION
To add a callback after test execution, the common way seems to add a reporter and use the `jasmineDone` callback.

Having a dedicated method to do that would be a little less hacky and could be helpful to fix https://github.com/jasmine/jasmine-npm/issues/90 with https://github.com/jasmine/jasmine-npm/pull/92.