### PR TITLE
Add support of pend() reason to Suites.

### DIFF
--- a/spec/core/SuiteSpec.js
+++ b/spec/core/SuiteSpec.js
@@ -95,6 +95,15 @@ describe("Suite", function() {
     suite.pend();
 
     expect(suite.getResult().status).toBe('pending');
+    expect(suite.getResult().pendingReason).toBe('');
+  });
+
+  it("should set the pendingReason", function() {
+    var suite = new jasmineUnderTest.Suite({});
+    suite.pend('custom message');
+
+    expect(suite.getResult().status).toBe('pending');
+    expect(suite.getResult().pendingReason).toBe('custom message');
   });
 
   it("priviledges a disabled status over pending status", function() {

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -20,7 +20,8 @@ getJasmineRequireObj().Suite = function(j$) {
       id: this.id,
       description: this.description,
       fullName: this.getFullName(),
-      failedExpectations: []
+      failedExpectations: [],
+      pendingReason: ''
     };
   }
 
@@ -44,6 +45,9 @@ getJasmineRequireObj().Suite = function(j$) {
 
   Suite.prototype.pend = function(message) {
     this.markedPending = true;
+    if (message) {
+      this.result.pendingReason = message;
+    }
   };
 
   Suite.prototype.beforeEach = function(fn) {

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -235,9 +235,13 @@ jasmineRequire.HtmlReporter = function(j$) {
         for (var i = 0; i < resultsTree.children.length; i++) {
           var resultNode = resultsTree.children[i];
           if (resultNode.type == 'suite') {
+            var suiteDescription = resultNode.result.description;
+            if (resultNode.result.status === 'pending' && resultNode.result.pendingReason !== '') {
+              suiteDescription = suiteDescription + ' PENDING WITH MESSAGE: ' + resultNode.result.pendingReason;
+            }
             var suiteListNode = createDom('ul', {className: 'jasmine-suite', id: 'suite-' + resultNode.result.id},
-              createDom('li', {className: 'jasmine-suite-detail'},
-                createDom('a', {href: specHref(resultNode.result)}, resultNode.result.description)
+              createDom('li', {className: 'jasmine-suite-detail jasmine-' + resultNode.result.status},
+                createDom('a', {href: specHref(resultNode.result)}, suiteDescription)
               )
             );
 


### PR DESCRIPTION
This fixes #1132, mostly by recording the `.pend()` message and making it available for reporters (this PR also updates the `HtmlReporter` to take the message into account). I suppose a next-step would be to update the console reporter in `jasmine-npm` (https://github.com/jasmine/jasmine-npm) to do the same.

JSHint is green, passing in node and browser environments. 
