### PR TITLE
Better primitives detection for 'saveArgumentsByValue'

### DIFF
--- a/spec/core/CallTrackerSpec.js
+++ b/spec/core/CallTrackerSpec.js
@@ -117,4 +117,14 @@ describe("CallTracker", function() {
     expect(callTracker.mostRecent().args[1]).not.toBe(arrayArg);
     expect(callTracker.mostRecent().args[1]).toEqual(arrayArg);
   });
+
+  it('saves primitive arguments by value', function() {
+    var callTracker = new jasmineUnderTest.CallTracker(),
+      args = [undefined, null, false, '', /\s/, 0, 1.2, NaN];
+
+    callTracker.saveArgumentsByValue();
+    callTracker.track({ object: {}, args: args });
+
+    expect(callTracker.mostRecent().args).toEqual(args);
+  });
 });

--- a/src/core/CallTracker.js
+++ b/src/core/CallTracker.js
@@ -11,10 +11,13 @@ getJasmineRequireObj().CallTracker = function(j$) {
       var clonedArgs = [];
       var argsAsArray = j$.util.argsToArray(context.args);
       for(var i = 0; i < argsAsArray.length; i++) {
-        if(Object.prototype.toString.apply(argsAsArray[i]).match(/^\[object/)) {
-          clonedArgs.push(j$.util.clone(argsAsArray[i]));
-        } else {
+        var str = Object.prototype.toString.apply(argsAsArray[i]),
+          primitives = /^\[object (Boolean|String|RegExp|Number)/;
+
+        if (argsAsArray[i] == null || str.match(primitives)) {
           clonedArgs.push(argsAsArray[i]);
+        } else {
+          clonedArgs.push(j$.util.clone(argsAsArray[i]));
         }
       }
       context.args = clonedArgs;


### PR DESCRIPTION
## Description
- check `undefined` or `null` with `== null` (for IE 8);
- check other primitives by matching string presentation with regular expression;

## Motivation and Context
Changes was requested in #1403. All primitives was mistakenly treated as non-primitives when `saveArgumentsByValue` was applied.

## How Has This Been Tested?
- added a test that checks if primitives passed as arguments was not changed;

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

