### PR TITLE
Small enhancement to let a user pass an ES6 class into Jasmine and ha…

### DIFF
--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -124,4 +124,34 @@ describe('Spies', function () {
       }).toThrow("createSpyObj requires a non-empty array or object of method names to create spies for");
     });
   });
+
+  describe("createSpyForClass", function() {
+
+    // transpiled Typescript class using tsc targeting ES5
+    var TscClassTranspiledToES5 = (function () {
+      function TestClass() {
+      }
+      TestClass.prototype.testMethod1 = function () {
+        return "";
+      };
+      TestClass.prototype.testMethod2 = function () {
+        return "";
+      };
+      return TestClass;
+    }());
+
+
+    it("should create an object with spy methods when you call jasmine.createSpyForClass() with a Typescript class", function () {
+      var spyObj = jasmineUnderTest.createSpyForClass(TscClassTranspiledToES5);
+
+      spyObj.testMethod1.and.returnValue(42);
+      spyObj.testMethod2.and.returnValue("special sauce");
+
+      expect(spyObj.testMethod1()).toEqual(42);
+      expect(spyObj.testMethod1.and.identity()).toEqual('TestClass.testMethod1');
+
+      expect(spyObj.testMethod2()).toEqual("special sauce");
+      expect(spyObj.testMethod2.and.identity()).toEqual('TestClass.testMethod2');
+    });
+  });
 });

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -118,4 +118,36 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
 
     return obj;
   };
+
+  j$.createSpyForClass = function(Class) {
+
+    if (!Class || !Class.prototype || !Class.prototype.constructor || !Class.prototype.constructor.name) {
+      throw 'createSpyForClass requires an ES6 style class';
+    }
+
+    var props = [];
+    var currentSearchClass = Class;
+
+    // search for any class methods
+    do {
+      if (currentSearchClass.prototype && Object.getOwnPropertyNames(currentSearchClass.prototype)) {
+        var currentProps = Object.getOwnPropertyNames(currentSearchClass.prototype);
+
+        // check for duplicates and only add functions
+        for (var propIndex = 0; propIndex < currentProps.length; propIndex++) {
+          var prop = currentProps[propIndex];
+          if (props.indexOf(prop) === -1 && typeof currentSearchClass.prototype[prop] === 'function') {
+            props.push(prop);
+          }
+        }
+      }
+
+      // move up the prototype hierarchy
+      currentSearchClass = Object.getPrototypeOf(currentSearchClass);
+    } while (currentSearchClass);
+
+    // create a spy object containing all the props
+    return jasmine.createSpyObj(Class.prototype.constructor.name, props);
+  };
+
 };


### PR DESCRIPTION
Hi Jasmine folks,

Here's a little enhancement for you. Something I miss coming from the Java world is the ability to give Jasmine a class (I use typescript and ES6) and have Jasmine automatically create an object with all the method in the class spied on. This means that I can more easily create spy objects and know that the methods have the right names (refactoring support often misses changing method names when you use jasmine.createSpyObj mechanism).

So here's a pull request that adds that functionality.

Thanks,

Tim
