### PR TITLE
Fix `TypeError: Cannot read property 'result' of undefined`

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -2334,7 +2334,7 @@ getJasmineRequireObj().Suite = function(j$) {
   };
 
   function isAfterAll(children) {
-    return children && children[0].result.status;
+    return children && children[0] && children[0].result && children[0].result.status;
   }
 
   function isFailure(args) {


### PR DESCRIPTION
...via safer property access.  

The previous implementation is throwing errors when `this.children` is empty.  I don't know enough about jasmine to know when that situation occurs, but I believe I should be seeing some kind of test or code error rather than a jasmine error related to `TypeError: Cannot read property 'result' of undefined`.

Console output before this change:
```
return children && children[0].result.status;
                              ^

TypeError: Cannot read property 'result' of undefined
at isAfterAll (/path/to/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:2337:35)
at Suite.onException (/path/to/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:2300:8)
at Suite.onException (/path/to/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:2312:27)
at QueueRunner.onException (/path/to/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:2419:28)
at onException (/path/to/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1980:12)
at Timeout._onTimeout (/path/to/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1966:11)
at tryOnTimeout (timers.js:232:11)
at Timer.listOnTimeout (timers.js:202:5)
```