### PR TITLE
Allow omitting the name argument: `createSpy(func)`

### DIFF
--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -20,6 +20,13 @@ describe('Spies', function () {
       expect(spy.bob).toEqual("test");
     });
 
+    it("should allow you to omit the name argument and only pass the originalFn argument", function() {
+      var fn = function test() {};
+      var spy = env.createSpy(fn);
+
+      expect(spy.and.identity).toEqual("test");
+    })
+
     it("warns the user that we intend to overwrite an existing property", function() {
       TestClass.prototype.someFunction.and = "turkey";
 

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -474,6 +474,11 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     this.createSpy = function(name, originalFn) {
+      if (arguments.length === 1 && j$.isFunction_(name)) {
+        originalFn = name;
+        name = originalFn.name;
+      }
+
       return spyFactory.createSpy(name, originalFn);
     };
 


### PR DESCRIPTION
## Description
Added a new signature to `jasmine.createSpy()`: `createSpy(originalFn)`.

## Motivation and Context
There were many times I'd like to write:

```js
const myFunc = () => {
  ...
}
const spy = jasmine.createSpy(myFunc)
```

Instead, jasmine requires me to do so:

```js
const myFunc = () => {
  ...
}
const spy = jasmine.createSpy('myFunc', myFunc)
```

## How Has This Been Tested?

I have added a new test case for this signature. The changes I've made should only affect the callings of `jasmine.createSpy()`, not any other parts of jasmine. The test case passed in Node v10 & v4. Browser environments not tested, because of [a bug of Bundler](https://github.com/bundler/bundler/issues/6311). But I think it should be fine.
I am aware that this will change the public interface, but I believe it should have no negative effects on any existing projects that are using jasmine.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I have left the documentation unchaged, since I am very bad at English :)

