### PR TITLE
Add toHaveLength matcher

### DIFF
--- a/spec/core/matchers/toHaveLengthSpec.js
+++ b/spec/core/matchers/toHaveLengthSpec.js
@@ -1,0 +1,32 @@
+describe("toHaveLength", function() {
+  it("fails for invalid lengths", function() {
+    var matcher = jasmineUnderTest.matchers.toHaveLength(),
+      result;
+
+    result = matcher.compare(['foo'], 0);
+    expect(result.pass).toBe(false);
+
+    result = matcher.compare('hello', 4);
+    expect(result.pass).toBe(false);
+  });
+
+  it("succeeds for valid lengths", function() {
+    var matcher = jasmineUnderTest.matchers.toHaveLength(),
+      result;
+
+    result = matcher.compare('foo bar baz', 11);
+    expect(result.pass).toBe(true);
+
+    result = matcher.compare(['foo', 'bar', 'baz'], 3);
+    expect(result.pass).toBe(true);
+  });
+
+  it("throws an Error when the expected is not a String or Array", function() {
+    var matcher = jasmineUnderTest.matchers.toHaveLength();
+
+    expect(function() {
+      matcher.compare({}, 0);
+    }).toThrowError(/Expected is not a String or an Array/);
+  });
+
+});

--- a/src/core/matchers/requireMatchers.js
+++ b/src/core/matchers/requireMatchers.js
@@ -21,6 +21,7 @@ getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
       'toHaveBeenCalledBefore',
       'toHaveBeenCalledTimes',
       'toHaveBeenCalledWith',
+      'toHaveLength',
       'toMatch',
       'toThrow',
       'toThrowError'

--- a/src/core/matchers/toHaveLength.js
+++ b/src/core/matchers/toHaveLength.js
@@ -1,0 +1,27 @@
+getJasmineRequireObj().toHaveLength = function(j$) {
+
+  var getErrorMsg = j$.formatErrorMsg('<toHaveLength>', 'expect(<string> || <array>).toHaveLength(<number>)');
+
+  /**
+   * {@link expect} the length of actual value to be equal to the expected, using strict equality comparison.
+   * @function
+   * @name matchers#toHaveLength
+   * @param {Array|String} expected - Expected length
+   * @example
+   * expect(['foo', 'bar', 'baz']).toHaveLength(3);
+   */
+  function toHaveLength(util, customEqualityTesters) {
+    return {
+      compare: function(actual, expected) {
+        if (!j$.isString_(actual) && !j$.isArray_(actual)) {
+          throw new Error(getErrorMsg('Expected is not a String or an Array'));
+        }
+        return {
+          pass: actual.length === expected
+        };
+      }
+    };
+  }
+
+  return toHaveLength;
+};


### PR DESCRIPTION
## Description

Thanks for the lib :+1:

I've added an additional matcher called `toHaveLength` which can be helpful for arrays and strings.

## Motivation and Context

Minor utility for length checking. In my use case it would also makes it easier to switch from `jest` to `jasmine`.

The matcher could be extended to support any object that has a length property, I didn't add it because I'm not sure it's that would be a common use case.

## How Has This Been Tested?

`npm t -s`

## Types of changes

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
