### PR TITLE
Custom Error Messages

### DIFF
--- a/spec/core/ExpectationSpec.js
+++ b/spec/core/ExpectationSpec.js
@@ -113,6 +113,7 @@ describe("Expectation", function() {
       matcherName: "toFoo",
       passed: true,
       message: "",
+      error: undefined,
       expected: "hello",
       actual: "an actual"
     });
@@ -146,7 +147,8 @@ describe("Expectation", function() {
       passed: false,
       expected: "hello",
       actual: "an actual",
-      message: ""
+      message: "",
+      error: undefined
     });
   });
 
@@ -179,7 +181,8 @@ describe("Expectation", function() {
       passed: false,
       expected: "hello",
       actual: "an actual",
-      message: "I am a custom message"
+      message: "I am a custom message",
+      error: undefined
     });
   });
 
@@ -212,7 +215,8 @@ describe("Expectation", function() {
       passed: false,
       expected: "hello",
       actual: "an actual",
-      message: "I am a custom message"
+      message: "I am a custom message",
+      error: undefined
     });
   });
 
@@ -244,6 +248,7 @@ describe("Expectation", function() {
       matcherName: "toFoo",
       passed: true,
       message: "",
+      error: undefined,
       expected: "hello",
       actual: actual
     });
@@ -279,7 +284,8 @@ describe("Expectation", function() {
       passed: false,
       expected: "hello",
       actual: actual,
-      message: "default message"
+      message: "default message",
+      error: undefined
     });
   });
 
@@ -314,7 +320,8 @@ describe("Expectation", function() {
       passed: false,
       expected: "hello",
       actual: actual,
-      message: "I am a custom message"
+      message: "I am a custom message",
+      error: undefined
     });
   });
 
@@ -345,7 +352,8 @@ describe("Expectation", function() {
       passed: true,
       expected: "hello",
       actual: actual,
-      message: ""
+      message: "",
+      error: undefined
     });
   });
 
@@ -381,7 +389,8 @@ describe("Expectation", function() {
       passed: false,
       expected: "hello",
       actual: actual,
-      message: "I'm a custom message"
+      message: "I'm a custom message",
+      error: undefined
     });
   });
   

--- a/spec/core/ExpectationSpec.js
+++ b/spec/core/ExpectationSpec.js
@@ -384,6 +384,42 @@ describe("Expectation", function() {
       message: "I'm a custom message"
     });
   });
+  
+  it("reports a custom error message to the spec", function() {
+    var customError = new Error("I am a custom error");
+    var matchers = {
+        toFoo: function() {
+          return {
+            compare: function() {
+              return {
+                pass: false,
+                message: "I am a custom message",
+                error: customError
+              };
+            }
+          };
+        }
+      },
+      addExpectationResult = jasmine.createSpy("addExpectationResult"),
+      expectation;
+
+    expectation = new jasmineUnderTest.Expectation({
+      actual: "an actual",
+      customMatchers: matchers,
+      addExpectationResult: addExpectationResult
+    });
+
+    expectation.toFoo("hello");
+
+    expect(addExpectationResult).toHaveBeenCalledWith(false, {
+      matcherName: "toFoo",
+      passed: false,
+      expected: "hello",
+      actual: "an actual",
+      message: "I am a custom message",
+      error: customError
+    });
+  });
 
 });
 

--- a/src/core/Expectation.js
+++ b/src/core/Expectation.js
@@ -65,6 +65,7 @@ getJasmineRequireObj().Expectation = function() {
           matcherName: name,
           passed: result.pass,
           message: message,
+          error: result.error,
           actual: this.actual,
           expected: expected // TODO: this may need to be arrayified/sliced
         }


### PR DESCRIPTION
Closes #1123 

Allow custom matchers to return custom errors.