### PR TITLE
Improved error message for typed arrays

### DIFF
--- a/spec/core/matchers/toEqualSpec.js
+++ b/spec/core/matchers/toEqualSpec.js
@@ -216,7 +216,7 @@ describe("toEqual", function() {
 
     var actual = new Uint32Array([1, 2, 3]),
       expected = new Uint16Array([1, 2, 3]),
-      message = "Expected Uint32Array 1,2,3 to equal Uint16Array 1,2,3.";
+      message = "Expected Uint32Array [ 1, 2, 3 ] to equal Uint16Array [ 1, 2, 3 ].";
 
     expect(compareEquals(actual, expected).message).toEqual(message);
   });

--- a/spec/core/matchers/toEqualSpec.js
+++ b/spec/core/matchers/toEqualSpec.js
@@ -211,6 +211,16 @@ describe("toEqual", function() {
     expect(compareEquals(actual, expected).message).toEqual(message);
   });
 
+  it("reports mismatches between arrays of different types", function() {
+    jasmine.getEnv().requireFunctioningTypedArrays();
+
+    var actual = new Uint32Array([1, 2, 3]),
+      expected = new Uint16Array([1, 2, 3]),
+      message = "Expected Uint32Array 1,2,3 to equal Uint16Array 1,2,3.";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
   it("reports mismatches involving NaN", function() {
     var actual = {x: 0},
       expected = {x: 0/0},

--- a/spec/helpers/checkForTypedArrays.js
+++ b/spec/helpers/checkForTypedArrays.js
@@ -1,0 +1,20 @@
+(function(env) {
+  function hasFunctioningTypedArrays() {
+    if (typeof Uint32Array === 'undefined') { return false; }
+
+    try {
+      var a = new Uint32Array([1, 2, 3]);
+      if (a.length !== 3) { return false; }
+      return true;
+    } catch(e) {
+      return false;
+    }
+  }
+
+  env.requireFunctioningTypedArrays = function() {
+    if (!hasFunctioningTypedArrays()) {
+      env.pending("Browser has incomplete or missing support for typed arrays");
+    }
+  };
+  
+})(jasmine.getEnv());

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -9,6 +9,7 @@
     "helpers/asyncAwait.js",
     "helpers/checkForSet.js",
     "helpers/checkForMap.js",
+    "helpers/checkForTypedArrays.js",
     "helpers/nodeDefineJasmineUnderTest.js"
   ],
   "random": true

--- a/spec/support/jasmine.yml
+++ b/spec/support/jasmine.yml
@@ -20,6 +20,7 @@ helpers:
   - 'helpers/BrowserFlags.js'
   - 'helpers/checkForSet.js'
   - 'helpers/checkForMap.js'
+  - 'helpers/checkForTypedArrays.js'
   - 'helpers/defineJasmineUnderTest.js'
 spec_files:
   - '**/*[Ss]pec.js'

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -212,11 +212,16 @@ getJasmineRequireObj().pp = function(j$) {
     this.append(' })');
   };
 
-  StringPrettyPrinter.prototype.emitTypedArray = function(obj) {
-    var constructorName = j$.fnNameFor(obj.constructor);
-    var stringifiedArray = Array.prototype.join.call(obj);
+  StringPrettyPrinter.prototype.emitTypedArray = function(arr) {
+    var constructorName = j$.fnNameFor(arr.constructor),
+      limitedArray = Array.prototype.slice.call(arr, 0, j$.MAX_PRETTY_PRINT_ARRAY_LENGTH),
+      itemsString = Array.prototype.join.call(limitedArray, ', ');
 
-    this.append(constructorName + ' ' + stringifiedArray);
+    if (limitedArray.length !== arr.length) {
+      itemsString += ', ...';
+    }
+
+    this.append(constructorName + ' [ ' + itemsString + ' ]');
   };
 
   StringPrettyPrinter.prototype.formatProperty = function(obj, property, isGetter) {

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -40,6 +40,8 @@ getJasmineRequireObj().pp = function(j$) {
         this.emitSet(value);
       } else if (j$.getType_(value) == '[object Map]') {
         this.emitMap(value);
+      } else if (j$.isTypedArray_(value)) {
+        this.emitTypedArray(value);
       } else if (value.toString && typeof value === 'object' && !j$.isArray_(value) && hasCustomToString(value)) {
         this.emitScalar(value.toString());
       } else if (j$.util.arrayContains(this.seen, value)) {
@@ -208,6 +210,13 @@ getJasmineRequireObj().pp = function(j$) {
     if (truncated) { this.append(', ...'); }
 
     this.append(' })');
+  };
+
+  StringPrettyPrinter.prototype.emitTypedArray = function(obj) {
+    var constructorName = j$.fnNameFor(obj.constructor);
+    var stringifiedArray = Array.prototype.join.call(obj);
+
+    this.append(constructorName + ' ' + stringifiedArray);
   };
 
   StringPrettyPrinter.prototype.formatProperty = function(obj, property, isGetter) {

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -92,7 +92,9 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
       return func.name;
     }
 
-    var matches = func.toString().match(/^\s*function\s*(\w*)\s*\(/);
+    var matches = func.toString().match(/^\s*function\s*(\w*)\s*\(/) ||
+      func.toString().match(/^\s*\[object\s*(\w*)Constructor\]/);
+
     return matches ? matches[1] : '<anonymous>';
   };
 

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -63,6 +63,18 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
     return j$.isA_('AsyncFunction', value);
   };
 
+  j$.isTypedArray_ = function(value) {
+    return j$.isA_('Float32Array', value) ||
+      j$.isA_('Float64Array', value) ||
+      j$.isA_('Int16Array', value) ||
+      j$.isA_('Int32Array', value) ||
+      j$.isA_('Int8Array', value) ||
+      j$.isA_('Uint16Array', value) ||
+      j$.isA_('Uint32Array', value) ||
+      j$.isA_('Uint8Array', value) ||
+      j$.isA_('Uint8ClampedArray', value);
+  };
+
   j$.isA_ = function(typeName, value) {
     return j$.getType_(value) === '[object ' + typeName + ']';
   };


### PR DESCRIPTION
Typed arrays presentation now contains info about their type.

## Description
- added helper method to check if value is typed array - since we know which types there might be, method simply checks each;
- added clause in PrettyPrinter' format method that catches typed arrays;

## Motivation and Context
Without this changes (requested in #1180) in cases when toEqual compares two arrays of different types but equal elements error message is unclear, because no type data is given.

## How Has This Been Tested?
- added helper function to check that typed arrays are supported in current environment;
- added test case that compares two arrays of different types;

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

