### PR TITLE
Support for promises and and ES2017 async/await in before/it/after

### DIFF
--- a/spec/core/EnvSpec.js
+++ b/spec/core/EnvSpec.js
@@ -91,6 +91,13 @@ describe("Env", function() {
         env.it('pending spec');
       }).not.toThrow();
     });
+
+    it('accepts an async function', function() {
+      jasmine.getEnv().requireAsyncAwait();
+      expect(function() {
+        env.it('async', jasmine.getEnv().makeAsyncAwaitFunction());
+      }).not.toThrow();
+    });
   });
 
   describe('#xit', function() {
@@ -114,6 +121,13 @@ describe("Env", function() {
         env.xit('pending spec');
       }).not.toThrow();
     });
+
+    it('accepts an async function', function() {
+      jasmine.getEnv().requireAsyncAwait();
+      expect(function() {
+        env.xit('async', jasmine.getEnv().makeAsyncAwaitFunction());
+      }).not.toThrow();
+    });
   });
 
   describe('#fit', function () {
@@ -130,6 +144,13 @@ describe("Env", function() {
         env.beforeEach(undefined);
       }).toThrowError(/beforeEach expects a function argument; received \[object (Undefined|DOMWindow|Object)\]/);
     });
+
+    it('accepts an async function', function() {
+      jasmine.getEnv().requireAsyncAwait();
+      expect(function() {
+        env.beforeEach(jasmine.getEnv().makeAsyncAwaitFunction());
+      }).not.toThrow();
+    });
   });
 
   describe('#beforeAll', function () {
@@ -137,6 +158,13 @@ describe("Env", function() {
       expect(function() {
         env.beforeAll(undefined);
       }).toThrowError(/beforeAll expects a function argument; received \[object (Undefined|DOMWindow|Object)\]/);
+    });
+
+    it('accepts an async function', function() {
+      jasmine.getEnv().requireAsyncAwait();
+      expect(function() {
+        env.beforeAll(jasmine.getEnv().makeAsyncAwaitFunction());
+      }).not.toThrow();
     });
   });
 
@@ -146,6 +174,13 @@ describe("Env", function() {
         env.afterEach(undefined);
       }).toThrowError(/afterEach expects a function argument; received \[object (Undefined|DOMWindow|Object)\]/);
     });
+
+    it('accepts an async function', function() {
+      jasmine.getEnv().requireAsyncAwait();
+      expect(function() {
+        env.afterEach(jasmine.getEnv().makeAsyncAwaitFunction());
+      }).not.toThrow();
+    });
   });
 
   describe('#afterAll', function () {
@@ -153,6 +188,13 @@ describe("Env", function() {
       expect(function() {
         env.afterAll(undefined);
       }).toThrowError(/afterAll expects a function argument; received \[object (Undefined|DOMWindow|Object)\]/);
+    });
+
+    it('accepts an async function', function() {
+      jasmine.getEnv().requireAsyncAwait();
+      expect(function() {
+        env.afterAll(jasmine.getEnv().makeAsyncAwaitFunction());
+      }).not.toThrow();
     });
   });
 });

--- a/spec/helpers/asyncAwait.js
+++ b/spec/helpers/asyncAwait.js
@@ -1,0 +1,27 @@
+(function(env) {
+  function getAsyncCtor() {
+    try {
+      eval("var func = async function(){};");
+    } catch (e) {
+      return null;
+    }
+
+    return Object.getPrototypeOf(func).constructor;
+  }
+
+  function hasAsyncAwaitSupport() {
+    return getAsyncCtor() !== null;
+  }
+
+  env.makeAsyncAwaitFunction = function() {
+    var AsyncFunction = getAsyncCtor();
+    return new AsyncFunction("");
+  };
+
+  env.requireAsyncAwait = function() {
+    if (!hasAsyncAwaitSupport()) {
+      env.pending("Environment does not support async/await functions");
+    }
+  };
+})(jasmine.getEnv());
+

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -6,6 +6,7 @@
     "npmPackage/**/*.js"
   ],
   "helpers": [
+    "helpers/asyncAwait.js",
     "helpers/checkForSet.js",
     "helpers/nodeDefineJasmineUnderTest.js"
   ],

--- a/spec/support/jasmine.yml
+++ b/spec/support/jasmine.yml
@@ -16,6 +16,7 @@ src_files:
   - '**/*.js'
 stylesheets:
 helpers:
+  - 'helpers/asyncAwait.js'
   - 'helpers/BrowserFlags.js'
   - 'helpers/checkForSet.js'
   - 'helpers/defineJasmineUnderTest.js'

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -319,6 +319,12 @@ getJasmineRequireObj().Env = function(j$) {
       }
     };
 
