### PR TITLE
Implemented hiding of disabled specs

### DIFF
--- a/lib/jasmine-core/boot/boot.js
+++ b/lib/jasmine-core/boot/boot.js
@@ -56,6 +56,9 @@
 
   var throwingExpectationFailures = queryString.getParam("throwFailures");
   env.throwOnExpectationFailure(throwingExpectationFailures);
+  
+  var hideDisabled = queryString.getParam("hideDisabled");
+  env.hideDisabled(hideDisabled); 
 
   var random = queryString.getParam("random");
 

--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -103,7 +103,6 @@ describe("HtmlReporter", function() {
           createTextNode: function() { return document.createTextNode.apply(document, arguments); }
         });
       reporter.initialize();
-
       reporter.specDone({id: 789, status: "excluded", fullName: "symbols should have titles", passedExpectations: [], failedExpectations: []});
 
       var specEl = container.querySelector('.jasmine-symbol-summary li');
@@ -696,7 +695,85 @@ describe("HtmlReporter", function() {
         expect(navigateHandler).toHaveBeenCalledWith('throwFailures', false);
       });
     });
+    describe("UI for hiding disabled specs", function() {
+      it("should be unchecked if not hiding disabled specs", function() {
+        var env = new jasmineUnderTest.Env(),
+          container = document.createElement("div"),
+          getContainer = function() {
+            return container;
+          },
+          reporter = new jasmineUnderTest.HtmlReporter({
+            env: env,
+            getContainer: getContainer,
+            createElement: function() {
+              return document.createElement.apply(document, arguments);
+            },
+            createTextNode: function() {
+              return document.createTextNode.apply(document, arguments);
+            }
+          });
 
+        env.hideDisabled(false);
+        reporter.initialize();
+        reporter.jasmineDone({});
+
+        var disabledUI = container.querySelector(".jasmine-disabled");
+        expect(disabledUI.checked).toBe(false);
+      });
+
+      it("should be checked if hiding disabled", function() {
+        var env = new jasmineUnderTest.Env(),
+          container = document.createElement("div"),
+          getContainer = function() {
+            return container;
+          },
+          reporter = new jasmineUnderTest.HtmlReporter({
+            env: env,
+            getContainer: getContainer,
+            createElement: function() {
+              return document.createElement.apply(document, arguments);
+            },
+            createTextNode: function() {
+              return document.createTextNode.apply(document, arguments);
+            }
+          });
+
+        env.hideDisabled(true);
+        reporter.initialize();
+        reporter.jasmineDone({});
+
+        var disabledUI = container.querySelector(".jasmine-disabled");
+        expect(disabledUI.checked).toBe(true);
+      });
+
+      it("should not display specs that have been disabled", function() {
+        var env = new jasmineUnderTest.Env(),
+        container = document.createElement('div'),
+        
+        getContainer = function() {return container;},
+
+        reporter = new jasmineUnderTest.HtmlReporter({
+          env: env,
+          getContainer: getContainer,
+          createElement: function() { return document.createElement.apply(document, arguments); },
+          createTextNode: function() { return document.createTextNode.apply(document, arguments); }
+        });
+        env.hideDisabled(true);
+        reporter.initialize();
+        reporter.specDone({
+            id: 789, 
+            status: "excluded", 
+            fullName: "symbols should have titles", 
+            passedExpectations: [], 
+            failedExpectations: []
+          });
+
+        
+
+        var specEl = container.querySelector('.jasmine-symbol-summary li');
+        expect(specEl.getAttribute("class")).toEqual("jasmine-excluded-no-display");
+      });
+    });
     describe("UI for running tests in random order", function() {
       it("should be unchecked if not randomizing", function() {
         var env = new jasmineUnderTest.Env(),

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -26,6 +26,7 @@ getJasmineRequireObj().Env = function(j$) {
     var throwOnExpectationFailure = false;
     var stopOnSpecFailure = false;
     var random = true;
+    var hidingDisabled = false; 
     var seed = null;
     var handlingLoadErrors = true;
     var hasFailures = false;
@@ -192,6 +193,14 @@ getJasmineRequireObj().Env = function(j$) {
 
     this.randomizeTests = function(value) {
       random = !!value;
+    };
+
+    this.hidingDisabled = function(value) { 
+      return hidingDisabled; 
+    };
+
+    this.hideDisabled = function(value) { 
+      hidingDisabled = !!value; 
     };
 
     this.randomTests = function() {

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -119,7 +119,7 @@ jasmineRequire.HtmlReporter = function(j$) {
       }
 
       symbols.appendChild(createDom('li', {
-          className: noExpectations(result) ? 'jasmine-empty' : 'jasmine-' + result.status,
+          className: this.displaySpecInCorrectFormat(result),
           id: 'spec_' + result.id,
           title: result.fullName
         }
@@ -130,6 +130,17 @@ jasmineRequire.HtmlReporter = function(j$) {
       }
 
       addDeprecationWarnings(result);
+    };
+
+    this.displaySpecInCorrectFormat = function(result) {
+      return noExpectations(result) ? 'jasmine-empty' : this.resultStatus(result.status);
+    };
+
+    this.resultStatus = function(status) {
+      if(status === 'excluded') {
+        return env.hidingDisabled() ?  'jasmine-excluded-no-display' : 'jasmine-excluded';
+      } 
+      return 'jasmine-' + status; 
     };
 
     this.jasmineDone = function(doneResult) {
@@ -323,7 +334,14 @@ jasmineRequire.HtmlReporter = function(j$) {
               id: 'jasmine-random-order',
               type: 'checkbox'
             }),
-            createDom('label', { className: 'jasmine-label', 'for': 'jasmine-random-order' }, 'run tests in random order'))
+            createDom('label', { className: 'jasmine-label', 'for': 'jasmine-random-order' }, 'run tests in random order')),
+          createDom('div', { className: 'jasmine-hide-disabled' },
+            createDom('input', {
+              className: 'jasmine-disabled',
+              id: 'jasmine-hide-disabled',
+              type: 'checkbox'
+            }),
+            createDom('label', { className: 'jasmine-label', 'for': 'jasmine-hide-disabled' }, 'hide disabled tests'))
         )
       );
 
@@ -343,6 +361,12 @@ jasmineRequire.HtmlReporter = function(j$) {
       randomCheckbox.checked = env.randomTests();
       randomCheckbox.onclick = function() {
         navigateWithNewParam('random', !env.randomTests());
+      };
+
+      var hideDisabled = optionsMenuDom.querySelector('#jasmine-hide-disabled');
+      hideDisabled.checked = env.hidingDisabled();
+      hideDisabled.onclick = function() {
+        navigateWithNewParam('hideDisabled', !env.hidingDisabled());
       };
 
       var optionsTrigger = optionsMenuDom.querySelector('.jasmine-trigger'),

--- a/src/html/_HTMLReporter.scss
+++ b/src/html/_HTMLReporter.scss
@@ -135,13 +135,18 @@ body {
         }
       }
 
-        &.jasmine-excluded {
+       &.jasmine-excluded {
           font-size: 14px;
 
           &:before {
             color: $neutral-color;
             content: "\02022";
           }
+        }
+
+        &.jasmine-excluded-no-display {
+          font-size: 14px;
+          display: none;
         }
 
       &.jasmine-pending {
@@ -294,7 +299,7 @@ body {
 
       &.jasmine-excluded a {
         color: $neutral-color;
-      }
+      } 
     }
   }
 


### PR DESCRIPTION
based on #1458. users can hide the grey dots that display when there are disabled specs.

![jasmine-change](https://user-images.githubusercontent.com/32267676/40363522-bc4fcb8c-5dc7-11e8-8591-6d6e0520985e.gif)

## Description
* In HtmlReporter.js:  Added a new item in the options menu for 'hide disabled tests' - adds hideDisabled=true|false to URL when pressed.
* In HtmlReporterSpec.js: Added tests for behavior when toggled on/off.
* In Boot.js: read hideDisabled from URL and set a property accessible via hidingDisabled() method.
* added a jasmine-excluded-no-display class to CSS.
* apply this class instead of jasmine-excluded when 'hide disabled tests' pressed. 

## Motivation and Context
Solves issue in https://github.com/jasmine/jasmine/issues/1458.

## How Has This Been Tested?
 unit tests in HtmlReporterSpec.js + following manual tests:
Test Procedure: 
   Scenario #1: 
   -> Run subset of tests.
   -> Press 'hide disabled tests'
   -> Verify that the disabled tests are hidden

  Scenario #2: 
   -> Run subset of tests.
   -> Press 'hide disabled tests'
   -> Refresh page
   -> Verify that the disabled tests are hidden

  Scenario #3: 
   -> Run subset of tests.
   -> Press 'hide disabled tests'
   -> Press 'hide disabled tests' again
   -> Verify that the disabled tests are hidden
   
   Tested on: Mac OS Sierra (chrome 66.0.3359.139, firefox: 59.0.2)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

