### PR TITLE
Ensure it() nested in xdescribe() has the same status as xit() tests

### DIFF
--- a/spec/core/SpecSpec.js
+++ b/spec/core/SpecSpec.js
@@ -222,7 +222,8 @@ describe("Spec", function() {
       fullName: 'a suite with a spec',
       failedExpectations: [],
       passedExpectations: [],
-      pendingReason: ''
+      pendingReason: '',
+      markedPending: true
     });
   });
 
@@ -321,6 +322,19 @@ describe("Spec", function() {
     expect(specNameSpy.calls.mostRecent().args[0].id).toEqual(spec.id);
   });
 
+  it("should have false markedPending by default", function() {
+    var spec = new jasmineUnderTest.Spec({
+        description: 'my test',
+        id: 'some-id',
+        queueableFn: { fn: function() { } },
+        queueRunnerFactory: function(attrs) { attrs.onComplete(); },
+      });
+
+    spec.execute();
+
+    expect(spec.result.markedPending).toBe(false)
+  });
+
   describe("when a spec is marked pending during execution", function() {
     it("should mark the spec as pending", function() {
       var fakeQueueRunner = function(opts) {
@@ -336,7 +350,7 @@ describe("Spec", function() {
       spec.execute();
 
       expect(spec.status()).toEqual("pending");
-      expect(spec.result.pendingReason).toEqual('');
+      expect(spec.result.markedPending).toBe(true);
     });
 
     it("should set the pendingReason", function() {

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -1397,12 +1397,15 @@ describe("Env integration", function() {
 
       expect(reporter.specDone).toHaveBeenCalledWith(jasmine.objectContaining({
         description: 'with a top level spec',
-        status: 'passed'
+        status: 'passed',
+        markedPending: false
       }));
 
       expect(reporter.specDone).toHaveBeenCalledWith(jasmine.objectContaining({
         description: "with an x'ed spec",
-        status: 'pending'
+        status: 'pending',
+        pendingReason: 'Temporarily disabled with xit',
+        markedPending: true
       }));
 
       expect(reporter.specDone).toHaveBeenCalledWith(jasmine.objectContaining({
@@ -1486,6 +1489,7 @@ describe("Env integration", function() {
       var specStatus = reporter.specDone.calls.argsFor(0)[0];
 
       expect(specStatus.pendingReason).toBe('with a message');
+      expect(specStatus.markedPending).toBe(true);
 
       done();
     });
@@ -1538,6 +1542,8 @@ describe("Env integration", function() {
         order: jasmine.any(jasmineUnderTest.Order)
       });
 
+      expect(reporter.specDone).toHaveBeenCalledWith(jasmine.objectContaining({ pendingReason: '' }));
+      expect(reporter.specDone).toHaveBeenCalledWith(jasmine.objectContaining({ markedPending: true }));
       expect(reporter.specDone).toHaveBeenCalledWith(jasmine.objectContaining({ status: 'disabled' }));
       expect(reporter.suiteDone).toHaveBeenCalledWith(jasmine.objectContaining({ description: 'xd out', status: 'pending' }));
       expect(reporter.suiteDone.calls.count()).toBe(4);

--- a/src/core/Spec.js
+++ b/src/core/Spec.js
@@ -16,6 +16,8 @@ getJasmineRequireObj().Spec = function(j$) {
 
     if (!this.queueableFn.fn) {
       this.pend();
+    } else {
+      this.markedPending = false;
     }
 
     /**
@@ -25,7 +27,8 @@ getJasmineRequireObj().Spec = function(j$) {
      * @property {String} fullName - The full description including all ancestors of this spec.
      * @property {Expectation[]} failedExpectations - The list of expectations that failed during execution of this spec.
      * @property {Expectation[]} passedExpectations - The list of expectations that passed during execution of this spec.
-     * @property {String} pendingReason - If the spec is {@link pending}, this will be the reason.
+     * @property {String} pendingReason - If the spec is {@link pending}, this will be the reason; may be empty string.
+     * @property {boolean} markedPending - If the spec is {@link pending}. status may be 'disabled' or 'pending'
      * @property {String} status - Once the spec has completed, this string represents the pass/fail status of this spec.
      */
     this.result = {
@@ -34,7 +37,8 @@ getJasmineRequireObj().Spec = function(j$) {
       fullName: this.getFullName(),
       failedExpectations: [],
       passedExpectations: [],
-      pendingReason: ''
+      pendingReason: '',
+      markedPending: false
     };
   }
 
@@ -126,6 +130,8 @@ getJasmineRequireObj().Spec = function(j$) {
   };
 
   Spec.prototype.status = function(enabled) {
+    this.result.markedPending = this.markedPending;
+
     if (this.disabled || enabled === false) {
       return 'disabled';
     }


### PR DESCRIPTION
## Description
Add Spec.result.markPending and set it to Spec.markPending in status().
Ensure the value is false by default.  Added unit tests and updated integration tests.

## Motivation and Context
We have a small jasmine reporter that exits with code 3 if any test has SKIPPED tests. This prevent accidental commits with fit() or fdescribe() left over by accident.  We allow explicit xit() or xdescribe(), that is PENDING tests.

Back in 2.4, it() functions inside xdescribe() were status pending. After commit c21bdaf
these functions have status 'disabled' and we can now longer account for pending specs
separate from disabled ones. By adding a markedPending the the result sent to status done,
reporters can once again detect pending specs nested in xdescribe() suites.

See my comment on c21bdaf

## How Has This Been Tested?
grunt execSpecsInNode

I added this change and a matching one to jasmine-spec-reporter and ran the jasmine tests for
https://github.com/foam-framework/foam2 using our internal build system.  This case failed under jasmine 2.7 because the it() functions under xdescribe() were marked "disabled"; it passes now.

I ran some karma tests internal that use the jasmine code in the browser.

I did not succeed with Ruby so I will work on #883 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
I guess this means CONTRIBUTING.md
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

