### PR TITLE
Don't crash if an error occurs when no error handlers are installed

### DIFF
--- a/spec/core/GlobalErrorsSpec.js
+++ b/spec/core/GlobalErrorsSpec.js
@@ -1,4 +1,22 @@
 describe("GlobalErrors", function() {
+  it("is installed only when there are listeners", function() {
+    var fakeGlobal = { onerror: null },
+      errors = new jasmineUnderTest.GlobalErrors(fakeGlobal);
+
+    errors.install();
+    expect(fakeGlobal.onerror).toBeNull();
+
+    errors.pushListener(function() {});
+    expect(fakeGlobal.onerror).not.toBeNull();
+
+    errors.pushListener(function() {});
+    errors.popListener();
+    expect(fakeGlobal.onerror).not.toBeNull();
+
+    errors.popListener();
+    expect(fakeGlobal.onerror).toBeNull();
+  });
+
   it("calls the added handler on error", function() {
     var fakeGlobal = { onerror: null },
         handler = jasmine.createSpy('errorHandler'),
@@ -54,6 +72,7 @@ describe("GlobalErrors", function() {
     expect(fakeGlobal.onerror).toBe(originalCallback);
 
     errors.install();
+    errors.pushListener(function() {});
 
     expect(fakeGlobal.onerror).not.toBe(originalCallback);
 
@@ -75,11 +94,10 @@ describe("GlobalErrors", function() {
         errors = new jasmineUnderTest.GlobalErrors(fakeGlobal);
 
     errors.install();
+    errors.pushListener(handler);
     expect(fakeGlobal.process.on).toHaveBeenCalledWith('uncaughtException', jasmine.any(Function));
     expect(fakeGlobal.process.listeners).toHaveBeenCalledWith('uncaughtException');
     expect(fakeGlobal.process.removeAllListeners).toHaveBeenCalledWith('uncaughtException');
-
-    errors.pushListener(handler);
 
     var addedListener = fakeGlobal.process.on.calls.argsFor(0)[1];
     addedListener(new Error('bar'));

--- a/src/core/GlobalErrors.js
+++ b/src/core/GlobalErrors.js
@@ -1,6 +1,6 @@
 getJasmineRequireObj().GlobalErrors = function(j$) {
   function GlobalErrors(global) {
-    var handlers = [], installed = false, originalHandler = null;
+    var handlers = [], installable = false, installed = false, originalHandler = null;
     global = global || j$.getGlobal();
 
     var onerror = function onerror() {
@@ -9,6 +9,11 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
     };
 
     this.uninstall = function uninstall() {
+      unregister();
+      installable = false;
+    };
+
+    var unregister = function unregister() {
       if (!installed) {
         return;
       }
@@ -27,6 +32,10 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
     };
 
     this.install = function install() {
+      installable = true;
+    };
+
+    var register = function register() {
       if (global.process && global.process.listeners && j$.isFunction_(global.process.on)) {
         originalHandler = global.process.listeners('uncaughtException');
         global.process.removeAllListeners('uncaughtException');
@@ -41,10 +50,18 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
 
     this.pushListener = function pushListener(listener) {
       handlers.push(listener);
+
+      if (installable && !installed) {
+        register();
+      }
     };
 
     this.popListener = function popListener() {
       handlers.pop();
+
+      if (handlers.length === 0) {
+        unregister();
+      }
     };
   }
 


### PR DESCRIPTION
It's possible for an exception to be thrown when there aren't any listeners installed with Jasmine's GlobalErrors object. In that case,  it will try to call the nonexistent listener. The resulting exception masks the original problem (in our case, a possible state corruption bug that we're still trying to pin down).