### PR TITLE
iterate through keys with a regular for loop

### DIFF
--- a/spec/core/matchers/matchersUtilSpec.js
+++ b/spec/core/matchers/matchersUtilSpec.js
@@ -418,8 +418,12 @@ describe("matchersUtil", function() {
       // IE 8 doesn't support `definePropery` on non-DOM nodes
       if (jasmine.getEnv().ieVersion < 9) { return; }
 
+      var findIndexDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, 'findIndex');
+      if (!findIndexDescriptor) {
+        return;
+      }
+
       beforeEach(function() {
-        this.origDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, 'findIndex');
         Object.defineProperty(Array.prototype, 'findIndex', {
           enumerable: true,
           value: function (predicate) {
@@ -449,7 +453,7 @@ describe("matchersUtil", function() {
       });
 
       afterEach(function() {
-        Object.defineProperty(Array.prototype, 'findIndex', this.origDescriptor);
+        Object.defineProperty(Array.prototype, 'findIndex', findIndexDescriptor);
       });
 
       it("passes when there's an array polyfill", function() {

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -327,7 +327,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
     }
 
     var extraKeys = [];
-    for (var i in allKeys) {
+    for (var i = 0; i < allKeys.length; i++) {
       if (!allKeys[i].match(/^[0-9]+$/)) {
         extraKeys.push(allKeys[i]);
       }


### PR DESCRIPTION
This PR addresses the #1188 regression in 2.6.0 by reintroducing the code from #1192. I also added a test for this that simulates what's going on in PhantomJS by adding an enumerable polyfill to the Array prototype.

Also related:
#1324 
#1321
#1195 