### PR TITLE
Removed postfixed comma on array

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -127,7 +127,7 @@ getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
       'toMatch',
       'toThrow',
       'toThrowError',
-      'toThrowMatching',
+      'toThrowMatching'
     ],
     matchers = {};
 


### PR DESCRIPTION
Fixes #1584 

Removed postfixed comma on `availableMatchers` declaration.

This is needed because IE8 compatibility doesn't allow an array to be declared ending with a comma on last item, in that situation IE8 append an "undefined" item to the array, breaking the `matchers[name]` code

## Description
Removed the comma after the last item on array, this comma makes the IE8 add an undefined item to array. This is a commom error that not affect any other major browsers

## Motivation and Context
This fix allow Jasmine to remain compatible with IE8 as the Contributing document says:
[Compatibilty](https://github.com/jasmine/jasmine/blob/master/.github/CONTRIBUTING.md#compatibility)


## How Has This Been Tested?
Ran the `jasmine.js` code on Internet Explorer 8 without the error occurring

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.

