### PR TITLE
Fail when one of the arguments passed into toBeCloseTo matcher is null

### DIFF
--- a/spec/core/matchers/toBeCloseToSpec.js
+++ b/spec/core/matchers/toBeCloseToSpec.js
@@ -29,6 +29,22 @@ describe("toBeCloseTo", function() {
     expect(result.pass).toBe(true);
   });
 
+  it("fails when one of the arguments is null", function() {
+    var matcher = jasmineUnderTest.matchers.toBeCloseTo();
+
+    expect(function() {
+      matcher.compare(null, null);
+    }).toThrowError('Cannot use toBeCloseTo with null. Arguments evaluated to: expect(null).toBeCloseTo(null).');
+
+    expect(function() {
+      matcher.compare(0, null);
+    }).toThrowError('Cannot use toBeCloseTo with null. Arguments evaluated to: expect(0).toBeCloseTo(null).');
+
+    expect(function() {
+      matcher.compare(null, 0);
+    }).toThrowError('Cannot use toBeCloseTo with null. Arguments evaluated to: expect(null).toBeCloseTo(0).');
+  });
+
   it("rounds expected values", function() {
     var matcher = jasmineUnderTest.matchers.toBeCloseTo(),
       result;

--- a/src/core/matchers/toBeCloseTo.js
+++ b/src/core/matchers/toBeCloseTo.js
@@ -15,6 +15,12 @@ getJasmineRequireObj().toBeCloseTo = function() {
           precision = precision || 2;
         }
 
+        if (expected === null || actual === null) {
+          throw new Error('Cannot use toBeCloseTo with null. Arguments evaluated to: ' +
+            'expect(' + actual + ').toBeCloseTo(' + expected + ').'
+          );
+        }
+
         return {
           pass: Math.abs(expected - actual) < (Math.pow(10, -precision) / 2)
         };


### PR DESCRIPTION
Currently, `toBeCloseTo` passes when one of the arguments passed into it is `null`. This is due to the quirk that `9 - null` evaluates to `9`, and also `null - 9` evaluates to `-9`. Whether that's well defined in the language is probably a separate discussion. The matcher should fail though since it can't be said whether `null` is close to any other value.