### PR TITLE
Send unfocused tests through the same queue as focused tests

### DIFF
--- a/spec/core/SpecSpec.js
+++ b/spec/core/SpecSpec.js
@@ -141,7 +141,8 @@ describe("Spec", function() {
   });
 
   it("can be disabled, but still calls callbacks", function() {
-    var fakeQueueRunner = jasmine.createSpy('fakeQueueRunner'),
+    var fakeQueueRunner = jasmine.createSpy('fakeQueueRunner')
+        .and.callFake(function(attrs) { attrs.onComplete(); }),
       startCallback = jasmine.createSpy('startCallback'),
       specBody = jasmine.createSpy('specBody'),
       resultCallback = jasmine.createSpy('resultCallback'),
@@ -158,7 +159,7 @@ describe("Spec", function() {
 
     spec.execute();
 
-    expect(fakeQueueRunner).not.toHaveBeenCalled();
+    expect(fakeQueueRunner).toHaveBeenCalled();
     expect(specBody).not.toHaveBeenCalled();
 
     expect(startCallback).toHaveBeenCalled();
@@ -166,7 +167,8 @@ describe("Spec", function() {
   });
 
   it("can be disabled at execution time by a parent", function() {
-    var fakeQueueRunner = jasmine.createSpy('fakeQueueRunner'),
+    var fakeQueueRunner = jasmine.createSpy('fakeQueueRunner')
+        .and.callFake(function(attrs) { attrs.onComplete(); }),
       startCallback = jasmine.createSpy('startCallback'),
       specBody = jasmine.createSpy('specBody'),
       resultCallback = jasmine.createSpy('resultCallback'),
@@ -181,7 +183,7 @@ describe("Spec", function() {
 
     expect(spec.result.status).toBe('disabled');
 
-    expect(fakeQueueRunner).not.toHaveBeenCalled();
+    expect(fakeQueueRunner).toHaveBeenCalled();
     expect(specBody).not.toHaveBeenCalled();
 
     expect(startCallback).toHaveBeenCalled();
@@ -189,7 +191,8 @@ describe("Spec", function() {
   });
 
   it("can be marked pending, but still calls callbacks when executed", function() {
-    var fakeQueueRunner = jasmine.createSpy('fakeQueueRunner'),
+    var fakeQueueRunner = jasmine.createSpy('fakeQueueRunner')
+        .and.callFake(function(attrs) { attrs.onComplete(); }),
       startCallback = jasmine.createSpy('startCallback'),
       resultCallback = jasmine.createSpy('resultCallback'),
       spec = new jasmineUnderTest.Spec({
@@ -209,7 +212,7 @@ describe("Spec", function() {
 
     spec.execute();
 
-    expect(fakeQueueRunner).not.toHaveBeenCalled();
+    expect(fakeQueueRunner).toHaveBeenCalled();
 
     expect(startCallback).toHaveBeenCalled();
     expect(resultCallback).toHaveBeenCalledWith({

--- a/src/core/Spec.js
+++ b/src/core/Spec.js
@@ -50,22 +50,25 @@ getJasmineRequireObj().Spec = function(j$) {
 
     this.onStart(this);
 
-    if (!this.isExecutable() || this.markedPending || enabled === false) {
-      complete(enabled);
-      return;
-    }
-
     var fns = this.beforeAndAfterFns();
     var regularFns = fns.befores.concat(this.queueableFn);
 
-    this.queueRunnerFactory({
+    var runnerConfig = {
       isLeaf: true,
       queueableFns: regularFns,
       cleanupFns: fns.afters,
       onException: function() { self.onException.apply(self, arguments); },
       onComplete: complete,
       userContext: this.userContext()
-    });
+    };
+
+    if (!this.isExecutable() || this.markedPending || enabled === false) {
+      runnerConfig.queueableFns = [];
+      runnerConfig.cleanupFns = [];
+      runnerConfig.onComplete = function() { complete(enabled); };
+    }
+
+    this.queueRunnerFactory(runnerConfig);
 
     function complete(enabledAgain) {
       self.result.status = self.status(enabledAgain);


### PR DESCRIPTION
For specs that are not executable, pending, or disabled, queue them like any other test instead of calling the complete callback inline.

## Description
* Spec.execute:
  * For specs that are not executable, pending, or disabled:
    * stop calling the complete callback inline and returning early
    * queue them like any other spec, without queueable functions, cleanup functions, and with a specialized invocation of the `complete` callback
  * All other specs should continue to run the same way they used to

## Motivation and Context
This change dramatically improves performance in both the browser and in the CLI when there are focused tests. I didn't see an open issue that this PR resolves. When running specs for the Jasmine project, with a single focused test, it would take over 2 seconds. With this change, it takes about 0.3 seconds. When running  [Apps Manager](https://github.com/pivotal-cf/apps-manager-js) specs (2500 specs exist), when a single test is focused, it takes 6 seconds (half the time the full suite takes). With this change, it runs in about a second.

## How Has This Been Tested?
I updated the `SpecSpec` file to assert that specs that are not execuable, pending, or disabled do go through the queue runner. I updated the mocked queue runner to call the completion callback, as had been done in other tests.
I tested the changes according to the contribution guidelines by running all of the unit tests in the Jasmine codebase in Chrome 59, Safari 11, and phantom (via grunt).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
