### PR TITLE
Do not execute pending specs

### DIFF
--- a/spec/core/SpecSpec.js
+++ b/spec/core/SpecSpec.js
@@ -422,13 +422,13 @@ describe("Spec", function() {
     expect(spec.isExecutable()).toBe(false);
   });
 
-  it("should be executable when pending", function() {
+  it("should not be executable when pending", function() {
     var spec = new jasmineUnderTest.Spec({
       queueableFn: { fn: function() {} }
     });
     spec.pend();
 
-    expect(spec.isExecutable()).toBe(true);
+    expect(spec.isExecutable()).toBe(false);
   });
 
   it("should be executable when not disabled or pending", function() {

--- a/spec/core/SuiteSpec.js
+++ b/spec/core/SuiteSpec.js
@@ -90,8 +90,9 @@ describe("Suite", function() {
     expect(suite.getResult().status).toBe('pending');
   });
 
-  it("is executable if not pending", function() {
+  it("is executable if it has any executable children", function() {
     var suite = new jasmineUnderTest.Suite({});
+    suite.addChild({ isExecutable: function() { return true ; } });
 
     expect(suite.isExecutable()).toBe(true);
   });

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -1400,7 +1400,7 @@ describe("Env integration", function() {
         status: 'passed'
       }));
 
-      expect(reporter.specDone).toHaveBeenCalledWith(jasmine.objectContaining({
+      expect(reporter.specDone).not.toHaveBeenCalledWith(jasmine.objectContaining({
         description: "with an x'ed spec",
         status: 'pending'
       }));
@@ -1410,7 +1410,7 @@ describe("Env integration", function() {
         status: 'failed'
       }));
 
-      expect(reporter.specDone).toHaveBeenCalledWith(jasmine.objectContaining({
+      expect(reporter.specDone).not.toHaveBeenCalledWith(jasmine.objectContaining({
         description: 'is pending',
         status: 'pending'
       }));

--- a/spec/core/integration/SpecRunningSpec.js
+++ b/spec/core/integration/SpecRunningSpec.js
@@ -560,6 +560,29 @@ describe("jasmine spec running", function () {
     env.execute();
   });
 
+  it("shouldn't run before/after functions in a suite without executable specs", function(done) {
+    var shouldNotRun = jasmine.createSpy("shouldNotRun"),
+
+    suite = env.describe('A Suite', function() {
+      // None of the before/after functions should run.
+      env.beforeAll(shouldNotRun);
+      env.beforeEach(shouldNotRun);
+      env.afterEach(shouldNotRun);
+      env.afterAll(shouldNotRun);
+
+      env.xit('pending spec', shouldNotRun);
+    });
+
+    var assertions = function() {
+      expect(shouldNotRun).not.toHaveBeenCalled();
+      done();
+    };
+
+    env.addReporter({jasmineDone: assertions});
+
+    env.execute();
+  });
+
   it("should allow top level suites to be disabled", function(done) {
     var specInADisabledSuite = jasmine.createSpy("specInADisabledSuite"),
       otherSpec = jasmine.createSpy("otherSpec");

--- a/src/core/Spec.js
+++ b/src/core/Spec.js
@@ -142,7 +142,7 @@ getJasmineRequireObj().Spec = function(j$) {
   };
 
   Spec.prototype.isExecutable = function() {
-    return !this.disabled;
+    return !this.disabled && !this.markedPending;
   };
 
   Spec.prototype.getFullName = function() {

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -82,7 +82,7 @@ getJasmineRequireObj().Suite = function(j$) {
   };
 
   Suite.prototype.isExecutable = function() {
-    return !this.markedPending;
+    return !this.markedPending && this.children.some(function(child) { return child.isExecutable(); });
   };
 
   Suite.prototype.canBeReentered = function() {


### PR DESCRIPTION
## Description

This changes the implementation of `isExecutable` so that pending specs and suites without any executable specs are considered non-executable.

## Motivation and Context

Previously, suites would needlessly execute beforeAll and afterAll when all of the specs were pending. This was causing lots of setup/teardown to occur for no reason.

Fixes #1265

#1225 is similar, but was only concerned with **disabled** suites. In contrast, this change is concerned with **enabled** suites that have no executable specs or suites inside.

## How Has This Been Tested?

- This repo's test suite
- Monkey patching Jasmine in an app that uses Protractor

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This changes the conditions under which `specDone` executes, and probably has other side effects I'm not aware of at the moment.

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.