### PR TITLE
Add support for jasmine.any(Symbol).

### DIFF
--- a/spec/core/asymmetric_equality/AnySpec.js
+++ b/spec/core/asymmetric_equality/AnySpec.js
@@ -29,6 +29,38 @@ describe("Any", function() {
     expect(any.asymmetricMatch(true)).toBe(true);
   });
 
+  it("matches a Map", function() {
+    jasmine.getEnv().requireFunctioningMaps();
+
+    var any = new jasmineUnderTest.Any(Map);
+
+    expect(any.asymmetricMatch(new Map())).toBe(true);
+  });
+
+  it("matches a Set", function() {
+    jasmine.getEnv().requireFunctioningSets();
+
+    var any = new jasmineUnderTest.Any(Set);
+
+    expect(any.asymmetricMatch(new Set())).toBe(true);
+  });
+
+  it("matches a TypedArray", function() {
+    jasmine.getEnv().requireFunctioningTypedArrays();
+
+    var any = new jasmineUnderTest.Any(Uint32Array);
+
+    expect(any.asymmetricMatch(new Uint32Array([]))).toBe(true);
+  });
+
+  it("matches a Symbol", function() {
+    jasmine.getEnv().requireFunctioningSymbols();
+
+    var any = new jasmineUnderTest.Any(Symbol);
+
+    expect(any.asymmetricMatch(Symbol())).toBe(true);
+  });
+
   it("matches another constructed object", function() {
     var Thing = function() {},
       any = new jasmineUnderTest.Any(Thing);

--- a/spec/helpers/checkForSymbol.js
+++ b/spec/helpers/checkForSymbol.js
@@ -1,0 +1,28 @@
+(function(env) {
+  function hasFunctioningSymbols() {
+    if (typeof Symbol === 'undefined') {
+      return false;
+    }
+
+    try {
+      var s1 = Symbol();
+      var s2 = Symbol();
+      if (typeof s1 !== 'symbol') {
+        return false;
+      }
+      if (s1 === s2) {
+        return false;
+      }
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  env.requireFunctioningSymbols = function() {
+    if (!hasFunctioningSymbols()) {
+      env.pending("Browser has incomplete or missing support for Symbols");
+    }
+  };
+
+})(jasmine.getEnv());

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -7,8 +7,9 @@
   ],
   "helpers": [
     "helpers/asyncAwait.js",
-    "helpers/checkForSet.js",
     "helpers/checkForMap.js",
+    "helpers/checkForSet.js",
+    "helpers/checkForSymbol.js",
     "helpers/checkForTypedArrays.js",
     "helpers/nodeDefineJasmineUnderTest.js"
   ],

--- a/spec/support/jasmine.yml
+++ b/spec/support/jasmine.yml
@@ -18,8 +18,9 @@ stylesheets:
 helpers:
   - 'helpers/asyncAwait.js'
   - 'helpers/BrowserFlags.js'
-  - 'helpers/checkForSet.js'
   - 'helpers/checkForMap.js'
+  - 'helpers/checkForSet.js'
+  - 'helpers/checkForSymbol.js'
   - 'helpers/checkForTypedArrays.js'
   - 'helpers/defineJasmineUnderTest.js'
 spec_files:

--- a/src/core/asymmetric_equality/Any.js
+++ b/src/core/asymmetric_equality/Any.js
@@ -31,6 +31,12 @@ getJasmineRequireObj().Any = function(j$) {
       return typeof other == 'boolean';
     }
 
+    /* jshint -W122 */
+    if (typeof Symbol != 'undefined' && this.expectedObject == Symbol) {
+      return typeof other == 'symbol';
+    }
+    /* jshint +W122 */
+
     return other instanceof this.expectedObject;
   };
 


### PR DESCRIPTION
## Description
The original asymmetric matcher code for Any did not work with symbols
since `symbolInstance instanceof Symbol` is actually `false` (but,
`symbolInstance.constructor` is `Symbol). This simply adds an extra
clause that explicitly checks for symbol (if available) like the other
primitive types.

Also added some missing specs for other types, like Map, Set, etc.

Fixes #1431.

## Motivation and Context
Before this change `jasmine.any(Symbol)` would not match `Symbol` instances.

## How Has This Been Tested?
Executed tests in-browser as well as in node, before and after `grunt buildDistribution`. Importantly, have not run the tests in IE yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

