### PR TITLE
Issue 1255: Have jasmine.any(Object) not pass for null

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -78,13 +78,13 @@ To install the Ruby dependencies, you will need Ruby, Rubygems, and Bundler avai
 
 ...should get you to the point that `bundle` can install everything.
 
-To install the Node dependencies, you will need Node.js, Npm, and [Grunt](http://gruntjs.com/), the [grunt-cli](https://github.com/gruntjs/grunt-cli) and ensure that `grunt` is on your path.
+To install the Node dependencies you will need Node.js and Npm, all other dependencies are installed locally to the project.
 
-    $ npm install --local
+    $ npm install
 
 ...will install all of the node modules locally. Now run
 
-    $ grunt
+    $ npm run lint
 
 ...if you see that JSHint runs, your system is ready.
 
@@ -111,7 +111,7 @@ Jasmine uses the [Jasmine Ruby gem](http://github.com/jasmine/jasmine-gem) to te
 
 Jasmine uses the [Jasmine NPM package](http://github.com/jasmine/jasmine-npm) to test itself in a Node.js/npm environment.
 
-    $ grunt execSpecsInNode
+    $ npm test
 
 ...and then the results will print to the console. All specs run except those that expect a browser (the specs in `spec/html` are ignored).
 
@@ -127,11 +127,11 @@ The easiest way to run the tests in **Internet Explorer** is to run a VM that ha
 ## Before Committing or Submitting a Pull Request
 
 1. Ensure all specs are green in browser *and* node
-1. Ensure JSHint is green with `grunt jshint`
-1. Build `jasmine.js` with `grunt buildDistribution` and run all specs again - this ensures that your changes self-test well
+1. Ensure JSHint is green with `npm run lint`
+1. Build `jasmine.js` with `npm run build` and run all specs again - this ensures that your changes self-test well
 
 ## Submitting a Pull Request
-1. Revert your changes to `jasmine.js` and `jasmine-html.js`
+1. Revert your changes to `jasmine.js` and `jasmine-html.js` (in `lib/jasmine-core/`)
   * We do this because `jasmine.js` and `jasmine-html.js` are auto-generated (as you've seen in the previous steps) and accepting multiple pull requests when this auto-generated file changes causes lots of headaches
 1. When we accept your pull request, we will generate these files as a separate commit and merge the entire branch into master
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,7 @@ Please attempt to keep commits to `master` small, but cohesive. If a feature is 
 
 We attempt to stick to [Semantic Versioning](http://semver.org/). Most of the time, development should be against a new minor version - fixing bugs and adding new features that are backwards compatible.
 
-The current version lives in the file `/package.json`. This version will be the version number that is currently released. When releasing a new version, update `package.json` with the new version and `grunt build:copyVersionToGem` to update the gem version number.
+The current version lives in the file `/package.json`. This version will be the version number that is currently released. When releasing a new version, update `package.json` with the new version and `npm run build:rubygem` to update the gem version number.
 
 This version is used by both `jasmine.js` and the `jasmine-core` Ruby gem.
 
@@ -36,7 +36,7 @@ When ready to release - specs are all green and the stories are done:
 
 ### Build standalone distribution
 
-1. Build the standalone distribution with `grunt buildStandaloneDist`
+1. Build the standalone distribution with `npm run build:standalone`
 
 ### Release the Python egg
 
@@ -44,7 +44,7 @@ When ready to release - specs are all green and the stories are done:
 
 ### Release the Ruby gem
 
-1. Copy version to the Ruby gem with `grunt build:copyVersionToGem`
+1. Copy version to the Ruby gem with `npm run build:rubygem`
 1. __NOTE__: You will likely need to point to a local jasmine gem in order to run tests locally. _Do not_ push this version of the Gemfile.
 1. __NOTE__: You will likely need to push a new jasmine gem with a dependent version right after this release.
 1. Push these changes to GitHub and verify that this SHA is green

--- a/lib/console/console.js
+++ b/lib/console/console.js
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2016 Pivotal Labs
+Copyright (c) 2008-2017 Pivotal Labs
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/jasmine-core/boot.js
+++ b/lib/jasmine-core/boot.js
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2016 Pivotal Labs
+Copyright (c) 2008-2017 Pivotal Labs
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/jasmine-core/node_boot.js
+++ b/lib/jasmine-core/node_boot.js
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2016 Pivotal Labs
+Copyright (c) 2008-2017 Pivotal Labs
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   "homepage": "http://jasmine.github.io",
   "main": "./lib/jasmine-core.js",
   "devDependencies": {
-    "glob": "~7.0.5",
-    "grunt": "^1.0.1",
-    "grunt-cli": "^1.2.0",
-    "grunt-contrib-compass": "^1.1.1",
-    "grunt-contrib-compress": "^1.3.0",
-    "grunt-contrib-concat": "^1.0.1",
-    "grunt-contrib-jshint": "^1.0.0",
-    "jasmine": "^2.5.0",
-    "load-grunt-tasks": "^0.4.0",
-    "shelljs": "^0.7.0",
-    "temp": "~0.8.1"
+    "glob": "7.1.1",
+    "grunt": "1.0.1",
+    "grunt-cli": "1.2.0",
+    "grunt-contrib-compass": "1.1.1",
+    "grunt-contrib-compress": "1.4.1",
+    "grunt-contrib-concat": "1.0.1",
+    "grunt-contrib-jshint": "1.1.0",
+    "jasmine": "2.5.3",
+    "load-grunt-tasks": "3.5.2",
+    "shelljs": "0.7.6",
+    "temp": "0.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "bdd"
   ],
   "scripts": {
+    "benchmark": "grunt execSpecsInNode:performance",
+    "build": "grunt buildDistribution",
+    "build:rubygem": "grunt build:copyVersionToGem",
+    "build:standalone": "grunt buildStandaloneDist",
+    "lint": "grunt jshint",
     "test": "grunt jshint execSpecsInNode"
   },
   "description": "Official packaging of Jasmine's core files for use by Node.js projects.",

--- a/spec/core/asymmetric_equality/AnySpec.js
+++ b/spec/core/asymmetric_equality/AnySpec.js
@@ -21,6 +21,7 @@ describe("Any", function() {
     var any = new jasmineUnderTest.Any(Object);
 
     expect(any.asymmetricMatch({})).toBe(true);
+    expect(any.asymmetricMatch(null)).toBe(false);
   });
 
   it("matches a Boolean", function() {

--- a/src/core/asymmetric_equality/Any.js
+++ b/src/core/asymmetric_equality/Any.js
@@ -24,7 +24,7 @@ getJasmineRequireObj().Any = function(j$) {
     }
 
     if (this.expectedObject == Object) {
-      return typeof other == 'object';
+      return Object.prototype.toString.call(other) == '[object Object]';
     }
 
     if (this.expectedObject == Boolean) {


### PR DESCRIPTION
This pull request aims to:

+ Fix #1255 by ensuring `jasmine.any(Object)` returns `false` for `null`.
+ Update npm dependencies.
+ Use npm scripts and remove the need for contributors to install `grunt` globally, also giving control to the project over specifically which version of `grunt` is used by contributors.

Hope this helps, thanks.

/cc @lmj0011