### PR TITLE
Add special handling of asymmetric matcher objects as keys in Maps.

### DIFF
--- a/spec/core/asymmetric_equality/AnythingSpec.js
+++ b/spec/core/asymmetric_equality/AnythingSpec.js
@@ -23,6 +23,22 @@ describe("Anything", function() {
     expect(anything.asymmetricMatch([1,2,3])).toBe(true);
   });
 
+  it("matches a Map", function() {
+    jasmine.getEnv().requireFunctioningMaps();
+
+    var anything = new jasmineUnderTest.Anything();
+
+    expect(anything.asymmetricMatch(new Map())).toBe(true);
+  });
+
+  it("matches a Set", function() {
+    jasmine.getEnv().requireFunctioningSets();
+
+    var anything = new jasmineUnderTest.Anything();
+
+    expect(anything.asymmetricMatch(new Set())).toBe(true);
+  });
+
   it("doesn't match undefined", function() {
     var anything = new jasmineUnderTest.Anything();
 

--- a/spec/core/matchers/toEqualSpec.js
+++ b/spec/core/matchers/toEqualSpec.js
@@ -504,6 +504,14 @@ describe("toEqual", function() {
     expect(compareEquals(actual, expected).message).toEqual(message);
   });
 
+  it("does not report mismatches when comparing Map key to jasmine.anything()", function() {
+    jasmine.getEnv().requireFunctioningMaps();
+
+    var actual = new Map([['a', 1]]),
+      expected = new Map([[jasmineUnderTest.anything(), 1]]);
+    expect(compareEquals(actual, expected).pass).toBe(true);
+  });
+
   function isNotRunningInBrowser() {
     return typeof document === 'undefined'
   }


### PR DESCRIPTION
## Description
The previous Map equality code was assuming that the set of keys would
be identical between the two Maps. This change adds insertion-order
tracking for each key with its corresponding key. If one of the two keys
is an asymmetric equality obj, the keys are eq()'d, and if it succeeds,
the corresponding values are compared. Otherwise, the "main" key is
looked up directly in the other object; this is to prevent
similar-looking obj keys with different obj identities from comparing
equal.

## Motivation and Context
Fixes #1432.

## How Has This Been Tested?
Executed tests in node and Chrome, both before and after `grunt buildDistribution`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Note that this is softly blocked on #1435, which adds `hasFunctioningSymbols()`, which I'd like to use to add a few more unit tests to this PR that exercise Symbol keys. Besides that, though, the src itself should require no changes (besides reviewer comments, of course).