### PR TITLE
Added matchers: truthy, falsy, empty and notEmpty

### DIFF
--- a/spec/core/asymmetric_equality/AsymmetricEqualitySpec.js
+++ b/spec/core/asymmetric_equality/AsymmetricEqualitySpec.js
@@ -1,0 +1,40 @@
+describe("Fuzzy Equalities", function() {
+  describe('Truthy/Falsy equalities', function() {
+    it('allows the test to pass', function() {
+      expect({
+        name: "Rex",
+        id: null,
+        description: undefined,
+        age: 42,
+        tags: [],
+      }).toEqual({
+        name: jasmineUnderTest.truthy(),
+        id: jasmineUnderTest.falsy(),
+        description: jasmineUnderTest.falsy(),
+        age: jasmineUnderTest.truthy(),
+        tags: jasmineUnderTest.truthy()
+      })
+    })
+  });
+
+  if (typeof Set !== 'undefined') {
+    describe('empty/notEmpty equalities', function () {
+      it('allows the test to pass', function () {
+        var tags = new Set(['blue', 'green']);
+        expect({
+          name: "Rex",
+          description: '',
+          age: 42,
+          tags: tags,
+          gps_coord: []
+        }).toEqual({
+          name: jasmineUnderTest.notEmpty(),
+          description: jasmineUnderTest.empty(),
+          age: jasmineUnderTest.truthy(),
+          tags: jasmineUnderTest.notEmpty(),
+          gps_coord: jasmineUnderTest.empty()
+        })
+      })
+    });
+  }
+});

--- a/spec/core/asymmetric_equality/EmptySpec.js
+++ b/spec/core/asymmetric_equality/EmptySpec.js
@@ -1,0 +1,39 @@
+describe("Empty", function () {
+  it("matches an empty object", function () {
+    var empty = new jasmineUnderTest.Empty();
+
+    expect(empty.asymmetricMatch({})).toBe(true);
+    expect(empty.asymmetricMatch({undefined: false})).toBe(false);
+  });
+
+  it("matches an empty array", function () {
+    var empty = new jasmineUnderTest.Empty();
+
+    expect(empty.asymmetricMatch([])).toBe(true);
+    expect(empty.asymmetricMatch([1, 12, 3])).toBe(false);
+  });
+
+  it("matches an empty string", function () {
+    var empty = new jasmineUnderTest.Empty();
+
+    expect(empty.asymmetricMatch("")).toBe(true);
+    expect(empty.asymmetricMatch('')).toBe(true);
+    expect(empty.asymmetricMatch('12312')).toBe(false);
+  });
+
+  if (typeof Map !== 'undefined') {
+    it("matches an empty map", function () {
+      var empty = new jasmineUnderTest.Empty();
+
+      expect(empty.asymmetricMatch(new Map())).toBe(true);
+    });
+  }
+
+  if (typeof Set !== 'undefined') {
+    it("matches an empty map", function () {
+      var empty = new jasmineUnderTest.Empty();
+
+      expect(empty.asymmetricMatch(new Set())).toBe(true);
+    });
+  }
+});

