### PR TITLE
Handle exceptions thrown "during" a suite with no children.

### DIFF
--- a/spec/core/SpecSpec.js
+++ b/spec/core/SpecSpec.js
@@ -357,6 +357,23 @@ describe("Spec", function() {
     }]);
   });
 
+  it("should return true when handling an exception", function() {
+    var spec = new jasmineUnderTest.Spec(
+      {queueableFn: { fn: function() {} }
+    });
+
+    expect(spec.onException('foo')).toEqual(true);
+  });
+
+  it("should return true when handling a pending spec exception", function() {
+    var spec = new jasmineUnderTest.Spec(
+      {queueableFn: { fn: function() {} }
+      });
+    var error = new Error(jasmineUnderTest.Spec.pendingSpecExceptionMessage);
+
+    expect(spec.onException(error)).toEqual(true);
+  });
+
   it("should not log an additional failure when handling an ExpectationFailed error", function() {
     var resultCallback = jasmine.createSpy('resultCallback'),
       spec = new jasmineUnderTest.Spec({

--- a/src/core/Spec.js
+++ b/src/core/Spec.js
@@ -78,11 +78,11 @@ getJasmineRequireObj().Spec = function(j$) {
   Spec.prototype.onException = function onException(e) {
     if (Spec.isPendingSpecException(e)) {
       this.pend(extractCustomPendingMessage(e));
-      return;
+      return true;
     }
 
     if (e instanceof j$.errors.ExpectationFailed) {
-      return;
+      return false;
     }
 
     this.addExpectationResult(false, {
@@ -92,6 +92,7 @@ getJasmineRequireObj().Spec = function(j$) {
       actual: '',
       error: e
     }, true);
+    return true;
   };
 
   Spec.prototype.disable = function() {


### PR DESCRIPTION
This is tricky to reproduce, but it can happen in certain async scenarios in the presence of focused specs if an async spec tells Jasmine that it's complete and then causes the global error event to fire later on. In that situation we avoid crashing and record the failure as a top level afterAll failure, so that it at least get surfaced to the user somewhere.