### PR TITLE
Add 'nothing' matcher to expect nothing explicitly

### DIFF
--- a/spec/core/matchers/nothingSpec.js
+++ b/spec/core/matchers/nothingSpec.js
@@ -1,0 +1,8 @@
+describe('nothing', function() {
+  it('should pass', function() {
+    var matcher = jasmineUnderTest.matchers.nothing(),
+      result = matcher.compare();
+
+    expect(result.pass).toBe(true);
+  });
+});

--- a/src/core/matchers/nothing.js
+++ b/src/core/matchers/nothing.js
@@ -1,0 +1,20 @@
+getJasmineRequireObj().nothing = function() {
+  /**
+   * {@link expect} nothing explicitly.
+   * @function
+   * @name matchers#nothing
+   * @example
+   * expect().nothing();
+   */
+  function nothing() {
+    return {
+      compare: function() {
+        return {
+          pass: true
+        };
+      }
+    };
+  }
+
+  return nothing;
+};

--- a/src/core/matchers/requireMatchers.js
+++ b/src/core/matchers/requireMatchers.js
@@ -1,5 +1,6 @@
 getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
   var availableMatchers = [
+      'nothing',
       'toBe',
       'toBeCloseTo',
       'toBeDefined',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added new matcher that always returns `true`.
<!--- Describe your changes in detail -->

## Motivation and Context
As requested in #1221 that feature allows developer to explicitly mark that spec has not any expectations and suppress warnings.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Added new test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

