### PR TITLE
[QueueRunner] Support "thenables" returned by tests

### DIFF
--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -29,15 +29,15 @@ getJasmineRequireObj().QueueRunner = function(j$) {
   QueueRunner.prototype.run = function(queueableFns, recursiveIndex) {
     var length = queueableFns.length,
       self = this,
-      iterativeIndex;
-
+      iterativeIndex,
+      promise;
 
     for(iterativeIndex = recursiveIndex; iterativeIndex < length; iterativeIndex++) {
       var queueableFn = queueableFns[iterativeIndex];
-      if (queueableFn.fn.length == 0) {
+      if (queueableFn.fn.length === 0) {
         try {
           // Synchronous tests may return a promise.
-          var promise = queueableFn.fn.call(self.userContext);
+          promise = queueableFn.fn.call(self.userContext);
         } catch (e) {
           handleException(e, queueableFn);
         }

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -41,7 +41,10 @@ getJasmineRequireObj().QueueRunner = function(j$) {
         } catch (e) {
           handleException(e, queueableFn);
         }
-        if (!promise || typeof promise.then !== 'function') {
+        if (promise && typeof promise.then !== 'function') {
+          promise = null;
+        }
+        if (!promise) {
           continue;
         }
       }

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -34,38 +34,30 @@ getJasmineRequireObj().QueueRunner = function(j$) {
 
     for(iterativeIndex = recursiveIndex; iterativeIndex < length; iterativeIndex++) {
       var queueableFn = queueableFns[iterativeIndex];
-      if (queueableFn.fn.length > 0) {
-        attemptAsync(queueableFn);
-        return;
-      } else {
-        attemptSync(queueableFn);
+      if (queueableFn.fn.length == 0) {
+        try {
+          // Synchronous tests may return a promise.
+          var promise = queueableFn.fn.call(self.userContext);
+        } catch (e) {
+          handleException(e, queueableFn);
+        }
+        if (!promise || typeof promise.then !== 'function') {
+          continue;
+        }
       }
-    }
 
-    this.clearStack(this.onComplete);
-
-    function attemptSync(queueableFn) {
-      try {
-        queueableFn.fn.call(self.userContext);
-      } catch (e) {
-        handleException(e, queueableFn);
-      }
-    }
-
-    function attemptAsync(queueableFn) {
-      var clearTimeout = function () {
+      var timeoutId,
+        clearTimeout = function() {
           Function.prototype.apply.apply(self.timeout.clearTimeout, [j$.getGlobal(), [timeoutId]]);
         },
-        next = once(function () {
+        next = once(function() {
           clearTimeout(timeoutId);
           self.run(queueableFns, iterativeIndex + 1);
-        }),
-        timeoutId;
-
-      next.fail = function() {
-        self.fail.apply(null, arguments);
-        next();
-      };
+        });
+        next.fail = function() {
+          self.fail.apply(null, arguments);
+          next();
+        };
 
       if (queueableFn.timeout) {
         timeoutId = Function.prototype.apply.apply(self.timeout.setTimeout, [j$.getGlobal(), [function() {
@@ -75,13 +67,23 @@ getJasmineRequireObj().QueueRunner = function(j$) {
         }, queueableFn.timeout()]]);
       }
 
-      try {
-        queueableFn.fn.call(self.userContext, next);
-      } catch (e) {
-        handleException(e, queueableFn);
-        next();
+      if (promise) {
+        promise.then(next, next.fail);
+      } else {
+        try {
+          queueableFn.fn.call(self.userContext, next);
+        } catch (e) {
+          handleException(e, queueableFn);
+          next();
+        }
       }
+
+      // Prevent further iterations until
+      // the asynchronous test is finished.
+      return;
     }
+
+    this.clearStack(this.onComplete);
 
     function onException(e) {
       self.onException(e);


### PR DESCRIPTION
This commit allows `done` or `done.fail` to be called by a returned promise/thenable.

This reduces the following boilerplate:
- `promise.then(done)`
- `promise.catch(done.fail)`

Includes **tests** for resolved promises and rejected promises.
Should I include one for pending promises, too?

### Example

```js
it(() => {
  return fetch('http://www.google.com')
    .then(res => expect(res).toBe(...));
});
```

- If the returned thenable is resolved, the `done` function is called.
- If the returned thenable is rejected, the `done.fail` function is called.

### Failure tests

To test failure cases, you can `catch` the error and call `expect(error.message)`.

```js
it(() => {
  return fetch('bad url')
    .catch(error => expect(error.message).toBe(...));
});
```