### PR TITLE
beforeEach, afterEach, beforeAll, afterAll support async function.

### DIFF
--- a/spec/core/EnvSpec.js
+++ b/spec/core/EnvSpec.js
@@ -128,7 +128,13 @@ describe("Env", function() {
     it('throws an error when it receives a non-fn argument', function() {
       expect(function() {
         env.beforeEach(undefined);
-      }).toThrowError(/beforeEach expects a function argument; received \[object (Undefined|DOMWindow|Object)\]/);
+      }).toThrowError(/beforeEach expects a function or async function argument; received \[object (Undefined|DOMWindow|Object)\]/);
+    });
+
+    it('does not throw when it receives a async function', function() {
+      expect(function() {
+        env.beforeEach(async function(){});
+      }).not.toThrow()
     });
   });
 
@@ -136,7 +142,7 @@ describe("Env", function() {
     it('throws an error when it receives a non-fn argument', function() {
       expect(function() {
         env.beforeAll(undefined);
-      }).toThrowError(/beforeAll expects a function argument; received \[object (Undefined|DOMWindow|Object)\]/);
+      }).toThrowError(/beforeAll expects a function or async function argument; received \[object (Undefined|DOMWindow|Object)\]/);
     });
   });
 
@@ -144,7 +150,7 @@ describe("Env", function() {
     it('throws an error when it receives a non-fn argument', function() {
       expect(function() {
         env.afterEach(undefined);
-      }).toThrowError(/afterEach expects a function argument; received \[object (Undefined|DOMWindow|Object)\]/);
+      }).toThrowError(/afterEach expects a function or async function argument; received \[object (Undefined|DOMWindow|Object)\]/);
     });
   });
 
@@ -152,7 +158,7 @@ describe("Env", function() {
     it('throws an error when it receives a non-fn argument', function() {
       expect(function() {
         env.afterAll(undefined);
-      }).toThrowError(/afterAll expects a function argument; received \[object (Undefined|DOMWindow|Object)\]/);
+      }).toThrowError(/afterAll expects a function or async function argument; received \[object (Undefined|DOMWindow|Object)\]/);
     });
   });
 });

--- a/spec/core/EnvSpec.js
+++ b/spec/core/EnvSpec.js
@@ -130,12 +130,6 @@ describe("Env", function() {
         env.beforeEach(undefined);
       }).toThrowError(/beforeEach expects a function or async function argument; received \[object (Undefined|DOMWindow|Object)\]/);
     });
-
-    it('does not throw when it receives a async function', function() {
-      expect(function() {
-        env.beforeEach(async function(){});
-      }).not.toThrow()
-    });
   });
 
   describe('#beforeAll', function () {

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -309,6 +309,12 @@ getJasmineRequireObj().Env = function(j$) {
       return spyRegistry.spyOnProperty.apply(spyRegistry, arguments);
     };
 
+    var ensureIsFunctionOrAsyncFunction = function(fn, caller) {
+      if (!j$.isFunction_(fn) && !j$.isAsyncFunction_(fn)) {
+        throw new Error(caller + ' expects a function or async function argument; received ' + j$.getType_(fn));
+      }
+    };
+
     var ensureIsFunction = function(fn, caller) {
       if (!j$.isFunction_(fn)) {
         throw new Error(caller + ' expects a function argument; received ' + j$.getType_(fn));
@@ -492,7 +498,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.beforeEach = function(beforeEachFunction, timeout) {
-      ensureIsFunction(beforeEachFunction, 'beforeEach');
+      ensureIsFunctionOrAsyncFunction(beforeEachFunction, 'beforeEach');
       currentDeclarationSuite.beforeEach({
         fn: beforeEachFunction,
         timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
@@ -500,7 +506,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.beforeAll = function(beforeAllFunction, timeout) {
-      ensureIsFunction(beforeAllFunction, 'beforeAll');
+      ensureIsFunctionOrAsyncFunction(beforeAllFunction, 'beforeAll');
       currentDeclarationSuite.beforeAll({
         fn: beforeAllFunction,
         timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
@@ -508,7 +514,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.afterEach = function(afterEachFunction, timeout) {
-      ensureIsFunction(afterEachFunction, 'afterEach');
+      ensureIsFunctionOrAsyncFunction(afterEachFunction, 'afterEach');
       currentDeclarationSuite.afterEach({
         fn: afterEachFunction,
         timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
@@ -516,7 +522,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.afterAll = function(afterAllFunction, timeout) {
-      ensureIsFunction(afterAllFunction, 'afterAll');
+      ensureIsFunctionOrAsyncFunction(afterAllFunction, 'afterAll');
       currentDeclarationSuite.afterAll({
         fn: afterAllFunction,
         timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -54,6 +54,10 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
     return j$.isA_('Number', value);
   };
 
+  j$.isAsyncFunction_ = function(value) {
+    return j$.isA_('AsyncFunction', value);
+  };
+
   j$.isFunction_ = function(value) {
     return j$.isA_('Function', value);
   };


### PR DESCRIPTION
This PR will supports async function with

* beforeEach()
* afterEach()
* beforeAll()
* afterAll()

it() is not supported because #1270 is now "waiting".

I am looking forward to jasmine to fully support asynchronous functions!