--- a/spec/core/asymmetric_equality/FalsySpec.js
+++ b/spec/core/asymmetric_equality/FalsySpec.js
@@ -1,0 +1,38 @@
+describe("Falsy", function() {
+    it("is true for an empty string", function() {
+        var falsy = new jasmineUnderTest.Falsy();
+
+        expect(falsy.asymmetricMatch("")).toBe(true);
+        expect(falsy.asymmetricMatch('')).toBe(true);
+        expect(falsy.asymmetricMatch('asdasdad')).toBe(false);
+    });
+
+    it("is false for a number that is 0", function() {
+        var falsy = new jasmineUnderTest.Falsy(Number);
+
+        expect(falsy.asymmetricMatch(1)).toBe(false);
+        expect(falsy.asymmetricMatch(0)).toBe(true);
+        expect(falsy.asymmetricMatch(-23)).toBe(false);
+        expect(falsy.asymmetricMatch(-3.1)).toBe(false);
+    });
+
+    it("is true for a null or undefined", function() {
+        var falsy = new jasmineUnderTest.Falsy(Function);
+
+        expect(falsy.asymmetricMatch(null)).toBe(true);
+        expect(falsy.asymmetricMatch(undefined )).toBe(true);
+    });
+
+    it("is true for NaN", function() {
+        var falsy = new jasmineUnderTest.Falsy(Object);
+
+        expect(falsy.asymmetricMatch(NaN)).toBe(true);
+    });
+
+    it("is true for a false Boolean", function() {
+        var falsy = new jasmineUnderTest.Falsy(Boolean);
+
+        expect(falsy.asymmetricMatch(false)).toBe(true);
+        expect(falsy.asymmetricMatch(true)).toBe(false);
+    });
+});

--- a/spec/core/asymmetric_equality/NotEmptySpec.js
+++ b/spec/core/asymmetric_equality/NotEmptySpec.js
@@ -1,0 +1,43 @@
+describe("NotEmpty", function () {
+  it("matches a non empty object", function () {
+    var notEmpty = new jasmineUnderTest.NotEmpty();
+
+    expect(notEmpty.asymmetricMatch({undefined: false})).toBe(true);
+    expect(notEmpty.asymmetricMatch({})).toBe(false);
+  });
+
+  it("matches a non empty array", function () {
+    var notEmpty = new jasmineUnderTest.NotEmpty();
+
+    expect(notEmpty.asymmetricMatch([1, 12, 3])).toBe(true);
+    expect(notEmpty.asymmetricMatch([])).toBe(false);
+  });
+
+  it("matches a non empty string", function () {
+    var notEmpty = new jasmineUnderTest.NotEmpty();
+
+    expect(notEmpty.asymmetricMatch('12312')).toBe(true);
+    expect(notEmpty.asymmetricMatch("")).toBe(false);
+    expect(notEmpty.asymmetricMatch('')).toBe(false);
+  });
+
+  if (typeof Map !== 'undefined') {
+    it("matches a non empty map", function () {
+      var notEmpty = new jasmineUnderTest.NotEmpty();
+      var fullMap = new Map([['one',1]]);
+      var emptyMap = new Map();
+
+      expect(notEmpty.asymmetricMatch(fullMap)).toBe(true);
+      expect(notEmpty.asymmetricMatch(emptyMap)).toBe(false);
+    });
+  }
+
+  if (typeof Set !== 'undefined') {
+    it("matches a non empty map", function () {
+      var notEmpty = new jasmineUnderTest.NotEmpty();
+      var filledSet = new Set([1,2,2,2,2,34]);
+
+      expect(notEmpty.asymmetricMatch(filledSet)).toBe(true);
+    });
+  }
+});

