### PR TITLE
Correctly route errors that occur while a QueueRunner is clearing stack

### DIFF
--- a/spec/core/QueueRunnerSpec.js
+++ b/spec/core/QueueRunnerSpec.js
@@ -252,7 +252,7 @@ describe("QueueRunner", function() {
 
       nextQueueableFn.fn.and.callFake(function() {
         // should remove the same function that was added
-        expect(globalErrors.popListener).toHaveBeenCalledWith(globalErrors.pushListener.calls.argsFor(0)[0]);
+        expect(globalErrors.popListener).toHaveBeenCalledWith(globalErrors.pushListener.calls.argsFor(1)[0]);
       });
 
       queueRunner.execute();
@@ -314,6 +314,32 @@ describe("QueueRunner", function() {
     expect(nextQueueableFn.fn).toHaveBeenCalled();
   });
 
+  it("handles exceptions thrown while waiting for the stack to clear", function() {
+    var queueableFn = { fn: function(done) { done() } },
+      global = {},
+      errorListeners = [],
+      globalErrors = {
+        pushListener: function(f) { errorListeners.push(f); },
+        popListener: function() { errorListeners.pop(); }
+      },
+      clearStack = jasmine.createSpy('clearStack'),
+      onException = jasmine.createSpy('onException'),
+      queueRunner = new jasmineUnderTest.QueueRunner({
+        queueableFns: [queueableFn],
+        globalErrors: globalErrors,
+        clearStack: clearStack,
+        onException: onException
+      }),
+      error = new Error('nope');
+
+    queueRunner.execute();
+    expect(clearStack).toHaveBeenCalled();
+    expect(errorListeners.length).toEqual(1);
+    errorListeners[0](error);
+    clearStack.calls.argsFor(0)[0]();
+    expect(onException).toHaveBeenCalledWith(error);
+  });
+
   it("calls a provided complete callback when done", function() {
     var queueableFn = { fn: jasmine.createSpy('fn') },
       completeCallback = jasmine.createSpy('completeCallback'),
@@ -342,6 +368,8 @@ describe("QueueRunner", function() {
 
     queueRunner.execute();
     expect(afterFn.fn).toHaveBeenCalled();
-    expect(clearStack).toHaveBeenCalledWith(completeCallback);
+    expect(clearStack).toHaveBeenCalled();
+    clearStack.calls.argsFor(0)[0]();
+    expect(completeCallback).toHaveBeenCalled();
   });
 });

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -238,6 +238,10 @@ getJasmineRequireObj().Env = function(j$) {
           reporter.suiteStarted(suite.result);
         },
         nodeComplete: function(suite, result) {
+          if (suite !== currentSuite()) {
+            throw new Error('Tried to complete the wrong suite');
+          }
+
           if (!suite.markedPending) {
             clearResourcesForRunnable(suite.id);
           }

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -24,6 +24,11 @@ getJasmineRequireObj().QueueRunner = function(j$) {
   }
 
   QueueRunner.prototype.execute = function() {
+    var self = this;
+    this.handleFinalError = function(error) {
+      self.onException(error);
+    };
+    this.globalErrors.pushListener(this.handleFinalError);
     this.run(this.queueableFns, 0);
   };
 
@@ -43,7 +48,10 @@ getJasmineRequireObj().QueueRunner = function(j$) {
       }
     }
 
-    this.clearStack(this.onComplete);
+    this.clearStack(function() {
+      self.globalErrors.popListener(self.handleFinalError);
+      self.onComplete();
+    });
 
     function attemptSync(queueableFn) {
       try {


### PR DESCRIPTION
Besides surfacing the error in the hopefully-correct place, this also prevents the queue runners for sibling suites from interleaving, which in turn prevents all kinds of internal state corruption. The most common problem I was seeing was an exception due to spyRegistry.clearSpies() being called repeatedly, but this also appears to fix #1349 and prevents the scenario in #1344 from happening.