### PR TITLE
Report unhandled rejections as globalErrors.

### DIFF
--- a/spec/core/GlobalErrorsSpec.js
+++ b/spec/core/GlobalErrorsSpec.js
@@ -78,7 +78,7 @@ describe("GlobalErrors", function() {
     errors.uninstall();
   });
 
-  it("works in node.js", function() {
+  it("reports uncaughtException in node.js", function() {
     var fakeGlobal = {
           process: {
             on: jasmine.createSpy('process.on'),
@@ -106,5 +106,35 @@ describe("GlobalErrors", function() {
 
     expect(fakeGlobal.process.removeListener).toHaveBeenCalledWith('uncaughtException', addedListener);
     expect(fakeGlobal.process.on).toHaveBeenCalledWith('uncaughtException', 'foo');
+  });
+
+  it("reports unhandledRejection in node.js", function() {
+    var fakeGlobal = {
+          process: {
+            on: jasmine.createSpy('process.on'),
+            removeListener: jasmine.createSpy('process.removeListener'),
+            listeners: jasmine.createSpy('process.listeners').and.returnValue(['foo']),
+            removeAllListeners: jasmine.createSpy('process.removeAllListeners')
+          }
+        },
+        handler = jasmine.createSpy('errorHandler'),
+        errors = new jasmineUnderTest.GlobalErrors(fakeGlobal);
+
+    errors.install();
+    expect(fakeGlobal.process.on).toHaveBeenCalledWith('unhandledRejection', jasmine.any(Function));
+    expect(fakeGlobal.process.listeners).toHaveBeenCalledWith('unhandledRejection');
+    expect(fakeGlobal.process.removeAllListeners).toHaveBeenCalledWith('unhandledRejection');
+
+    errors.pushListener(handler);
+
+    var addedListener = fakeGlobal.process.on.calls.argsFor(0)[1];
+    addedListener(new Error('bar'));
+
+    expect(handler).toHaveBeenCalledWith(new Error('bar'));
+
+    errors.uninstall();
+
+    expect(fakeGlobal.process.removeListener).toHaveBeenCalledWith('unhandledRejection', addedListener);
+    expect(fakeGlobal.process.on).toHaveBeenCalledWith('unhandledRejection', 'foo');
   });
 });

--- a/src/core/GlobalErrors.js
+++ b/src/core/GlobalErrors.js
@@ -13,18 +13,29 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
       }
     };
 
+    this.originalHandlers = {};
+    this.installOne_ = function installOne_(errorType) {
+      this.originalHandlers[errorType] = global.process.listeners(errorType);
+      global.process.removeAllListeners(errorType);
+      global.process.on(errorType, onerror);
+
+      this.uninstall = function uninstall() {
+        var errorTypes = Object.keys(this.originalHandlers);
+        for (var iType = 0; iType < errorTypes.length; iType++) {
+          var errorType = errorTypes[iType];
+          global.process.removeListener(errorType, onerror);
+          for (var i = 0; i < this.originalHandlers[errorType].length; i++) {
+            global.process.on(errorType, this.originalHandlers[errorType][i]);
+          }
+          delete this.originalHandlers[errorType];
+        }
+      };
+    };
+
     this.install = function install() {
       if (global.process && global.process.listeners && j$.isFunction_(global.process.on)) {
-        var originalHandlers = global.process.listeners('uncaughtException');
-        global.process.removeAllListeners('uncaughtException');
-        global.process.on('uncaughtException', onerror);
-
-        this.uninstall = function uninstall() {
-          global.process.removeListener('uncaughtException', onerror);
-          for (var i = 0; i < originalHandlers.length; i++) {
-            global.process.on('uncaughtException', originalHandlers[i]);
-          }
-        };
+        this.installOne_('uncaughtException');
+        this.installOne_('unhandledRejection');
       } else {
         var originalHandler = global.onerror;
         global.onerror = onerror;


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Extend existing support for uncaughtExceptions to unhandledRejections now that many tests are async.  
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
On nodejs, unhandledRejections are not reported through jasmine.  A common example is an async test with a runtime type error, xxx.foo xxx is undefined.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Unit tests.  I can add a NODE_JS only  system integration test, but I did not see anything similar in the code.
<!--- Include details of your testing environment, and the tests you ran to -->
npm test
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

