### PR TITLE
Throw an error on methods in it/befores/afters

### DIFF
--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -1895,4 +1895,65 @@ describe("Env integration", function() {
 
     env.execute();
   });
+
+  it('should throw on suites/specs/befores/afters nested in methods other than \'describe\'', function(done) {
+    var env = new jasmineUnderTest.Env(),
+      reporter = jasmine.createSpyObj('reporter', ['jasmineDone', 'suiteDone', 'specDone']);
+
+    reporter.jasmineDone.and.callFake(function() {
+      var msg = /\'.*\' should only be used in \'describe\' function/;
+
+      expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite describe', [msg]);
+      expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite xdescribe', [msg]);
+      expect(reporter.specDone).toHaveFailedExpecationsForRunnable('suite fdescribe', [msg]);
+
+      expect(reporter.specDone).toHaveFailedExpecationsForRunnable('spec it', [msg]);
+      expect(reporter.specDone).toHaveFailedExpecationsForRunnable('spec xit', [msg]);
+      expect(reporter.specDone).toHaveFailedExpecationsForRunnable('spec fit', [msg]);
+
+      expect(reporter.specDone).toHaveFailedExpecationsForRunnable('beforeAll spec', [msg]);
+      expect(reporter.specDone).toHaveFailedExpecationsForRunnable('beforeEach spec', [msg]);
+
+      expect(reporter.suiteDone).toHaveFailedExpecationsForRunnable('afterAll', [msg]);
+      expect(reporter.specDone).toHaveFailedExpecationsForRunnable('afterEach spec', [msg]);
+
+      done();
+    });
+
+    env.addReporter(reporter);
+
+    env.describe('suite', function() {
+      env.it('describe', function() { env.describe('inner suite', function() {}); });
+      env.it('xdescribe', function() { env.xdescribe('inner suite', function() {}); });
+      env.it('fdescribe', function() { env.fdescribe('inner suite', function() {}); });
+    });
+
+    env.describe('spec', function() {
+      env.it('it', function() { env.it('inner spec', function() {}); });
+      env.it('xit', function() { env.xit('inner spec', function() {}); });
+      env.it('fit', function() { env.fit('inner spec', function() {}); });
+    });
+
+    env.describe('beforeAll', function() {
+      env.beforeAll(function() { env.beforeAll(function() {}); });
+      env.it('spec', function() {});
+    });
+
+    env.describe('beforeEach', function() {
+      env.beforeEach(function() { env.beforeEach(function() {}); });
+      env.it('spec', function() {});
+    });
+
+    env.describe('afterAll', function() {
+      env.afterAll(function() { env.afterAll(function() {}); });
+      env.it('spec', function() {});
+    });
+
+    env.describe('afterEach', function() {
+      env.afterEach(function() { env.afterEach(function() {}); });
+      env.it('spec', function() {});
+    });
+
+    env.execute();
+  });
 });

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -384,7 +384,8 @@ getJasmineRequireObj().Env = function(j$) {
       }
     };
 
