### PR TITLE
allow adding a deprecation object

### DIFF
--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -2349,11 +2349,11 @@ describe("Env integration", function() {
     var env = new jasmineUnderTest.Env(),
       exceptionFormatter = new jasmineUnderTest.ExceptionFormatter(),
       reporter = jasmine.createSpyObj('reporter', ['jasmineDone', 'suiteDone', 'specDone']),
-      topLevelError = new Error('top level deprecation'),
-      suiteLevelError = new Error('suite level deprecation'),
-      specLevelError = new Error('spec level deprecation');
+      topLevelError, suiteLevelError, specLevelError;
 
-
+      try { throw new Error('top level deprecation') } catch (err) { topLevelError = err; }
+      try { throw new Error('suite level deprecation') } catch (err) { suiteLevelError = err; }
+      try { throw new Error('spec level deprecation') } catch (err) { specLevelError = err; }
 
     // prevent deprecation from being desplayed
     spyOn(console, "error");
@@ -2402,8 +2402,6 @@ describe("Env integration", function() {
         env.deprecated(specLevelError);
       });
     });
-
-    console.log(env.topSuite());
 
     env.execute();
   });

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -2303,6 +2303,9 @@ describe("Env integration", function() {
     var env = new jasmineUnderTest.Env(),
       reporter = jasmine.createSpyObj('reporter', ['jasmineDone', 'suiteDone', 'specDone']);
 
+    // prevent deprecation from being desplayed
+    spyOn(console, "error");
+
     reporter.jasmineDone.and.callFake(function(result) {
       expect(result.deprecationWarnings).toEqual([
         jasmine.objectContaining({ message: 'top level deprecation' })
@@ -2338,6 +2341,69 @@ describe("Env integration", function() {
         env.deprecated('spec level deprecation');
       });
     });
+
+    env.execute();
+  });
+
+  it('should report deprecation stack with an error object', function(done) {
+    var env = new jasmineUnderTest.Env(),
+      exceptionFormatter = new jasmineUnderTest.ExceptionFormatter(),
+      reporter = jasmine.createSpyObj('reporter', ['jasmineDone', 'suiteDone', 'specDone']),
+      topLevelError = new Error('top level deprecation'),
+      suiteLevelError = new Error('suite level deprecation'),
+      specLevelError = new Error('spec level deprecation');
+
+
+
+    // prevent deprecation from being desplayed
+    spyOn(console, "error");
+
+    reporter.jasmineDone.and.callFake(function(result) {
+      expect(result.deprecationWarnings).toEqual([
+        jasmine.objectContaining({
+          message: topLevelError.message,
+          stack: exceptionFormatter.stack(topLevelError)
+        })
+      ]);
+
+      expect(reporter.suiteDone).toHaveBeenCalledWith(jasmine.objectContaining({
+        fullName: 'suite',
+        deprecationWarnings: [
+          jasmine.objectContaining({
+            message: suiteLevelError.message,
+            stack: exceptionFormatter.stack(suiteLevelError)
+          })
+        ]
+      }));
+
+      expect(reporter.specDone).toHaveBeenCalledWith(jasmine.objectContaining({
+        fullName: 'suite spec',
+        deprecationWarnings: [
+          jasmine.objectContaining({
+            message: specLevelError.message,
+            stack: exceptionFormatter.stack(specLevelError)
+          })
+        ]
+      }));
+
+      done();
+    });
+
+    env.addReporter(reporter);
+
+    env.deprecated(topLevelError);
+
+    env.describe('suite', function() {
+      env.beforeAll(function() {
+        env.deprecated(suiteLevelError);
+      });
+
+      env.it('spec', function() {
+        env.deprecated(specLevelError);
+      });
+    });
+
+    console.log(env.topSuite());
 
     env.execute();
   });

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -200,11 +200,11 @@ getJasmineRequireObj().Env = function(j$) {
       handlingLoadErrors = false;
     };
 
-    this.deprecated = function(msg) {
+    this.deprecated = function(deprecation) {
       var runnable = currentRunnable() || topSuite;
-      runnable.addDeprecationWarning(msg);
-      if(typeof console !== 'undefined' && typeof console.warn !== 'undefined') {
-        console.error('DEPRECATION: ' + msg);
+      runnable.addDeprecationWarning(deprecation);
+      if(typeof console !== 'undefined' && typeof console.error === 'function') {
+        console.error('DEPRECATION:', deprecation);
       }
     };
 

--- a/src/core/ExpectationResult.js
+++ b/src/core/ExpectationResult.js
@@ -45,10 +45,14 @@ getJasmineRequireObj().buildExpectationResult = function() {
 
       var error = options.error;
       if (!error) {
-        try {
-          throw new Error(message());
-        } catch (e) {
-          error = e;
+        if (options.stack) {
+          error = options;
+        } else {
+          try {
+            throw new Error(message());
+          } catch (e) {
+            error = e;
+          }
         }
       }
       return stackFormatter(error);

--- a/src/core/Spec.js
+++ b/src/core/Spec.js
@@ -152,8 +152,11 @@ getJasmineRequireObj().Spec = function(j$) {
     return this.getSpecName(this);
   };
 
-  Spec.prototype.addDeprecationWarning = function(msg) {
-    this.result.deprecationWarnings.push(this.expectationResultFactory({ message: msg }));
+  Spec.prototype.addDeprecationWarning = function(deprecation) {
+    if (typeof deprecation === 'string') {
+      deprecation = { message: deprecation };
+    }
+    this.result.deprecationWarnings.push(this.expectationResultFactory(deprecation));
   };
 
   var extractCustomPendingMessage = function(e) {

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -148,8 +148,11 @@ getJasmineRequireObj().Suite = function(j$) {
     }
   };
 
-  Suite.prototype.addDeprecationWarning = function(msg) {
-    this.result.deprecationWarnings.push(this.expectationResultFactory({ message: msg }));
+  Suite.prototype.addDeprecationWarning = function(deprecation) {
+    if (typeof deprecation === 'string') {
+      deprecation = { message: deprecation };
+    }
+    this.result.deprecationWarnings.push(this.expectationResultFactory(deprecation));
   };
 
   function isFailure(args) {


### PR DESCRIPTION
## Description

Allow `jasmine.getEnv().deprecated() to take an error object instead of a string

## Motivation and Context

Trying to add a deprecation with an error object so I can use it's stack instead of the the `deprecationWarning.stack` starting at `env.deprecated`

## How Has This Been Tested?

added integration test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I tried running `grunt buildDistribution` but it gave me the error `Warning: not found: bundle Use --force to continue.`
