### PR TITLE
Fix rounding in toBeCloseTo

### DIFF
--- a/spec/core/matchers/toBeCloseToSpec.js
+++ b/spec/core/matchers/toBeCloseToSpec.js
@@ -8,6 +8,9 @@ describe("toBeCloseTo", function() {
 
     result = matcher.compare(0, 0.001);
     expect(result.pass).toBe(true);
+
+    result = matcher.compare(0, 0.005);
+    expect(result.pass).toBe(true);
   });
 
   it("fails when not within two decimal places by default", function() {
@@ -15,6 +18,9 @@ describe("toBeCloseTo", function() {
       result;
 
     result = matcher.compare(0, 0.01);
+    expect(result.pass).toBe(false);
+
+    result = matcher.compare(0, 0.05);
     expect(result.pass).toBe(false);
   });
 
@@ -25,7 +31,19 @@ describe("toBeCloseTo", function() {
     result = matcher.compare(0, 0.1, 0);
     expect(result.pass).toBe(true);
 
+    result = matcher.compare(0, 0.5, 0);
+    expect(result.pass).toBe(true);
+
     result = matcher.compare(0, 0.0001, 3);
+    expect(result.pass).toBe(true);
+
+    result = matcher.compare(0, 0.0005, 3);
+    expect(result.pass).toBe(true);
+
+    result = matcher.compare(0, 0.00001, 4);
+    expect(result.pass).toBe(true);
+
+    result = matcher.compare(0, 0.00005, 4);
     expect(result.pass).toBe(true);
   });
 
@@ -58,7 +76,15 @@ describe("toBeCloseTo", function() {
     result = matcher.compare(1.23, 1.225);
     expect(result.pass).toBe(true);
 
+    result = matcher.compare(1.23, 1.235);
+    expect(result.pass).toBe(true);
+
+    // 1.2249999 will be rounded to 1.225
     result = matcher.compare(1.23, 1.2249999);
+    expect(result.pass).toBe(true);
+
+    // 1.2249999 will be rounded to 1.224
+    result = matcher.compare(1.23, 1.2244999);
     expect(result.pass).toBe(false);
 
     result = matcher.compare(1.23, 1.234);

--- a/src/core/matchers/toBeCloseTo.js
+++ b/src/core/matchers/toBeCloseTo.js
@@ -21,8 +21,9 @@ getJasmineRequireObj().toBeCloseTo = function() {
           );
         }
 
+        var pow = Math.pow(10, precision + 1);
         return {
-          pass: Math.abs(expected - actual) < (Math.pow(10, -precision) / 2)
+          pass: +(Math.round(Math.abs(expected - actual) * pow) / pow).toFixed(precision + 1) <= (Math.pow(10, -precision) / 2)
         };
       }
     };


### PR DESCRIPTION
Currently the difference between actual and expected value is not rounded  and some edge cases to fail.
For example with `actual = 1.2` and` expected = 1.25`:
`Math.abs(1.2 - 1.25)` => `0.050000000000000044` which is greater than `Math.pow(10, -2) / 2 => 0.05`.
This PR rounds the the difference between actual and expected values based on the requested precision. Now  the difference between `1.2` and `1.25` with a precision of `2` is rounded to `0.05` and compared to `Math.pow(10, -2) / 2 => 0.05`.

Fixes #1382