-    function ensureIsNotNested(method, runnable) {
+    function ensureIsNotNested(method) {
+      var runnable = currentRunnable();
       if (runnable !== null && runnable !== undefined) {
         throw new Error('\'' + method + '\' should only be used in \'describe\' function');
       }
@@ -405,7 +406,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.describe = function(description, specDefinitions) {
-      ensureIsNotNested('describe', currentRunnable());
+      ensureIsNotNested('describe');
       ensureIsFunction(specDefinitions, 'describe');
       var suite = suiteFactory(description);
       if (specDefinitions.length > 0) {
@@ -419,7 +420,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.xdescribe = function(description, specDefinitions) {
-      ensureIsNotNested('xdescribe', currentRunnable());
+      ensureIsNotNested('xdescribe');
       ensureIsFunction(specDefinitions, 'xdescribe');
       var suite = suiteFactory(description);
       suite.pend();
@@ -430,7 +431,7 @@ getJasmineRequireObj().Env = function(j$) {
     var focusedRunnables = [];
 
     this.fdescribe = function(description, specDefinitions) {
-      ensureIsNotNested('fdescribe', currentRunnable());
+      ensureIsNotNested('fdescribe');
       ensureIsFunction(specDefinitions, 'fdescribe');
       var suite = suiteFactory(description);
       suite.isFocused = true;
@@ -528,7 +529,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.it = function(description, fn, timeout) {
-      ensureIsNotNested('it', currentRunnable());
+      ensureIsNotNested('it');
       // it() sometimes doesn't have a fn argument, so only check the type if
       // it's given.
       if (arguments.length > 1 && typeof fn !== 'undefined') {
@@ -543,7 +544,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.xit = function(description, fn, timeout) {
-      ensureIsNotNested('xit', currentRunnable());
+      ensureIsNotNested('xit');
       // xit(), like it(), doesn't always have a fn argument, so only check the
       // type when needed.
       if (arguments.length > 1 && typeof fn !== 'undefined') {
@@ -555,7 +556,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.fit = function(description, fn, timeout){
-      ensureIsNotNested('fit', currentRunnable());
+      ensureIsNotNested('fit');
       ensureIsFunctionOrAsync(fn, 'fit');
       var spec = specFactory(description, fn, currentDeclarationSuite, timeout);
       currentDeclarationSuite.addChild(spec);
@@ -573,7 +574,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.beforeEach = function(beforeEachFunction, timeout) {
-      ensureIsNotNested('beforeEach', currentRunnable());
+      ensureIsNotNested('beforeEach');
       ensureIsFunctionOrAsync(beforeEachFunction, 'beforeEach');
       currentDeclarationSuite.beforeEach({
         fn: beforeEachFunction,
@@ -582,7 +583,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.beforeAll = function(beforeAllFunction, timeout) {
-      ensureIsNotNested('beforeAll', currentRunnable());
+      ensureIsNotNested('beforeAll');
       ensureIsFunctionOrAsync(beforeAllFunction, 'beforeAll');
       currentDeclarationSuite.beforeAll({
         fn: beforeAllFunction,
@@ -591,7 +592,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.afterEach = function(afterEachFunction, timeout) {
-      ensureIsNotNested('afterEach', currentRunnable());
+      ensureIsNotNested('afterEach');
       ensureIsFunctionOrAsync(afterEachFunction, 'afterEach');
       afterEachFunction.isCleanup = true;
       currentDeclarationSuite.afterEach({
@@ -601,7 +602,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.afterAll = function(afterAllFunction, timeout) {
-      ensureIsNotNested('afterAll', currentRunnable());
+      ensureIsNotNested('afterAll');
       ensureIsFunctionOrAsync(afterAllFunction, 'afterAll');
       currentDeclarationSuite.afterAll({
         fn: afterAllFunction,

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -384,6 +384,12 @@ getJasmineRequireObj().Env = function(j$) {
       }
     };
 
+    function ensureIsNotNested(method, currentSuite) {
+      if (currentSuite !== undefined) {
+        throw new Error('\'' + method + '\' should only be used in \'describe\' function');
+      }
+    }
+
     var suiteFactory = function(description) {
       var suite = new j$.Suite({
         env: self,
@@ -399,6 +405,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.describe = function(description, specDefinitions) {
+      ensureIsNotNested('describe', currentSuite());
       ensureIsFunction(specDefinitions, 'describe');
       var suite = suiteFactory(description);
       if (specDefinitions.length > 0) {
@@ -412,6 +419,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.xdescribe = function(description, specDefinitions) {
+      ensureIsNotNested('xdescribe', currentSuite());
       ensureIsFunction(specDefinitions, 'xdescribe');
       var suite = suiteFactory(description);
       suite.pend();
@@ -422,6 +430,7 @@ getJasmineRequireObj().Env = function(j$) {
     var focusedRunnables = [];
 
     this.fdescribe = function(description, specDefinitions) {
+      ensureIsNotNested('fdescribe', currentSuite());
       ensureIsFunction(specDefinitions, 'fdescribe');
       var suite = suiteFactory(description);
       suite.isFocused = true;
@@ -519,6 +528,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.it = function(description, fn, timeout) {
+      ensureIsNotNested('it', currentSuite());
       // it() sometimes doesn't have a fn argument, so only check the type if
       // it's given.
       if (arguments.length > 1 && typeof fn !== 'undefined') {
@@ -533,6 +543,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.xit = function(description, fn, timeout) {
+      ensureIsNotNested('xit', currentSuite());
       // xit(), like it(), doesn't always have a fn argument, so only check the
       // type when needed.
       if (arguments.length > 1 && typeof fn !== 'undefined') {
@@ -544,6 +555,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.fit = function(description, fn, timeout){
+      ensureIsNotNested('fit', currentSuite());
       ensureIsFunctionOrAsync(fn, 'fit');
       var spec = specFactory(description, fn, currentDeclarationSuite, timeout);
       currentDeclarationSuite.addChild(spec);
@@ -561,6 +573,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.beforeEach = function(beforeEachFunction, timeout) {
+      ensureIsNotNested('beforeEach', currentSuite());
       ensureIsFunctionOrAsync(beforeEachFunction, 'beforeEach');
       currentDeclarationSuite.beforeEach({
         fn: beforeEachFunction,
@@ -569,6 +582,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.beforeAll = function(beforeAllFunction, timeout) {
+      ensureIsNotNested('beforeAll', currentSuite());
       ensureIsFunctionOrAsync(beforeAllFunction, 'beforeAll');
       currentDeclarationSuite.beforeAll({
         fn: beforeAllFunction,
@@ -577,6 +591,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.afterEach = function(afterEachFunction, timeout) {
+      ensureIsNotNested('afterEach', currentSuite());
       ensureIsFunctionOrAsync(afterEachFunction, 'afterEach');
       afterEachFunction.isCleanup = true;
       currentDeclarationSuite.afterEach({
@@ -586,6 +601,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.afterAll = function(afterAllFunction, timeout) {
+      ensureIsNotNested('afterAll', currentSuite());
       ensureIsFunctionOrAsync(afterAllFunction, 'afterAll');
       currentDeclarationSuite.afterAll({
         fn: afterAllFunction,

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -384,8 +384,8 @@ getJasmineRequireObj().Env = function(j$) {
       }
     };
 
-    function ensureIsNotNested(method, currentSuite) {
-      if (currentSuite !== undefined) {
+    function ensureIsNotNested(method, runnable) {
+      if (runnable !== null && runnable !== undefined) {
         throw new Error('\'' + method + '\' should only be used in \'describe\' function');
       }
     }
@@ -405,7 +405,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.describe = function(description, specDefinitions) {
-      ensureIsNotNested('describe', currentSuite());
+      ensureIsNotNested('describe', currentRunnable());
       ensureIsFunction(specDefinitions, 'describe');
       var suite = suiteFactory(description);
       if (specDefinitions.length > 0) {
@@ -419,7 +419,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.xdescribe = function(description, specDefinitions) {
-      ensureIsNotNested('xdescribe', currentSuite());
+      ensureIsNotNested('xdescribe', currentRunnable());
       ensureIsFunction(specDefinitions, 'xdescribe');
       var suite = suiteFactory(description);
       suite.pend();
@@ -430,7 +430,7 @@ getJasmineRequireObj().Env = function(j$) {
     var focusedRunnables = [];
 
     this.fdescribe = function(description, specDefinitions) {
-      ensureIsNotNested('fdescribe', currentSuite());
+      ensureIsNotNested('fdescribe', currentRunnable());
       ensureIsFunction(specDefinitions, 'fdescribe');
       var suite = suiteFactory(description);
       suite.isFocused = true;
@@ -528,7 +528,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.it = function(description, fn, timeout) {
-      ensureIsNotNested('it', currentSuite());
+      ensureIsNotNested('it', currentRunnable());
       // it() sometimes doesn't have a fn argument, so only check the type if
       // it's given.
       if (arguments.length > 1 && typeof fn !== 'undefined') {
@@ -543,7 +543,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.xit = function(description, fn, timeout) {
-      ensureIsNotNested('xit', currentSuite());
+      ensureIsNotNested('xit', currentRunnable());
       // xit(), like it(), doesn't always have a fn argument, so only check the
       // type when needed.
       if (arguments.length > 1 && typeof fn !== 'undefined') {
@@ -555,7 +555,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.fit = function(description, fn, timeout){
-      ensureIsNotNested('fit', currentSuite());
+      ensureIsNotNested('fit', currentRunnable());
       ensureIsFunctionOrAsync(fn, 'fit');
       var spec = specFactory(description, fn, currentDeclarationSuite, timeout);
       currentDeclarationSuite.addChild(spec);
@@ -573,7 +573,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.beforeEach = function(beforeEachFunction, timeout) {
-      ensureIsNotNested('beforeEach', currentSuite());
+      ensureIsNotNested('beforeEach', currentRunnable());
       ensureIsFunctionOrAsync(beforeEachFunction, 'beforeEach');
       currentDeclarationSuite.beforeEach({
         fn: beforeEachFunction,
@@ -582,7 +582,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.beforeAll = function(beforeAllFunction, timeout) {
-      ensureIsNotNested('beforeAll', currentSuite());
+      ensureIsNotNested('beforeAll', currentRunnable());
       ensureIsFunctionOrAsync(beforeAllFunction, 'beforeAll');
       currentDeclarationSuite.beforeAll({
         fn: beforeAllFunction,
@@ -591,7 +591,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.afterEach = function(afterEachFunction, timeout) {
-      ensureIsNotNested('afterEach', currentSuite());
+      ensureIsNotNested('afterEach', currentRunnable());
       ensureIsFunctionOrAsync(afterEachFunction, 'afterEach');
       afterEachFunction.isCleanup = true;
       currentDeclarationSuite.afterEach({
@@ -601,7 +601,7 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.afterAll = function(afterAllFunction, timeout) {
-      ensureIsNotNested('afterAll', currentSuite());
+      ensureIsNotNested('afterAll', currentRunnable());
       ensureIsFunctionOrAsync(afterAllFunction, 'afterAll');
       currentDeclarationSuite.afterAll({
         fn: afterAllFunction,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added check on each method call to ensure that no suite is currently executing.
<!--- Describe your changes in detail -->

## Motivation and Context
As described in #1295 methods nested in it/before/after are not supported and jasmine does not explicitly tell that if user have them.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Added new test.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

