### PR TITLE
Ensure no error message added on asymmetric match success

### DIFF
--- a/spec/core/matchers/toEqualSpec.js
+++ b/spec/core/matchers/toEqualSpec.js
@@ -487,9 +487,9 @@ describe("toEqual", function() {
 
   it("does not report a mismatch when asymmetric matchers are satisfied", function() {
     var actual = {a: 'a'},
-      expected = {a: jasmineUnderTest.any(String)},
-      message = 'Expected $.a = 1 to equal <jasmine.any(String)>.';
+      expected = {a: jasmineUnderTest.any(String)};
 
+    expect(compareEquals(actual, expected).message).toEqual('');
     expect(compareEquals(actual, expected).pass).toBe(true)
   });
 

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -64,19 +64,15 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       return undefined;
     }
 
-    if (asymmetricA) {
-      result = a.asymmetricMatch(b, customTesters);
+    if (asymmetricA || asymmetricB) {
+      result = asymmetricA ?
+        a.asymmetricMatch(b, customTesters) :
+        b.asymmetricMatch(a, customTesters);
+      
       if (!result) {
         diffBuilder.record(a, b);
       }
-      return result;
-    }
 
-    if (asymmetricB) {
-      result = b.asymmetricMatch(a, customTesters);
-      if (!result) {
-        diffBuilder.record(a, b);
-      }
       return result;
     }
   }

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -66,13 +66,17 @@ getJasmineRequireObj().matchersUtil = function(j$) {
 
     if (asymmetricA) {
       result = a.asymmetricMatch(b, customTesters);
-      diffBuilder.record(a, b);
+      if (!result) {
+        diffBuilder.record(a, b);
+      }
       return result;
     }
 
     if (asymmetricB) {
       result = b.asymmetricMatch(a, customTesters);
-      diffBuilder.record(a, b);
+      if (!result) {
+        diffBuilder.record(a, b);
+      }
       return result;
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- added new condition to add diffBuilder record only when match fails;

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #1388. Without this changes `asymmetricMatch` method adds error message even if match was successful leading those messages to appear when some other check fails.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- added expectation to the old spec to ensure there is no messages on success;

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

