### PR TITLE
Deep clone args before passing them to reporters

### DIFF
--- a/src/core/CallTracker.js
+++ b/src/core/CallTracker.js
@@ -7,25 +7,9 @@ getJasmineRequireObj().CallTracker = function(j$) {
     var calls = [];
     var opts = {};
 
-    function argCloner(context) {
-      var clonedArgs = [];
-      var argsAsArray = j$.util.argsToArray(context.args);
-      for(var i = 0; i < argsAsArray.length; i++) {
-        var str = Object.prototype.toString.apply(argsAsArray[i]),
-          primitives = /^\[object (Boolean|String|RegExp|Number)/;
-
-        if (argsAsArray[i] == null || str.match(primitives)) {
-          clonedArgs.push(argsAsArray[i]);
-        } else {
-          clonedArgs.push(j$.util.clone(argsAsArray[i]));
-        }
-      }
-      context.args = clonedArgs;
-    }
-
     this.track = function(context) {
       if(opts.cloneArgs) {
-        argCloner(context);
+        context.args = j$.util.cloneArgs(context.args);
       }
       calls.push(context);
     };

--- a/src/core/ReportDispatcher.js
+++ b/src/core/ReportDispatcher.js
@@ -1,4 +1,4 @@
-getJasmineRequireObj().ReportDispatcher = function() {
+getJasmineRequireObj().ReportDispatcher = function(j$) {
   function ReportDispatcher(methods) {
 
     var dispatchedMethods = methods || [];
@@ -36,7 +36,7 @@ getJasmineRequireObj().ReportDispatcher = function() {
       for (var i = 0; i < reporters.length; i++) {
         var reporter = reporters[i];
         if (reporter[method]) {
-          reporter[method].apply(reporter, args);
+          reporter[method].apply(reporter, j$.util.cloneArgs(args));
         }
       }
     }

--- a/src/core/requireCore.js
+++ b/src/core/requireCore.js
@@ -23,7 +23,7 @@ var getJasmineRequireObj = (function (jasmineGlobal) {
     var j$ = {};
 
     jRequire.base(j$, jasmineGlobal);
-    j$.util = jRequire.util();
+    j$.util = jRequire.util(j$);
     j$.errors = jRequire.errors();
     j$.formatErrorMsg = jRequire.formatErrorMsg();
     j$.Any = jRequire.Any(j$);
@@ -44,7 +44,7 @@ var getJasmineRequireObj = (function (jasmineGlobal) {
     j$.ArrayWithExactContents = jRequire.ArrayWithExactContents(j$);
     j$.pp = jRequire.pp(j$);
     j$.QueueRunner = jRequire.QueueRunner(j$);
-    j$.ReportDispatcher = jRequire.ReportDispatcher();
+    j$.ReportDispatcher = jRequire.ReportDispatcher(j$);
     j$.Spec = jRequire.Spec(j$);
     j$.Spy = jRequire.Spy(j$);
     j$.SpyRegistry = jRequire.SpyRegistry(j$);

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -1,4 +1,4 @@
-getJasmineRequireObj().util = function() {
+getJasmineRequireObj().util = function(j$) {
 
   var util = {};
 
@@ -53,6 +53,22 @@ getJasmineRequireObj().util = function() {
     }
 
     return cloned;
+  };
+
+  util.cloneArgs = function(args) {
+    var clonedArgs = [];
+    var argsAsArray = j$.util.argsToArray(args);
+    for(var i = 0; i < argsAsArray.length; i++) {
+      var str = Object.prototype.toString.apply(argsAsArray[i]),
+        primitives = /^\[object (Boolean|String|RegExp|Number)/;
+
+      if (argsAsArray[i] == null || str.match(primitives)) {
+        clonedArgs.push(argsAsArray[i]);
+      } else {
+        clonedArgs.push(j$.util.clone(argsAsArray[i]));
+      }
+    }
+    return clonedArgs;
   };
 
   util.getPropertyDescriptor = function(obj, methodName) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds deep cloning for args before passing them to every registered reporter. This way one reporter will never adversely affect another reporter's output. For the sake of code reuse, I have added a utils method `j$.util.cloneArgs` which is now used in both `ReportDispatcher` and `CallTracker`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some jasmine reporters extend or overwrite test results and, since they are passed by reference to all reporters, side effects become inevitable.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The behaviour when args are being modified by reference can be observed by using [protractor-pretty-html-reporter](https://github.com/stuisme/protractor-pretty-html-reporter) and [jasmine-spec-reporter](https://github.com/bcaudan/jasmine-spec-reporter) together. The `result.duration` property is converted to a human readable string in `jasmine-spec-reporter` which affects the the way `result.duration` is displayed in `protractor-pretty-html-reporter`. With args deep cloning in place, the same behaviour is no longer reproducible.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