--- a/spec/core/asymmetric_equality/TruthySpec.js
+++ b/spec/core/asymmetric_equality/TruthySpec.js
@@ -1,0 +1,63 @@
+describe("Truthy", function () {
+  it("is true for a non empty string", function () {
+    var truthy = new jasmineUnderTest.Truthy();
+
+    expect(truthy.asymmetricMatch("foo")).toBe(true);
+    expect(truthy.asymmetricMatch("")).toBe(false);
+  });
+
+  it("is true for a number that is not 0", function () {
+    var truthy = new jasmineUnderTest.Truthy();
+
+    expect(truthy.asymmetricMatch(1)).toBe(true);
+    expect(truthy.asymmetricMatch(0)).toBe(false);
+    expect(truthy.asymmetricMatch(-23)).toBe(true);
+    expect(truthy.asymmetricMatch(-3.1)).toBe(true);
+  });
+
+  it("is true for a function", function () {
+    var truthy = new jasmineUnderTest.Truthy();
+
+    expect(truthy.asymmetricMatch(function () {
+    })).toBe(true);
+  });
+
+  it("is true for an Object", function () {
+    var truthy = new jasmineUnderTest.Truthy();
+
+    expect(truthy.asymmetricMatch({})).toBe(true);
+  });
+
+  it("is true for a truthful Boolean", function () {
+    var truthy = new jasmineUnderTest.Truthy();
+
+    expect(truthy.asymmetricMatch(true)).toBe(true);
+    expect(truthy.asymmetricMatch(false)).toBe(false);
+  });
+
+  it("is true for an empty object", function () {
+    var truthy = new jasmineUnderTest.Truthy();
+
+    expect(truthy.asymmetricMatch({})).toBe(true);
+  });
+
+  it("is true for an empty array", function () {
+    var truthy = new jasmineUnderTest.Truthy();
+
+    expect(truthy.asymmetricMatch([])).toBe(true);
+  });
+
+  it("is true for a date", function () {
+    var truthy = new jasmineUnderTest.Truthy();
+
+    expect(truthy.asymmetricMatch(new Date())).toBe(true);
+  });
+
+  it("is true for a infiniti", function () {
+    var truthy = new jasmineUnderTest.Truthy();
+
+    expect(truthy.asymmetricMatch(Infinity)).toBe(true);
+    expect(truthy.asymmetricMatch(-Infinity)).toBe(true);
+  });
+});
+

--- a/src/core/asymmetric_equality/Empty.js
+++ b/src/core/asymmetric_equality/Empty.js
@@ -1,0 +1,33 @@
+getJasmineRequireObj().Empty = function (j$) {
+
+  function Empty() {}
+
+  Empty.prototype.asymmetricMatch = function (other) {
+    if (typeof other === 'string') {
+      return other.length === 0;
+    }
+
+    if (other instanceof Array) {
+      return other.length === 0;
+    }
+
+    if (typeof Map !== 'undefined' && other instanceof Map) {
+      return other.size === 0;
+    }
+
+    if (typeof Set !== 'undefined' && other instanceof Set) {
+      return other.size === 0;
+    }
+
+    if (other instanceof Object) {
+      return Object.keys(other).length === 0;
+    }
+    return false;
+  };
+
+  Empty.prototype.jasmineToString = function () {
+    return '<jasmine.empty>';
+  };
+
+  return Empty;
+};

--- a/src/core/asymmetric_equality/Falsy.js
+++ b/src/core/asymmetric_equality/Falsy.js
@@ -1,0 +1,18 @@
+getJasmineRequireObj().Falsy = function(j$) {
+
+    function Falsy() {}
+
+    Falsy.prototype.asymmetricMatch = function(other) {
+        if (!other) {
+            return true;
+        }
+
+        return false;
+    };
+
+    Falsy.prototype.jasmineToString = function() {
+        return '<jasmine.falsy>';
+    };
+
+    return Falsy;
+};

--- a/src/core/asymmetric_equality/NotEmpty.js
+++ b/src/core/asymmetric_equality/NotEmpty.js
@@ -1,0 +1,34 @@
+getJasmineRequireObj().NotEmpty = function (j$) {
+
+  function NotEmpty() {}
+
+  NotEmpty.prototype.asymmetricMatch = function (other) {
+    if (typeof other === 'string') {
+      return other.length !== 0;
+    }
+
+    if (other instanceof Array) {
+      return other.length !== 0;
+    }
+
+    if (typeof Map !== 'undefined' && other instanceof Map) {
+      return other.size !== 0;
+    }
+
+    if (typeof Set !== 'undefined' && other instanceof Set) {
+      return other.size !== 0;
+    }
+
+    if (other instanceof Object) {
+      return Object.keys(other).length !== 0;
+    }
+
+    return false;
+  };
+
+  NotEmpty.prototype.jasmineToString = function () {
+    return '<jasmine.notEmpty>';
+  };
+
+  return NotEmpty;
+};

