### PR TITLE
add spec basic context to failed expectation result

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1035,6 +1035,8 @@ getJasmineRequireObj().Env = function(j$) {
       }
 
       currentRunnable().addExpectationResult(false, {
+        specId: currentRunnable().id,
+        specDescription: currentRunnable().description,
         matcherName: '',
         passed: false,
         expected: '',


### PR DESCRIPTION
This is more of a question than it is a PR as I realize that more than `this.fail` would need to be updated in order to complete this request.

I'm running Jasmine with WebDriverIO and thankfully I am able to take a screenshot after each assertion. The problem I'm encountering is that the callback that is passed the assertion data doesn't have any context so it's difficult to match the screenshot to the actual test that ran.

Here is the actual example provided by WDIO: http://webdriver.io/guide/testrunner/frameworks.html#Intercept-Assertion

Ideally, I could do something like `browser.saveScreenshot('assertionError_' + assertion.specId + '.png');`

Am I missing something? Any tips or guidance are much appreciated.