+    var ensureIsFunctionOrAsync = function(fn, caller) {
+      if (!j$.isFunction_(fn) && !j$.isAsyncFunction_(fn)) {
+        throw new Error(caller + ' expects a function argument; received ' + j$.getType_(fn));
+      }
+    };
+
     var suiteFactory = function(description) {
       var suite = new j$.Suite({
         env: self,
@@ -457,7 +463,7 @@ getJasmineRequireObj().Env = function(j$) {
       // it() sometimes doesn't have a fn argument, so only check the type if
       // it's given.
       if (arguments.length > 1 && typeof fn !== 'undefined') {
-        ensureIsFunction(fn, 'it');
+        ensureIsFunctionOrAsync(fn, 'it');
       }
       var spec = specFactory(description, fn, currentDeclarationSuite, timeout);
       if (currentDeclarationSuite.markedPending) {
@@ -471,7 +477,7 @@ getJasmineRequireObj().Env = function(j$) {
       // xit(), like it(), doesn't always have a fn argument, so only check the
       // type when needed.
       if (arguments.length > 1 && typeof fn !== 'undefined') {
-        ensureIsFunction(fn, 'xit');
+        ensureIsFunctionOrAsync(fn, 'xit');
       }
       var spec = this.it.apply(this, arguments);
       spec.pend('Temporarily disabled with xit');
@@ -479,7 +485,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.fit = function(description, fn, timeout){
-      ensureIsFunction(fn, 'fit');
+      ensureIsFunctionOrAsync(fn, 'fit');
       var spec = specFactory(description, fn, currentDeclarationSuite, timeout);
       currentDeclarationSuite.addChild(spec);
       focusedRunnables.push(spec.id);
@@ -496,7 +502,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.beforeEach = function(beforeEachFunction, timeout) {
-      ensureIsFunction(beforeEachFunction, 'beforeEach');
+      ensureIsFunctionOrAsync(beforeEachFunction, 'beforeEach');
       currentDeclarationSuite.beforeEach({
         fn: beforeEachFunction,
         timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
@@ -504,7 +510,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.beforeAll = function(beforeAllFunction, timeout) {
-      ensureIsFunction(beforeAllFunction, 'beforeAll');
+      ensureIsFunctionOrAsync(beforeAllFunction, 'beforeAll');
       currentDeclarationSuite.beforeAll({
         fn: beforeAllFunction,
         timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
@@ -512,7 +518,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.afterEach = function(afterEachFunction, timeout) {
-      ensureIsFunction(afterEachFunction, 'afterEach');
+      ensureIsFunctionOrAsync(afterEachFunction, 'afterEach');
       currentDeclarationSuite.afterEach({
         fn: afterEachFunction,
         timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
@@ -520,7 +526,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.afterAll = function(afterAllFunction, timeout) {
-      ensureIsFunction(afterAllFunction, 'afterAll');
+      ensureIsFunctionOrAsync(afterAllFunction, 'afterAll');
       currentDeclarationSuite.afterAll({
         fn: afterAllFunction,
         timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -87,7 +87,12 @@ getJasmineRequireObj().QueueRunner = function(j$) {
 
       try {
         if (queueableFn.fn.length === 0) {
-          queueableFn.fn.call(self.userContext);
+          var maybeThenable = queueableFn.fn.call(self.userContext);
+
+          if (maybeThenable && j$.isFunction_(maybeThenable.then)) {
+            maybeThenable.then(next, next.fail);
+            return false;
+          }
         } else {
           queueableFn.fn.call(self.userContext, next);
           return false;

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -40,11 +40,10 @@ getJasmineRequireObj().QueueRunner = function(j$) {
 
     for(iterativeIndex = recursiveIndex; iterativeIndex < length; iterativeIndex++) {
       var queueableFn = queueableFns[iterativeIndex];
-      if (queueableFn.fn.length > 0) {
-        attemptAsync(queueableFn);
+      var completedSynchronously = attempt(queueableFn);
+
+      if (!completedSynchronously) {
         return;
-      } else {
-        attemptSync(queueableFn);
       }
     }
 
@@ -53,15 +52,7 @@ getJasmineRequireObj().QueueRunner = function(j$) {
       self.onComplete();
     });
 
-    function attemptSync(queueableFn) {
-      try {
-        queueableFn.fn.call(self.userContext);
-      } catch (e) {
-        handleException(e, queueableFn);
-      }
-    }
-
-    function attemptAsync(queueableFn) {
+    function attempt(queueableFn) {
       var clearTimeout = function () {
           Function.prototype.apply.apply(self.timeout.clearTimeout, [j$.getGlobal(), [timeoutId]]);
         },
@@ -69,9 +60,12 @@ getJasmineRequireObj().QueueRunner = function(j$) {
           onException(error);
           next();
         },
-        next = once(function () {
+        cleanup = once(function() {
           clearTimeout(timeoutId);
           self.globalErrors.popListener(handleError);
+        }),
+        next = once(function () {
+          cleanup();
           self.run(queueableFns, iterativeIndex + 1);
         }),
         timeoutId;
@@ -92,11 +86,18 @@ getJasmineRequireObj().QueueRunner = function(j$) {
       }
 
       try {
-        queueableFn.fn.call(self.userContext, next);
+        if (queueableFn.fn.length === 0) {
+          queueableFn.fn.call(self.userContext);
+        } else {
+          queueableFn.fn.call(self.userContext, next);
+          return false;
+        }
       } catch (e) {
         handleException(e, queueableFn);
-        next();
       }
+
+      cleanup();
+      return true;
     }
 
     function onException(e) {

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -58,6 +58,10 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
     return j$.isA_('Function', value);
   };
 
+  j$.isAsyncFunction_ = function(value) {
+    return j$.isA_('AsyncFunction', value);
+  };
+
   j$.isA_ = function(typeName, value) {
     return j$.getType_(value) === '[object ' + typeName + ']';
   };


### PR DESCRIPTION
This is similar to #1270 but updated to account for recent changes to QueueRunner. I also added support for async functions, since that was nearly free once promises were supported. 