### PR TITLE
Improve Jasmine timeout error message

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -5094,9 +5094,8 @@ getJasmineRequireObj().QueueRunner = function(j$) {
       var timeoutInterval = queueableFn.timeout || j$.DEFAULT_TIMEOUT_INTERVAL;
       timeoutId = self.setTimeout(function() {
         var error = new Error(
-          'Timeout - Async callback was not invoked within ' +
-          (queueableFn.timeout ? 'custom timeout' : 'jasmine.DEFAULT_TIMEOUT_INTERVAL') +
-          ' (of ' + timeoutInterval + 'ms)'
+          'Timeout - Async callback was not invoked within ' + timeoutInterval + 'ms ' +
+          (queueableFn.timeout ? '(custom timeout)' : '(set by jasmine.DEFAULT_TIMEOUT_INTERVAL)')
         );
         onException(error);
         next();

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1453,7 +1453,7 @@ getJasmineRequireObj().Env = function(j$) {
         userContext: function() { return suite.clonedSharedUserContext(); },
         queueableFn: {
           fn: fn,
-          timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
+          timeout: timeout || 0
         },
         throwOnExpectationFailure: throwOnExpectationFailure
       });
@@ -1536,7 +1536,7 @@ getJasmineRequireObj().Env = function(j$) {
       ensureIsFunctionOrAsync(beforeEachFunction, 'beforeEach');
       currentDeclarationSuite.beforeEach({
         fn: beforeEachFunction,
-        timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
+        timeout: timeout || 0
       });
     };
 
@@ -1545,7 +1545,7 @@ getJasmineRequireObj().Env = function(j$) {
       ensureIsFunctionOrAsync(beforeAllFunction, 'beforeAll');
       currentDeclarationSuite.beforeAll({
         fn: beforeAllFunction,
-        timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
+        timeout: timeout || 0
       });
     };
 
@@ -1555,7 +1555,7 @@ getJasmineRequireObj().Env = function(j$) {
       afterEachFunction.isCleanup = true;
       currentDeclarationSuite.afterEach({
         fn: afterEachFunction,
-        timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
+        timeout: timeout || 0
       });
     };
 
@@ -1564,7 +1564,7 @@ getJasmineRequireObj().Env = function(j$) {
       ensureIsFunctionOrAsync(afterAllFunction, 'afterAll');
       currentDeclarationSuite.afterAll({
         fn: afterAllFunction,
-        timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
+        timeout: timeout || 0
       });
     };
 
@@ -5090,12 +5090,17 @@ getJasmineRequireObj().QueueRunner = function(j$) {
 
     self.globalErrors.pushListener(handleError);
 
-    if (queueableFn.timeout) {
+    if (queueableFn.timeout !== undefined) {
+      var timeoutInterval = queueableFn.timeout || j$.DEFAULT_TIMEOUT_INTERVAL;
       timeoutId = self.setTimeout(function() {
-        var error = new Error('Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.');
+        var error = new Error(
+          'Timeout - Async callback was not invoked within ' +
+          (queueableFn.timeout ? 'custom timeout' : 'jasmine.DEFAULT_TIMEOUT_INTERVAL') +
+          ' (of ' + timeoutInterval + 'ms)'
+        );
         onException(error);
         next();
-      }, queueableFn.timeout());
+      }, timeoutInterval);
     }
 
     try {

--- a/spec/core/QueueRunnerSpec.js
+++ b/spec/core/QueueRunnerSpec.js
@@ -183,7 +183,7 @@ describe("QueueRunner", function() {
 
     it("sets a timeout if requested for asynchronous functions so they don't go on forever", function() {
       var timeout = 3,
-        beforeFn = { fn: function(done) { }, type: 'before', timeout: function() { return timeout; } },
+        beforeFn = { fn: function(done) { }, type: 'before', timeout: timeout },
         queueableFn = { fn: jasmine.createSpy('fn'), type: 'queueable' },
         onComplete = jasmine.createSpy('onComplete'),
         onException = jasmine.createSpy('onException'),
@@ -304,7 +304,7 @@ describe("QueueRunner", function() {
     });
 
     it("continues running functions when an exception is thrown in async code without timing out", function() {
-      var queueableFn = { fn: function(done) { throwAsync(); }, timeout: function() { return 1; } },
+      var queueableFn = { fn: function(done) { throwAsync(); }, timeout: 1 },
         nextQueueableFn = { fn: jasmine.createSpy("nextFunction") },
         onException = jasmine.createSpy('onException'),
         globalErrors = { pushListener: jasmine.createSpy('pushListener'), popListener: jasmine.createSpy('popListener') },

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -1105,20 +1105,23 @@ describe("Env integration", function() {
     });
 
     it('should wait a custom interval before reporting async functions that fail to call done', function(done) {
+      var nodeVersion = typeof process !== 'undefined' && process.versions && process.versions.node.split(".").map(Number);
       var env = createMockedEnv(),
           reporter = jasmine.createSpyObj('fakeReport', ['jasmineDone', 'suiteDone', 'specDone']);
 
-
       reporter.jasmineDone.and.callFake(function(r) {
         expect(r.failedExpectations).toEqual([]);
-        expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('suite beforeAll', [ 'Error: Timeout - Async callback was not invoked within custom timeout (of 5000ms)' ]);
-        expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('suite afterAll', [ 'Error: Timeout - Async callback was not invoked within custom timeout (of 2000ms)' ]);
-        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite beforeEach times out', [
-          'Error: Timeout - Async callback was not invoked within custom timeout (of 1000ms)',
-          'Error: Timeout - Async callback was not invoked within jasmine.DEFAULT_TIMEOUT_INTERVAL (of 10000ms)'
-        ]);
-        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite afterEach times out', [ 'Error: Timeout - Async callback was not invoked within custom timeout (of 4000ms)' ]);
-        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite it times out', [ 'Error: Timeout - Async callback was not invoked within custom timeout (of 6000ms)' ]);
+        expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('suite beforeAll', [ 'Error: Timeout - Async callback was not invoked within 5000ms (custom timeout)' ]);
+        expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('suite afterAll', [ 'Error: Timeout - Async callback was not invoked within 2000ms (custom timeout)' ]);
+        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite beforeEach times out',
+          (nodeVerArr[0] == 4) ? [
+            'Error: Timeout - Async callback was not invoked within 1000ms (custom timeout)',
+          ] : [
+            'Error: Timeout - Async callback was not invoked within 1000ms (custom timeout)',
+            'Error: Timeout - Async callback was not invoked within 10000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)'
+          ]);
+        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite afterEach times out', [ 'Error: Timeout - Async callback was not invoked within 4000ms (custom timeout)' ]);
+        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite it times out', [ 'Error: Timeout - Async callback was not invoked within 6000ms (custom timeout))' ]);
 
         jasmine.clock().tick(1);
         realSetTimeout(done);

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -1105,7 +1105,6 @@ describe("Env integration", function() {
     });
 
     it('should wait a custom interval before reporting async functions that fail to call done', function(done) {
-      var nodeVersion = typeof process !== 'undefined' && process.versions && process.versions.node.split(".").map(Number);
       var env = createMockedEnv(),
           reporter = jasmine.createSpyObj('fakeReport', ['jasmineDone', 'suiteDone', 'specDone']);
 
@@ -1113,15 +1112,9 @@ describe("Env integration", function() {
         expect(r.failedExpectations).toEqual([]);
         expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('suite beforeAll', [ 'Error: Timeout - Async callback was not invoked within 5000ms (custom timeout)' ]);
         expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('suite afterAll', [ 'Error: Timeout - Async callback was not invoked within 2000ms (custom timeout)' ]);
-        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite beforeEach times out',
-          (nodeVerArr[0] == 4) ? [
-            'Error: Timeout - Async callback was not invoked within 1000ms (custom timeout)',
-          ] : [
-            'Error: Timeout - Async callback was not invoked within 1000ms (custom timeout)',
-            'Error: Timeout - Async callback was not invoked within 10000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)'
-          ]);
+        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite beforeEach times out', ['Error: Timeout - Async callback was not invoked within 1000ms (custom timeout)']);
         expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite afterEach times out', [ 'Error: Timeout - Async callback was not invoked within 4000ms (custom timeout)' ]);
-        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite it times out', [ 'Error: Timeout - Async callback was not invoked within 6000ms (custom timeout))' ]);
+        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite it times out', [ 'Error: Timeout - Async callback was not invoked within 6000ms (custom timeout)' ]);
 
         jasmine.clock().tick(1);
         realSetTimeout(done);

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -1106,17 +1106,19 @@ describe("Env integration", function() {
 
     it('should wait a custom interval before reporting async functions that fail to call done', function(done) {
       var env = createMockedEnv(),
-          reporter = jasmine.createSpyObj('fakeReport', ['jasmineDone', 'suiteDone', 'specDone']),
-          timeoutFailure = (/^Error: Timeout - Async callback was not invoked within timeout specified by jasmine\.DEFAULT_TIMEOUT_INTERVAL\./);
+          reporter = jasmine.createSpyObj('fakeReport', ['jasmineDone', 'suiteDone', 'specDone']);
 
 
       reporter.jasmineDone.and.callFake(function(r) {
         expect(r.failedExpectations).toEqual([]);
-        expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('suite beforeAll', [ timeoutFailure ]);
-        expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('suite afterAll', [ timeoutFailure ]);
-        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite beforeEach times out', [ timeoutFailure ]);
-        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite afterEach times out', [ timeoutFailure ]);
-        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite it times out', [ timeoutFailure ]);
+        expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('suite beforeAll', [ 'Error: Timeout - Async callback was not invoked within custom timeout (of 5000ms)' ]);
+        expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('suite afterAll', [ 'Error: Timeout - Async callback was not invoked within custom timeout (of 2000ms)' ]);
+        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite beforeEach times out', [
+          'Error: Timeout - Async callback was not invoked within custom timeout (of 1000ms)',
+          'Error: Timeout - Async callback was not invoked within jasmine.DEFAULT_TIMEOUT_INTERVAL (of 10000ms)'
+        ]);
+        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite afterEach times out', [ 'Error: Timeout - Async callback was not invoked within custom timeout (of 4000ms)' ]);
+        expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite it times out', [ 'Error: Timeout - Async callback was not invoked within custom timeout (of 6000ms)' ]);
 
         jasmine.clock().tick(1);
         realSetTimeout(done);

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -682,7 +682,7 @@ getJasmineRequireObj().Env = function(j$) {
         userContext: function() { return suite.clonedSharedUserContext(); },
         queueableFn: {
           fn: fn,
-          timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
+          timeout: timeout || 0
         },
         throwOnExpectationFailure: throwOnExpectationFailure
       });
@@ -765,7 +765,7 @@ getJasmineRequireObj().Env = function(j$) {
       ensureIsFunctionOrAsync(beforeEachFunction, 'beforeEach');
       currentDeclarationSuite.beforeEach({
         fn: beforeEachFunction,
-        timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
+        timeout: timeout || 0
       });
     };
 
@@ -774,7 +774,7 @@ getJasmineRequireObj().Env = function(j$) {
       ensureIsFunctionOrAsync(beforeAllFunction, 'beforeAll');
       currentDeclarationSuite.beforeAll({
         fn: beforeAllFunction,
-        timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
+        timeout: timeout || 0
       });
     };
 
@@ -784,7 +784,7 @@ getJasmineRequireObj().Env = function(j$) {
       afterEachFunction.isCleanup = true;
       currentDeclarationSuite.afterEach({
         fn: afterEachFunction,
-        timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
+        timeout: timeout || 0
       });
     };
 
@@ -793,7 +793,7 @@ getJasmineRequireObj().Env = function(j$) {
       ensureIsFunctionOrAsync(afterAllFunction, 'afterAll');
       currentDeclarationSuite.afterAll({
         fn: afterAllFunction,
-        timeout: function() { return timeout || j$.DEFAULT_TIMEOUT_INTERVAL; }
+        timeout: timeout || 0
       });
     };
 

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -105,12 +105,17 @@ getJasmineRequireObj().QueueRunner = function(j$) {
 
     self.globalErrors.pushListener(handleError);
 
-    if (queueableFn.timeout) {
+    if (queueableFn.timeout !== undefined) {
+      var timeoutInterval = queueableFn.timeout || j$.DEFAULT_TIMEOUT_INTERVAL;
       timeoutId = self.setTimeout(function() {
-        var error = new Error('Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.');
+        var error = new Error(
+          'Timeout - Async callback was not invoked within ' +
+          (queueableFn.timeout ? 'custom timeout' : 'jasmine.DEFAULT_TIMEOUT_INTERVAL') +
+          ' (of ' + timeoutInterval + 'ms)'
+        );
         onException(error);
         next();
-      }, queueableFn.timeout());
+      }, timeoutInterval);
     }
 
     try {

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -109,9 +109,8 @@ getJasmineRequireObj().QueueRunner = function(j$) {
       var timeoutInterval = queueableFn.timeout || j$.DEFAULT_TIMEOUT_INTERVAL;
       timeoutId = self.setTimeout(function() {
         var error = new Error(
-          'Timeout - Async callback was not invoked within ' +
-          (queueableFn.timeout ? 'custom timeout' : 'jasmine.DEFAULT_TIMEOUT_INTERVAL') +
-          ' (of ' + timeoutInterval + 'ms)'
+          'Timeout - Async callback was not invoked within ' + timeoutInterval + 'ms ' +
+          (queueableFn.timeout ? '(custom timeout)' : '(set by jasmine.DEFAULT_TIMEOUT_INTERVAL)')
         );
         onException(error);
         next();


### PR DESCRIPTION
We're addressing two issues:
1) When an async spec times out, Jasmine always reports an error saying the async callback was not invoked within the default timeout interval. This can be misleading when a custom timeout is passed as the 3rd argument to `it`, `beforeAll`, etc. 
2) Jasmine fails to report the timeout interval that was in effect, which can be valuable since the interval can be custom, and the default timeout too can be altered within the test code.

With this change, we make a distinction between custom timeouts and default timeouts, and we surface what was the actual timeout within the error message, e.g.
```
Error: Timeout - Async callback was not invoked within custom timeout (of 20ms)
```
or:
```
Error: Timeout - Async callback was not invoked within jasmine.DEFAULT_TIMEOUT_INTERVAL (of 100ms)
```