### PR TITLE
Add some unit tests that exercise jasmine.anything() and Map matching.

### DIFF
--- a/spec/core/asymmetric_equality/AnythingSpec.js
+++ b/spec/core/asymmetric_equality/AnythingSpec.js
@@ -39,6 +39,22 @@ describe("Anything", function() {
     expect(anything.asymmetricMatch(new Set())).toBe(true);
   });
 
+  it("matches a TypedArray", function() {
+    jasmine.getEnv().requireFunctioningTypedArrays();
+
+    var anything = new jasmineUnderTest.Anything();
+
+    expect(anything.asymmetricMatch(new Uint32Array([]))).toBe(true);
+  });
+
+  it("matches a Symbol", function() {
+    jasmine.getEnv().requireFunctioningSets();
+
+    var anything = new jasmineUnderTest.Anything();
+
+    expect(anything.asymmetricMatch(Symbol())).toBe(true);
+  });
+
   it("doesn't match undefined", function() {
     var anything = new jasmineUnderTest.Anything();
 

--- a/spec/core/matchers/toEqualSpec.js
+++ b/spec/core/matchers/toEqualSpec.js
@@ -512,6 +512,36 @@ describe("toEqual", function() {
     expect(compareEquals(actual, expected).pass).toBe(true);
   });
 
+  it("does not report mismatches when comparing Maps with the same symbol keys", function() {
+    jasmine.getEnv().requireFunctioningMaps();
+    jasmine.getEnv().requireFunctioningSymbols();
+
+    var key = Symbol(),
+      actual = new Map([[key, 1]]),
+      expected = new Map([[key, 1]]);
+    expect(compareEquals(actual, expected).pass).toBe(true);
+  });
+
+  it("reports mismatches between Maps with different symbol keys", function() {
+    jasmine.getEnv().requireFunctioningMaps();
+    jasmine.getEnv().requireFunctioningSymbols();
+
+    var actual = new Map([[Symbol(), 1]]),
+      expected = new Map([[Symbol(), 1]]),
+      message = "Expected Map( [ Symbol(), 1 ] ) to equal Map( [ Symbol(), 1 ] ).";
+
+    expect(compareEquals(actual, expected).message).toBe(message);
+  });
+
+  it("does not report mismatches when comparing Map symbol key to jasmine.anything()", function() {
+    jasmine.getEnv().requireFunctioningMaps();
+    jasmine.getEnv().requireFunctioningSymbols();
+
+    var actual = new Map([[Symbol(), 1]]),
+      expected = new Map([[jasmineUnderTest.anything(), 1]]);
+    expect(compareEquals(actual, expected).pass).toBe(true);
+  });
+
   function isNotRunningInBrowser() {
     return typeof document === 'undefined'
   }


### PR DESCRIPTION
## Description
Follow-up to some recent commits that fixed issues around
jasmine.anything() matching. This simply adds some extra tests that
exercise usage of Symbols with jasmine.anything() and as Map keys.

## Motivation and Context
Just adding some more unit test coverage.

## How Has This Been Tested?
Executed all tests in Node and in-browser, both before and after building the distribution.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

