### PR TITLE
Fix #1426 clearTimeout not correctly clearing a timeout

### DIFF
--- a/spec/core/ClockSpec.js
+++ b/spec/core/ClockSpec.js
@@ -680,7 +680,7 @@ describe("Clock (acceptance)", function() {
     expect(actualTimes).toEqual([baseTime.getTime(), baseTime.getTime() + 1, baseTime.getTime() + 3]);
   })
 
-  it('should be able to clear a timeout', function () {
+  it('correctly clears a scheduled timeout while the Clock is advancing', function () {
     var delayedFunctionScheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
       global = {Date: Date, setTimeout: undefined},
       mockDate = new jasmineUnderTest.MockDate(global),
@@ -694,10 +694,26 @@ describe("Clock (acceptance)", function() {
       global.clearTimeout(timerId2);
     }, 100);
 
-    timerId2 = global.setTimeout(() => {
-      fail();
-    }, 100);
+    timerId2 = global.setTimeout(fail, 100);
 
     clock.tick(100);
+  });
+
+  it('correctly clears a scheduled interval while the Clock is advancing', function () {
+    var delayedFunctionScheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+      global = {Date: Date, setTimeout: undefined},
+      mockDate = new jasmineUnderTest.MockDate(global),
+      clock = new jasmineUnderTest.Clock(global, function () { return delayedFunctionScheduler; }, mockDate);
+
+    clock.install();
+
+    var timerId2;
+    var timerId1 = global.setInterval(function () {
+      global.clearInterval(timerId2);
+    }, 100);
+
+    timerId2 = global.setInterval(fail, 100);
+
+    clock.tick(400);
   });
 });

--- a/spec/core/ClockSpec.js
+++ b/spec/core/ClockSpec.js
@@ -679,4 +679,25 @@ describe("Clock (acceptance)", function() {
 
     expect(actualTimes).toEqual([baseTime.getTime(), baseTime.getTime() + 1, baseTime.getTime() + 3]);
   })
+
+  it('should be able to clear a timeout', function () {
+    var delayedFunctionScheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+      global = {Date: Date, setTimeout: undefined},
+      mockDate = new jasmineUnderTest.MockDate(global),
+      clock = new jasmineUnderTest.Clock(global, function () { return delayedFunctionScheduler; }, mockDate);
+
+    clock.install();
+
+    var timerId2;
+
+    global.setTimeout(function () {
+      global.clearTimeout(timerId2);
+    }, 100);
+
+    timerId2 = global.setTimeout(() => {
+      fail();
+    }, 100);
+
+    clock.tick(100);
+  });
 });

--- a/spec/core/DelayedFunctionSchedulerSpec.js
+++ b/spec/core/DelayedFunctionSchedulerSpec.js
@@ -216,21 +216,23 @@ describe("DelayedFunctionScheduler", function() {
 
   it("removes functions during a tick that runs the function", function() {
     var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
-      fn = jasmine.createSpy('fn'),
+      spy = jasmine.createSpy('fn'),
+      spyAndRemove = jasmine.createSpy('fn'),
       fnDelay = 10,
       timeoutKey;
 
-    timeoutKey = scheduler.scheduleFunction(fn, fnDelay, [], true);
-    scheduler.scheduleFunction(function () {
+    spyAndRemove.and.callFake(function() {
       scheduler.removeFunctionWithId(timeoutKey);
-    }, 2 * fnDelay);
+    });
 
-    expect(fn).not.toHaveBeenCalled();
+    scheduler.scheduleFunction(spyAndRemove, fnDelay);
 
-    scheduler.tick(3 * fnDelay);
+    timeoutKey = scheduler.scheduleFunction(spy, fnDelay, [], true);
 
-    expect(fn).toHaveBeenCalled();
-    expect(fn.calls.count()).toBe(2);
+    scheduler.tick(2 * fnDelay);
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(spyAndRemove).toHaveBeenCalled();
   });
 
   it("removes functions during the first tick that runs the function", function() {

--- a/src/core/DelayedFunctionScheduler.js
+++ b/src/core/DelayedFunctionScheduler.js
@@ -129,9 +129,7 @@ getJasmineRequireObj().DelayedFunctionScheduler = function() {
 
         currentTime = newCurrentTime;
 
-        var funcsToRun = scheduledFunctions[currentTime].sort(function (a, b) {
-          return a.millis > b.millis;
-        });
+        var funcsToRun = scheduledFunctions[currentTime];
 
         delete scheduledFunctions[currentTime];
 


### PR DESCRIPTION
## Description

`clearTimeout` was not correctly handling the case of clearing a timeout that is also scheduled to run at the same tick.

This fix adds a `deletedKeys` array that is checked whilst we are running the scheduled functions for the current clock tick. If a function exists in `deletedKeys` it will not run. `deletedKeys` is then reset to an empty array.

## Motivation and Context

Fixes #1426 

## How Has This Been Tested?

Tests were added to confirm the issue presented in #1426 and changes were made to ensure they pass and no other tests break.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.