--- a/src/core/asymmetric_equality/Truthy.js
+++ b/src/core/asymmetric_equality/Truthy.js
@@ -1,0 +1,18 @@
+getJasmineRequireObj().Truthy = function(j$) {
+
+    function Truthy() {}
+
+    Truthy.prototype.asymmetricMatch = function(other) {
+        if (other) {
+            return true;
+        }
+
+        return false;
+    };
+
+    Truthy.prototype.jasmineToString = function() {
+        return '<jasmine.truthy>';
+    };
+
+    return Truthy;
+};

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -125,6 +125,38 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
 
   /**
    * Get a matcher, usable in any {@link matchers|matcher} that uses Jasmine's equality (e.g. {@link matchers#toEqual|toEqual}, {@link matchers#toContain|toContain}, or {@link matchers#toHaveBeenCalledWith|toHaveBeenCalledWith}),
+   * that will succeed if the actual value being compared is `true` or anything truthy.
+   * @name jasmine.truthy
+   * @function
+   */
+  j$.truthy = function() {return new j$.Truthy();};
+
+  /**
+   * Get a matcher, usable in any {@link matchers|matcher} that uses Jasmine's equality (e.g. {@link matchers#toEqual|toEqual}, {@link matchers#toContain|toContain}, or {@link matchers#toHaveBeenCalledWith|toHaveBeenCalledWith}),
+   * that will succeed if the actual value being compared is  `null`, `undefined`, `0`, `false` or anything falsey.
+   * @name jasmine.falsy
+   * @function
+   */
+  j$.falsy = function() {return new j$.Falsy();};
+
+  /**
+   * Get a matcher, usable in any {@link matchers|matcher} that uses Jasmine's equality (e.g. {@link matchers#toEqual|toEqual}, {@link matchers#toContain|toContain}, or {@link matchers#toHaveBeenCalledWith|toHaveBeenCalledWith}),
+   * that will succeed if the actual value being compared is empty.
+   * @name jasmine.empty
+   * @function
+   */
+  j$.empty = function() {return new j$.Empty();};
+
+  /**
+   * Get a matcher, usable in any {@link matchers|matcher} that uses Jasmine's equality (e.g. {@link matchers#toEqual|toEqual}, {@link matchers#toContain|toContain}, or {@link matchers#toHaveBeenCalledWith|toHaveBeenCalledWith}),
+   * that will succeed if the actual value being compared is not empty.
+   * @name jasmine.notEmpty
+   * @function
+   */
+  j$.notEmpty = function() {return new j$.NotEmpty();};
+
+  /**
+   * Get a matcher, usable in any {@link matchers|matcher} that uses Jasmine's equality (e.g. {@link matchers#toEqual|toEqual}, {@link matchers#toContain|toContain}, or {@link matchers#toHaveBeenCalledWith|toHaveBeenCalledWith}),
    * that will succeed if the actual value being compared contains at least the keys and values.
    * @name jasmine.objectContaining
    * @function

--- a/src/core/requireCore.js
+++ b/src/core/requireCore.js
@@ -61,6 +61,11 @@ var getJasmineRequireObj = (function (jasmineGlobal) {
     j$.ObjectPath = jRequire.ObjectPath(j$);
     j$.GlobalErrors = jRequire.GlobalErrors(j$);
 
+    j$.Truthy = jRequire.Truthy(j$);
+    j$.Falsy = jRequire.Falsy(j$);
+    j$.Empty = jRequire.Empty(j$);
+    j$.NotEmpty = jRequire.NotEmpty(j$);
+
     j$.matchers = jRequire.requireMatchers(jRequire, j$);
 
     return j$;


### PR DESCRIPTION
Added Matchers to enable testing against:
- truthy values
- falsy values
- empty values
- notEmpty values

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
We wanted to be able to check in react if props were `falsy` and we could not use `any`  so we created truthy as the opposite. The same went for `empty` which is a more specific case of `falsy` in some cases and would return true for cases like empty arrays or objects, which are truthy.

## How Has This Been Tested?
Included tests see PR

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

