### PR TITLE
Implement spies for get/set functions on accessor properties 

### DIFF
--- a/spec/core/UtilSpec.js
+++ b/spec/core/UtilSpec.js
@@ -25,4 +25,23 @@ describe("jasmineUnderTest.util", function() {
       expect(jasmineUnderTest.util.isUndefined(undefined)).toBe(false);
     });
   });
+
+  describe("getPropertyDescriptor", function() {
+    it("get property descriptor from object", function() {
+      var obj = {prop: 1},
+        actual = jasmineUnderTest.util.getPropertyDescriptor(obj, 'prop'),
+        expected = Object.getOwnPropertyDescriptor(obj, 'prop');
+
+      expect(actual).toEqual(expected);
+    });
+
+    it("get property descriptor from object property", function() {
+      var proto = {prop: 1},
+        obj = Object.create(proto),
+        actual = jasmineUnderTest.util.getPropertyDescriptor(proto, 'prop'),
+        expected = Object.getOwnPropertyDescriptor(proto, 'prop');
+
+      expect(actual).toEqual(expected);
+    });
+  });
 });

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -293,6 +293,10 @@ getJasmineRequireObj().Env = function(j$) {
       return spyRegistry.spyOn.apply(spyRegistry, arguments);
     };
 
+    this.spyOnProperty = function() {
+      return spyRegistry.spyOnProperty.apply(spyRegistry, arguments);
+    };
+
     var suiteFactory = function(description) {
       var suite = new j$.Suite({
         env: self,

--- a/src/core/SpyRegistry.js
+++ b/src/core/SpyRegistry.js
@@ -68,6 +68,66 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
       return spiedMethod;
     };
 
+    this.spyOnProperty = function (obj, propertyName, accessType) {
+      accessType = accessType || 'get';
+
+      if (j$.util.isUndefined(obj)) {
+        throw new Error('spyOn could not find an object to spy upon for ' + propertyName + '');
+      }
+
+      if (j$.util.isUndefined(propertyName)) {
+        throw new Error('No property name supplied');
+      }
+
+      var descriptor;
+      try {
+        descriptor = j$.util.getPropertyDescriptor(obj, propertyName);
+      } catch(e) {
+        // IE 8 doesn't support `definePropery` on non-DOM nodes
+      }
+
+      if (!descriptor) {
+        throw new Error(propertyName + ' property does not exist');
+      }
+
+      if (!descriptor.configurable) {
+        throw new Error(propertyName + ' is not declared configurable');
+      }
+
+      if(!descriptor[accessType]) {
+        throw new Error('Property ' + propertyName + ' does not have access type ' + accessType);
+      }
+
+      if (j$.isSpy(descriptor[accessType])) {
+        //TODO?: should this return the current spy? Downside: may cause user confusion about spy state
+        throw new Error(propertyName + ' has already been spied upon');
+      }
+
+      var originalDescriptor = j$.util.clone(descriptor),
+        spy = j$.createSpy(propertyName, descriptor[accessType]),
+        restoreStrategy;
+
+      if (Object.prototype.hasOwnProperty.call(obj, propertyName)) {
+        restoreStrategy = function() {
+          Object.defineProperty(obj, propertyName, originalDescriptor);
+        };
+      } else {
+        restoreStrategy = function() {
+          delete obj[propertyName];
+        };
+      }
+
+      currentSpies().push({
+        restoreObjectToOriginalState: restoreStrategy
+      });
+
+      descriptor[accessType] = spy;
+
+      Object.defineProperty(obj, propertyName, descriptor);
+
+      return spy;
+    };
+
     this.clearSpies = function() {
       var spies = currentSpies();
       for (var i = spies.length - 1; i >= 0; i--) {

--- a/src/core/requireInterface.js
+++ b/src/core/requireInterface.js
@@ -56,6 +56,10 @@ getJasmineRequireObj().interface = function(jasmine, env) {
       return env.spyOn(obj, methodName);
     },
 
+    spyOnProperty: function(obj, methodName, accessType) {
+      return env.spyOnProperty(obj, methodName, accessType);
+    },
+
     jsApiReporter: new jasmine.JsApiReporter({
       timer: new jasmine.Timer()
     }),

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -55,5 +55,17 @@ getJasmineRequireObj().util = function() {
     return cloned;
   };
 
+  util.getPropertyDescriptor = function(obj, methodName) {
+    var descriptor,
+      proto = obj;
+
+    do {
+      descriptor = Object.getOwnPropertyDescriptor(proto, methodName);
+      proto = Object.getPrototypeOf(proto);
+    } while (!descriptor && proto);
+
+    return descriptor;
+  };
+
   return util;
 };


### PR DESCRIPTION
This PR is a rebased version of #1008 against the current master branch of jasmine/jasmine, SHA 8624a52ee0b6f13b3b608ea6417ccc02257c5412.

I have proposed this to hopefully get this feature into base, fixing the merge conflicts, as the original PR author has not yes updated his PR.
