### PR TITLE
Use timeout objects when in node

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -1,4 +1,7 @@
 getJasmineRequireObj().Clock = function() {
+
+  var NODE_JS = typeof process !== 'undefined' && process.versions && typeof process.versions.node === 'string';
+
   /**
    * _Note:_ Do not construct this directly, Jasmine will make one during booting. You can get the current clock with {@link jasmine.clock}.
    * @class Clock
@@ -22,6 +25,7 @@ getJasmineRequireObj().Clock = function() {
       delayedFunctionScheduler,
       timer;
 
+    self.FakeTimeout = FakeTimeout;
 
     /**
      * Install the mock clock over the built-in methods.
@@ -145,7 +149,15 @@ getJasmineRequireObj().Clock = function() {
     }
 
     function setTimeout(fn, delay) {
-      return delayedFunctionScheduler.scheduleFunction(fn, delay, argSlice(arguments, 2));
+      if (!NODE_JS) {
+        return delayedFunctionScheduler.scheduleFunction(fn, delay, argSlice(arguments, 2));
+      }
+
+      var timeout = new FakeTimeout();
+
+      delayedFunctionScheduler.scheduleFunction(fn, delay, argSlice(arguments, 2), false, timeout);
+
+      return timeout;
     }
 
     function clearTimeout(id) {
@@ -153,7 +165,15 @@ getJasmineRequireObj().Clock = function() {
     }
 
     function setInterval(fn, interval) {
-      return delayedFunctionScheduler.scheduleFunction(fn, interval, argSlice(arguments, 2), true);
+      if (!NODE_JS) {
+        return delayedFunctionScheduler.scheduleFunction(fn, interval, argSlice(arguments, 2), true);
+      }
+
+      var timeout = new FakeTimeout();
+
+      delayedFunctionScheduler.scheduleFunction(fn, interval, argSlice(arguments, 2), true, timeout);
+
+      return timeout;
     }
 
     function clearInterval(id) {
@@ -164,6 +184,19 @@ getJasmineRequireObj().Clock = function() {
       return Array.prototype.slice.call(argsObj, n);
     }
   }
+
+  /**
+   * Mocks Node.js Timeout class
+   */
+  function FakeTimeout() {}
+
+  FakeTimeout.prototype.ref = function () {
+    return this;
+  };
+
+  FakeTimeout.prototype.unref = function () {
+    return this;
+  };
 
   return Clock;
 };


### PR DESCRIPTION
Fixes: https://github.com/jasmine/jasmine/issues/1469

<!--- Provide a general summary of your changes in the Title above -->

## Description
When run in Node, setTimeout and setInterval should return an instance of Timeout instead of a number
<!--- Describe your changes in detail -->

## Motivation and Context
A Node dependency that used `Timeout.unref()` was unable to be tested with Jasmine
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Specs pass in both browser and Node, fixes problem in my project
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

