### PR TITLE
Add matcher aliases "toBeTruey" & "toBeFalsey" [sic]

### DIFF
--- a/spec/core/matchers/toBeFalsySpec.js
+++ b/spec/core/matchers/toBeFalsySpec.js
@@ -35,4 +35,8 @@ describe("toBeFalsy", function() {
     result = matcher.compare({});
     expect(result.pass).toBe(false);
   });
+
+  it("has 'falsy' aliases", function() {
+    expect(jasmineUnderTest.matchers.toBeFalsey).toBe(jasmineUnderTest.matchers.toBeFalsy);
+  });
 });

--- a/spec/core/matchers/toBeTruthySpec.js
+++ b/spec/core/matchers/toBeTruthySpec.js
@@ -35,4 +35,8 @@ describe("toBeTruthy", function() {
     result = matcher.compare(void 0);
     expect(result.pass).toBe(false);
   });
+
+  it("has 'truthy' aliases", function() {
+    expect(jasmineUnderTest.matchers.toBeTruthy).toBe(jasmineUnderTest.matchers.toBeTruey);
+  });
 });

--- a/src/core/matchers/requireMatchers.js
+++ b/src/core/matchers/requireMatchers.js
@@ -1,34 +1,41 @@
 getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
-  var availableMatchers = [
-      'toBe',
-      'toBeCloseTo',
-      'toBeDefined',
-      'toBeFalsy',
-      'toBeGreaterThan',
-      'toBeGreaterThanOrEqual',
-      'toBeLessThan',
-      'toBeLessThanOrEqual',
-      'toBeNaN',
-      'toBeNegativeInfinity',
-      'toBeNull',
-      'toBePositiveInfinity',
-      'toBeTruthy',
-      'toBeUndefined',
-      'toContain',
-      'toEqual',
-      'toHaveBeenCalled',
-      'toHaveBeenCalledBefore',
-      'toHaveBeenCalledTimes',
-      'toHaveBeenCalledWith',
-      'toMatch',
-      'toThrow',
-      'toThrowError'
-    ],
+  var availableMatchers = {
+      'toBe': [],
+      'toBeCloseTo': [],
+      'toBeDefined': [],
+      'toBeFalsy': ['toBeFalsey'],
+      'toBeGreaterThan': [],
+      'toBeGreaterThanOrEqual': [],
+      'toBeLessThan': [],
+      'toBeLessThanOrEqual': [],
+      'toBeNaN': [],
+      'toBeNegativeInfinity': [],
+      'toBeNull': [],
+      'toBePositiveInfinity': [],
+      'toBeTruthy': ['toBeTruey'],
+      'toBeUndefined': [],
+      'toContain': [],
+      'toEqual': [],
+      'toHaveBeenCalled': [],
+      'toHaveBeenCalledBefore': [],
+      'toHaveBeenCalledTimes': [],
+      'toHaveBeenCalledWith': [],
+      'toMatch': [],
+      'toThrow': [],
+      'toThrowError': []
+    },
     matchers = {};
 
-  for (var i = 0; i < availableMatchers.length; i++) {
-    var name = availableMatchers[i];
+  var availableMatcherNames = Object.keys(availableMatchers);
+
+  for (var i = 0; i < availableMatcherNames.length; i++) {
+    var name = availableMatcherNames[i];
     matchers[name] = jRequire[name](j$);
+
+    var aliases = availableMatchers[name];
+    for (var j = 0; j < aliases.length; j++) {
+      matchers[aliases[j]] = matchers[name];
+    }
   }
 
   return matchers;


### PR DESCRIPTION
I've noticed many people trip over the `toBeFalsy` matcher's spelling, plus `toBeFalsy` & `toBeTruthy` are inconsistent with respect to `false` & `true`, respectively.

This PR normalizes the mapping from boolean value to adjective (`true` -> `toBeTruey` & `false` -> `toBeFalsey`) by adding matcher aliases.

Also see https://twitter.com/matthewadams12/status/872469510745468928.  :)