### PR TITLE
Fix lint warning in CallTracker.

### DIFF
--- a/src/core/CallTracker.js
+++ b/src/core/CallTracker.js
@@ -14,7 +14,8 @@ getJasmineRequireObj().CallTracker = function(j$) {
         var str = Object.prototype.toString.apply(argsAsArray[i]),
           primitives = /^\[object (Boolean|String|RegExp|Number)/;
 
-        if (argsAsArray[i] == null || str.match(primitives)) {
+        // All falsey values are either primitives, `null`, or `undefined.
+        if (!argsAsArray[i] || str.match(primitives)) {
           clonedArgs.push(argsAsArray[i]);
         } else {
           clonedArgs.push(j$.util.clone(argsAsArray[i]));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The previous code was using `== null` to handle both `null` and
`undefined`, resulting in a jshint warning. The conditional is meant to
check for non-primitive values, and it happens to be the case that a
falsey value in JS is always a primitive, or `null` or `undefined`.

## Motivation and Context
Just fixes a lint error that exists at jasmine/master.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all existing tests in both the node env (`grunt execSpecsInNode`) and in-browser via `bundle exec rake jasmine`. Also ran tests after building the distribution.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

