### PR TITLE
Display error properties for failed specs

### DIFF
--- a/spec/core/ExceptionFormatterSpec.js
+++ b/spec/core/ExceptionFormatterSpec.js
@@ -116,5 +116,27 @@ describe("ExceptionFormatter", function() {
     it("returns null if no Error provided", function() {
       expect(new jasmineUnderTest.ExceptionFormatter().stack()).toBeNull();
     });
+
+    it("includes error properties in stack", function() {
+      var error;
+      try { throw new Error("an error") } catch(e) { error = e; }
+      error.someProperty = 'hello there';
+
+      var result = new jasmineUnderTest.ExceptionFormatter().stack(error);
+
+      expect(result).toMatch(/error properties: {/);
+      expect(result).toMatch(/"someProperty": "hello there"/);
+    });
+
+    it("drops error properties if there is a cycle", function() {
+      var error;
+      try { throw new Error("an error") } catch(e) { error = e; }
+      error.someProperty = error;
+
+      var result = new jasmineUnderTest.ExceptionFormatter().stack(error);
+
+      expect(result).not.toMatch(/error properties/);
+    });
+
   });
 });

--- a/spec/core/ExceptionFormatterSpec.js
+++ b/spec/core/ExceptionFormatterSpec.js
@@ -124,18 +124,7 @@ describe("ExceptionFormatter", function() {
 
       var result = new jasmineUnderTest.ExceptionFormatter().stack(error);
 
-      expect(result).toMatch(/error properties: {/);
-      expect(result).toMatch(/"someProperty": "hello there"/);
-    });
-
-    it("drops error properties if there is a cycle", function() {
-      var error;
-      try { throw new Error("an error") } catch(e) { error = e; }
-      error.someProperty = error;
-
-      var result = new jasmineUnderTest.ExceptionFormatter().stack(error);
-
-      expect(result).not.toMatch(/error properties/);
+      expect(result).toMatch(/error properties:.*someProperty.*hello there/);
     });
 
   });

--- a/src/core/ExceptionFormatter.js
+++ b/src/core/ExceptionFormatter.js
@@ -29,12 +29,16 @@ getJasmineRequireObj().ExceptionFormatter = function(j$) {
 
       var stackTrace = new j$.StackTrace(error.stack);
       var lines = filterJasmine(stackTrace);
+      var result = '';
 
       if (stackTrace.message) {
         lines.unshift(stackTrace.message);
       }
 
-      return lines.join('\n');
+      result += formatProperties(error);
+      result += lines.join('\n');
+
+      return result;
     };
 
     function filterJasmine(stackTrace) {
@@ -50,6 +54,32 @@ getJasmineRequireObj().ExceptionFormatter = function(j$) {
       });
  
       return result;
+    }
+
+    function formatProperties(error) {
+      if (!(error instanceof Object)) {
+        return;
+      }
+
+      var ignored = ['name', 'message', 'stack', 'fileName', 'sourceURL', 'line', 'lineNumber', 'stack'];
+      var result = {};
+      var empty = true;
+
+      for (var prop in error) {
+        if (ignored.includes(prop)) {
+          continue;
+        }
+        result[prop] = error[prop];
+        empty = false;
+      }
+
+      if (!empty) {
+        try {
+          return 'error properties: ' + JSON.stringify(result, null, 2) + '\n';
+        } catch (_) {}
+      }
+
+      return '';
     }
   }
 

--- a/src/core/ExceptionFormatter.js
+++ b/src/core/ExceptionFormatter.js
@@ -74,9 +74,7 @@ getJasmineRequireObj().ExceptionFormatter = function(j$) {
       }
 
       if (!empty) {
-        try {
-          return 'error properties: ' + JSON.stringify(result, null, 2) + '\n';
-        } catch (_) {}
+        return 'error properties: ' + j$.pp(result) + '\n';
       }
 
       return '';

--- a/src/core/ExceptionFormatter.js
+++ b/src/core/ExceptionFormatter.js
@@ -61,7 +61,7 @@ getJasmineRequireObj().ExceptionFormatter = function(j$) {
         return;
       }
 
-      var ignored = ['name', 'message', 'stack', 'fileName', 'sourceURL', 'line', 'lineNumber', 'stack'];
+      var ignored = ['name', 'message', 'stack', 'fileName', 'sourceURL', 'line', 'lineNumber'];
       var result = {};
       var empty = true;
 


### PR DESCRIPTION
## Description
If a spec fails due to an uncaught exception or unhandled promise rejection then Jasmine currently prints the error message and stack. This is missing potentially very helpful information that may be in other custom properties on the error.

Happy to make any changes you suggest. Thanks for taking a look :)

## Motivation and Context
For example imagine a test like this:
```
async function makeHttpRequest(...) {
  // do stuff
  const error = new Error('Unexpected response from server!');
  error.statusCode = ...;
  error.body = ...;
  throw error;
}

it('talks to the server', async () => {
  const response = await makeHttpRequest(...);
  expect(response.body).toEqual('ok');
});
```

Having the `statusCode` and `body` properties printed in the spec failure text greatly simplifies debugging. Currently I have to catch the error and insert a console.log, or use a debugger. This is especially useful for sporadic test failures.

## How Has This Been Tested?
I ran the tests on my Arch Linux machine in the following environments:
- Firefox 58.0.2 (`bundle exec rake jasmine`)
- Chrome 64.0.3282.167 (`bundle exec rake jasmine`)
- Node v9.5.0 (`npm test`)

All the tests passed except for one failure in Firefox. Note that this test also fails for me on master, so this is not caused by my changes.
- `Env integration > with a mock clock > should wait a custom interval before reporting async functions that fail to call done`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

