### PR TITLE
Don't mask errors that occur when no handlers are installed

### DIFF
--- a/spec/core/GlobalErrorsSpec.js
+++ b/spec/core/GlobalErrorsSpec.js
@@ -62,6 +62,22 @@ describe("GlobalErrors", function() {
     expect(fakeGlobal.onerror).toBe(originalCallback);
   });
 
+  it("rethrows the original error when there is no handler", function() {
+    var fakeGlobal = { },
+        errors = new jasmineUnderTest.GlobalErrors(fakeGlobal),
+        originalError = new Error('nope');
+
+    errors.install();
+
+    try {
+      fakeGlobal.onerror(originalError);
+    } catch (e) {
+      expect(e).toBe(originalError);
+    }
+
+    errors.uninstall();
+  });
+
   it("works in node.js", function() {
     var fakeGlobal = {
           process: {

--- a/src/core/GlobalErrors.js
+++ b/src/core/GlobalErrors.js
@@ -5,7 +5,12 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
 
     var onerror = function onerror() {
       var handler = handlers[handlers.length - 1];
-      handler.apply(null, Array.prototype.slice.call(arguments, 0));
+
+      if (handler) {
+        handler.apply(null, Array.prototype.slice.call(arguments, 0));
+      } else {
+        throw arguments[0];
+      }
     };
 
     this.uninstall = function noop() {};


### PR DESCRIPTION
It's possible for async code to cause an error when Jasmine
doesn't have any listeners registered internally. This causes
Jasmine to crash (Node) or log to the console (browser)
because of trying to call the nonexistent handler. This change
doesn't fix the overall problem but it does ensure that the
original error is logged rather than Jasmine's internal error.