### PR TITLE
Update jasmine-html.js

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -35,7 +35,7 @@ jasmineRequire.HtmlReporter = function(j$) {
   };
 
   function HtmlReporter(options) {
-    var env = options.env || {},
+    var env = "env" in options : options.env ? {},
       getContainer = options.getContainer,
       createElement = options.createElement,
       createTextNode = options.createTextNode,

--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -35,7 +35,7 @@ jasmineRequire.HtmlReporter = function(j$) {
   };
 
   function HtmlReporter(options) {
-    var env = "env" in options : options.env ? {},
+    var env = "env" in options ? options.env : {},
       getContainer = options.getContainer,
       createElement = options.createElement,
       createTextNode = options.createTextNode,


### PR DESCRIPTION
Fix "Uncaught TypeError: Cannot read property 'env' of undefined at new HtmlReporter (jasmine-html.js:38)"  that results when call to new HtmlReporter() is made without defining options.env.