### PR TITLE
Change error message for extra elements at end of actual array. #1485

### DIFF
--- a/spec/core/matchers/toEqualSpec.js
+++ b/spec/core/matchers/toEqualSpec.js
@@ -700,7 +700,7 @@ describe("toEqual", function() {
       var actual = [1, 1, 2, 3, 5],
         expected = [1, 1, 2, 3],
         message = 'Expected $.length = 5 to equal 4.\n' +
-          'Expected $[4] = 5 to equal undefined.';
+          'Unexpected $[4] = 5 in array.';
 
       expect(compareEquals(actual, expected).pass).toBe(false);
       expect(compareEquals(actual, expected).message).toEqual(message);
@@ -711,6 +711,37 @@ describe("toEqual", function() {
         expected = [1, 1, 2, 3, 5],
         message = 'Expected $.length = 4 to equal 5.\n' +
           'Expected $[4] = undefined to equal 5.';
+
+      expect(compareEquals(actual, expected).pass).toBe(false);
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
+    it("undefined in middle of actual array", function() {
+      var actual = [1, void 0, 3],
+        expected = [1, 2, 3],
+        message = 'Expected $[1] = undefined to equal 2.';
+
+      expect(compareEquals(actual, expected).pass).toBe(false);
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
+    it("undefined in middle of expected array", function() {
+      var actual = [1, 2, 3],
+        expected = [1, void 0, 3],
+        message = 'Expected $[1] = 2 to equal undefined.';
+
+      expect(compareEquals(actual, expected).pass).toBe(false);
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
+    it("actual array is longer by 4 elements", function() {
+      var actual = [1, 1, 2, 3, 5, 8, 13],
+        expected = [1, 1, 2],
+        message = 'Expected $.length = 7 to equal 3.\n' +
+          'Unexpected $[3] = 3 in array.\n' +
+          'Unexpected $[4] = 5 in array.\n' +
+          'Unexpected $[5] = 8 in array.\n' +
+          'Unexpected $[6] = 13 in array.';
 
       expect(compareEquals(actual, expected).pass).toBe(false);
       expect(compareEquals(actual, expected).message).toEqual(message);
@@ -740,21 +771,41 @@ describe("toEqual", function() {
       expect(compareEquals(actual, expected).message).toEqual(message);
     });
 
-    it("object with nested array", function() {
+    it("object with nested array (actual longer than expected)", function() {
       var actual = { values: [1, 1, 2, 3] },
         expected = { values: [1, 1, 2] },
         message = 'Expected $.values.length = 4 to equal 3.\n' +
-          'Expected $.values[3] = 3 to equal undefined.';
+          'Unexpected $.values[3] = 3 in array.';
 
       expect(compareEquals(actual, expected).pass).toBe(false);
       expect(compareEquals(actual, expected).message).toEqual(message);
     });
 
-    it("array with nested object", function() {
+    it("object with nested array (expected longer than actual)", function() {
+      var actual = { values: [1, 1, 2] },
+        expected = { values: [1, 1, 2, 3] },
+        message = 'Expected $.values.length = 3 to equal 4.\n' +
+          'Expected $.values[3] = undefined to equal 3.';
+
+      expect(compareEquals(actual, expected).pass).toBe(false);
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
+    it("array with unexpected nested object", function() {
       var actual = [1, 1, 2, { value: 3 }],
         expected = [1, 1, 2],
         message = 'Expected $.length = 4 to equal 3.\n' +
-          'Expected $[3] = Object({ value: 3 }) to equal undefined.';
+          'Unexpected $[3] = Object({ value: 3 }) in array.';
+
+      expect(compareEquals(actual, expected).pass).toBe(false);
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
+    it("array with missing nested object", function() {
+      var actual = [1, 1, 2],
+        expected = [1, 1, 2, { value: 3 }],
+        message = 'Expected $.length = 3 to equal 4.\n' +
+          'Expected $[3] = undefined to equal Object({ value: 3 }).';
 
       expect(compareEquals(actual, expected).pass).toBe(false);
       expect(compareEquals(actual, expected).message).toEqual(message);
@@ -767,7 +818,7 @@ describe("toEqual", function() {
           'Expected $[0][1] = undefined to equal 1.\n' +
           'Expected $[1].length = 2 to equal 1.\n' +
           'Expected $[1][0] = 1 to equal 2.\n' +
-          'Expected $[1][1] = 2 to equal undefined.';
+          'Unexpected $[1][1] = 2 in array.';
 
       expect(compareEquals(actual, expected).pass).toBe(false);
       expect(compareEquals(actual, expected).message).toEqual(message);

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -225,8 +225,14 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       });
 
       for (i = 0; i < aLength || i < bLength; i++) {
+        var formatter = false;
         diffBuilder.withPath(i, function() {
-          result = eq(i < aLength ? a[i] : void 0, i < bLength ? b[i] : void 0, aStack, bStack, customTesters, diffBuilder) && result;
+          if (i >= bLength) {
+            diffBuilder.record(a[i], void 0, actualArrayIsLongerFormatter);
+            result = false;
+          } else {
+            result = eq(i < aLength ? a[i] : void 0, i < bLength ? b[i] : void 0, aStack, bStack, customTesters, diffBuilder) && result;
+          }
         });
       }
       if (!result) {
@@ -450,6 +456,13 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       path + ' to be a kind of ' +
       j$.fnNameFor(expected.constructor) +
       ', but was ' + j$.pp(actual) + '.';
+  }
+
+  function actualArrayIsLongerFormatter(actual, expected, path) {
+    return 'Unexpected ' +
+      path + (path.depth() ? ' = ' : '') +
+      j$.pp(actual) +
+      ' in array.';
   }
 
   function formatKeyValuePairs(obj) {


### PR DESCRIPTION
## Description
Changes the error output when asserting something of the form:
`expect(longerArray).toEqual(shorterArray)` 

Was:
`Expected $[n] = 'foo' to equal undefined.`

Now:
`Unexpected $[n] = 'foo' in array.`

This does *not* change assertions of the form:
`expect(shorterArray).toEqual(longerArray)`

Which should still output:
`Expected $[n] = undefined to equal 'foo'.`

## Motivation and Context
Fixes #1485 
I picked this up as an opportunity to get familiar with this project... I hope my newness isn't *too* obvious!

Quoting the original issue submitter, the previous error implied that "some `$[n]` was expected, when most likely the actual array was just longer than the expected". New message is easier to grok at a glance.

## How Has This Been Tested?
1. Added additional tests to `toEqualSpec` to distinguish between the actual array being longer than the expected one, and vice versa.
1. Added an additional test to `toEqualSpec` to address @slackersoft 's  comment on #1485 
1. Ran node tests
1. Ran browser tests in Chrome, Firefox, IE.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

I am unsure, here -- I don't know if changing the output of a failed assertion truly constitutes a breaking change or not.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

