### PR TITLE
Pontential fix for https://github.com/jasmine/jasmine-npm/issues/88

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -2013,7 +2013,7 @@ getJasmineRequireObj().ReportDispatcher = function() {
     this.addReporter = function(reporter) {
       reporters.push(reporter);
     };
-    
+
     this.provideFallbackReporter = function(reporter) {
       fallbackReporter = reporter;
     };
@@ -2022,7 +2022,7 @@ getJasmineRequireObj().ReportDispatcher = function() {
     return this;
 
     function dispatch(method, args) {
-      if (reporters.length === 0 && fallbackReporter !== null) {
+      if (reporters.length === 1 && fallbackReporter !== null) {
           reporters.push(fallbackReporter);
       }
       for (var i = 0; i < reporters.length; i++) {


### PR DESCRIPTION
At first glance it seems like this pr would address this issue: https://github.com/jasmine/jasmine-npm/issues/88 without major concerns, however, I'm not sure if there will be any repercussions to the reporter fallback logic (if there are tests targeting that, we are in the clear). But here's what I do know, [this](https://github.com/jasmine/jasmine-npm/blob/31897dd9450f7e719ce962f23761948803950573/lib/jasmine.js#L177) executes before [this](https://github.com/jasmine/jasmine/blob/master/lib/jasmine-core/jasmine.js#L2025), so the "reporters" length can never be 0. This one flip of the switch was enough to resolve my issue, with my current setup. I suspect that if this is not the right answer, it will empower someone with more knowledge about the system to squash this bug at the root.