### PR TITLE
Fix "Before Committing" section of CONTRIBUTING.md.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -129,11 +129,9 @@ The easiest way to run the tests in **Internet Explorer** is to run a VM that ha
 1. Ensure all specs are green in browser *and* node
 1. Ensure JSHint is green with `grunt jshint`
 1. Build `jasmine.js` with `grunt buildDistribution` and run all specs again - this ensures that your changes self-test well
-
-## Submitting a Pull Request
 1. Revert your changes to `jasmine.js` and `jasmine-html.js`
-  * We do this because `jasmine.js` and `jasmine-html.js` are auto-generated (as you've seen in the previous steps) and accepting multiple pull requests when this auto-generated file changes causes lots of headaches
-1. When we accept your pull request, we will generate these files as a separate commit and merge the entire branch into master
+    * We do this because `jasmine.js` and `jasmine-html.js` are auto-generated (as you've seen in the previous steps) and accepting multiple pull requests when this auto-generated file changes causes lots of headaches
+    * When we accept your pull request, we will generate these files as a separate commit and merge the entire branch into master
 
 Note that we use Travis for Continuous Integration. We only accept green pull requests.
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
The old contributing docs had a misaligned nested unordered-list, which
resulted in it creating a new list instead of being nested under its
parent.

It also seems like it would be useful to have the "revert your changes"
prose as part of the "Before Committing" section, since otherwise people
may miss it and have to amend.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Current incorrect markup:
![image](https://user-images.githubusercontent.com/744228/31597130-93713b1a-b1fb-11e7-91f3-75c0d05a2e91.png)


## How Has This Been Tested?
(It's documentation)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

