### PR TITLE
+ fix GlobalErrors - check for undefined global.process.listeners

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -2174,7 +2174,7 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
     this.uninstall = function noop() {};
 
     this.install = function install() {
-      if (global.process && j$.isFunction_(global.process.on)) {
+      if (global.process && global.process.listeners && j$.isFunction_(global.process.on)) {
         var originalHandlers = global.process.listeners('uncaughtException');
         global.process.removeAllListeners('uncaughtException');
         global.process.on('uncaughtException', onerror);


### PR DESCRIPTION
jasmine makes karma fails when global.process.listeners is undefined , karma just stops execution showing jasmine error. this simple extra check fix it.

working with windows 10 and karma-typescript.