### PR TITLE
Allowed async functions to be passed into SpyStrategy#callFake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,16 @@ matrix:
   include:
     - env:
       - USE_SAUCE=false
-      - TEST_COMMAND="bash travis-node-script.sh"
+      - TEST_COMMAND="bash travis-node-script.sh v0.12.18"
+    - env:
+      - USE_SAUCE=false
+      - TEST_COMMAND="bash travis-node-script.sh v4"
+    - env:
+      - USE_SAUCE=false
+      - TEST_COMMAND="bash travis-node-script.sh v8"
+    - env:
+      - USE_SAUCE=false
+      - TEST_COMMAND="bash travis-node-script.sh v9"
     - env:
       - JASMINE_BROWSER="safari"
       - SAUCE_OS="OS X 10.11"

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -5010,7 +5010,7 @@ getJasmineRequireObj().SpyStrategy = function(j$) {
      * @param {Function} fn The function to invoke with the passed parameters.
      */
     this.callFake = function(fn) {
-      if(!j$.isFunction_(fn)) {
+      if(!(j$.isFunction_(fn) || j$.isAsyncFunction_(fn))) {
         throw new Error('Argument passed to callFake should be a function, got ' + fn);
       }
       plan = fn;

--- a/spec/core/SpyStrategySpec.js
+++ b/spec/core/SpyStrategySpec.js
@@ -92,23 +92,22 @@ describe("SpyStrategy", function() {
     expect(returnValue).toEqual(67);
   });
 
-  it("allows a fake async function to be called instead", async function(done) {
-    try {
-      var originalFn = jasmine.createSpy("original"),
-          fakeFn = jasmine.createSpy("fake").and.callFake(async function () { return 67; }),
-          spyStrategy = new jasmineUnderTest.SpyStrategy({fn: originalFn}),
-          returnValue;
+  it("allows a fake async function to be called instead", function(done) {
+    jasmine.getEnv().requireAsyncAwait();
+    var originalFn = jasmine.createSpy("original"),
+        fakeFn = jasmine.createSpy("fake").and.callFake(eval("async () => { return 67; }")),
+        spyStrategy = new jasmineUnderTest.SpyStrategy({fn: originalFn}),
+        returnValue;
 
-      spyStrategy.callFake(fakeFn);
-      returnValue = await spyStrategy.exec();
-
+    spyStrategy.callFake(fakeFn);
+    spyStrategy.exec().then(function (returnValue) {
       expect(originalFn).not.toHaveBeenCalled();
+      expect(fakeFn).toHaveBeenCalled();
       expect(returnValue).toEqual(67);
-
       done();
-    } catch (err) {
+    }).catch(function (err) {
       done.fail(err);
-    }
+    })
   });
 
   it('throws an error when a non-function is passed to callFake strategy', function() {
@@ -124,7 +123,7 @@ describe("SpyStrategy", function() {
     }).toThrowError(/^Argument passed to callFake should be a function, got/);
 
     expect(function () {
-      spyStrategy.callFake(async function() {});
+      spyStrategy.callFake(function() {});
     }).toThrowError(/^Argument passed to callFake should be a function, got/);
   });
 

--- a/spec/core/SpyStrategySpec.js
+++ b/spec/core/SpyStrategySpec.js
@@ -92,15 +92,39 @@ describe("SpyStrategy", function() {
     expect(returnValue).toEqual(67);
   });
 
+  it("allows a fake async function to be called instead", async function(done) {
+    try {
+      var originalFn = jasmine.createSpy("original"),
+          fakeFn = jasmine.createSpy("fake").and.callFake(async function () { return 67; }),
+          spyStrategy = new jasmineUnderTest.SpyStrategy({fn: originalFn}),
+          returnValue;
+
+      spyStrategy.callFake(fakeFn);
+      returnValue = await spyStrategy.exec();
+
+      expect(originalFn).not.toHaveBeenCalled();
+      expect(returnValue).toEqual(67);
+
+      done();
+    } catch (err) {
+      done.fail(err);
+    }
+  });
+
   it('throws an error when a non-function is passed to callFake strategy', function() {
     var originalFn = jasmine.createSpy('original'),
         spyStrategy = new jasmineUnderTest.SpyStrategy({fn: originalFn}),
         invalidFakes = [5, 'foo', {}, true, false, null, void 0, new Date(), /.*/];
 
     spyOn(jasmineUnderTest, 'isFunction_').and.returnValue(false);
+    spyOn(jasmineUnderTest, 'isAsyncFunction_').and.returnValue(false);
 
     expect(function () {
       spyStrategy.callFake(function() {});
+    }).toThrowError(/^Argument passed to callFake should be a function, got/);
+
+    expect(function () {
+      spyStrategy.callFake(async function() {});
     }).toThrowError(/^Argument passed to callFake should be a function, got/);
   });
 

--- a/src/core/SpyStrategy.js
+++ b/src/core/SpyStrategy.js
@@ -88,7 +88,7 @@ getJasmineRequireObj().SpyStrategy = function(j$) {
      * @param {Function} fn The function to invoke with the passed parameters.
      */
     this.callFake = function(fn) {
-      if(!j$.isFunction_(fn)) {
+      if(!(j$.isFunction_(fn) || j$.isAsyncFunction_(fn))) {
         throw new Error('Argument passed to callFake should be a function, got ' + fn);
       }
       plan = fn;

--- a/travis-node-script.sh
+++ b/travis-node-script.sh
@@ -4,7 +4,7 @@ rm -rf ~/.nvm
 git clone https://github.com/creationix/nvm.git ~/.nvm
 (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`)
 source ~/.nvm/nvm.sh
-nvm install v0.12.18
+nvm install ${1:-"v0.12.18"}
 
 npm install
 npm test


### PR DESCRIPTION
## Description
Allow async functions as stubs for spies. Also included updates to run the tests in v4, v8, v9 node versions.

## Motivation and Context
A spy's callFake would not accept an `async function`. This change proposes that it should indeed allow AsyncFunctions.

## How Has This Been Tested?
By adding additional specs to cover this new functionality. This creates minimal impact to any existing code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

