### PR TITLE
Updating introduction url to last version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Jasmine is a Behavior Driven Development testing framework for JavaScript. It does not rely on browsers, DOM, or any JavaScript framework. Thus it's suited for websites, [Node.js](http://nodejs.org) projects, or anywhere that JavaScript can run.
 
 Documentation & guides live here: [http://jasmine.github.io](http://jasmine.github.io/)
-For a quick start guide of Jasmine 2.0, see the beginning of [http://jasmine.github.io/2.0/introduction.html](http://jasmine.github.io/2.0/introduction.html)
+For a quick start guide of Jasmine 2.x, see the beginning of [http://jasmine.github.io/edge/introduction.html](http://jasmine.github.io/edge/introduction.html)
 
 Upgrading from Jasmine 1.x? Check out the [2.0 release notes](https://github.com/jasmine/jasmine/blob/v2.0.0/release_notes/20.md) for a list of what's new (including breaking interface changes). You can also read the [upgrade guide](http://jasmine.github.io/2.0/upgrading.html).
 


### PR DESCRIPTION
Three tests in documentation version 2.0 fail, because lack of:
`returnValue: undefined`
They are fixed in last version.