### PR TITLE
[WIP] Fix context cloning proccess

### DIFF
--- a/spec/core/UserContextSpec.js
+++ b/spec/core/UserContextSpec.js
@@ -50,5 +50,85 @@ describe("UserContext", function() {
       });
     });
   });
-});
 
+  describe('context generation', function() {
+    beforeAll(function() {
+      this.id = 1;
+      this.name = 'John';
+    });
+
+    describe('when changing the context inside the example', function() {
+      it('changing the context', function() {
+        this.id = 10;
+        expect(this.id).toEqual(10);
+      });
+
+      it('runs example with clean context', function() {
+        expect(this.id).toEqual(1);
+      });
+    });
+
+    describe('when running a beforeEach', function() {
+      beforeEach(function() {
+        this.id = 2;
+      });
+
+      describe('when overriding a context property with beforeEach', function() {
+        it('override beforeAll context property', function() {
+          expect(this.id).toEqual(2);
+        });
+      });
+
+      describe('when changing the context inside the example', function() {
+        it('changing the context', function() {
+          this.id = 10;
+          expect(this.id).toEqual(10);
+        });
+
+        it('runs example with clean context', function() {
+          expect(this.id).toEqual(2);
+        });
+      });
+
+      describe('when not overriding a beforeAll property', function() {
+        it('carries properties of the context', function() {
+          expect(this.name).toEqual('John');
+        });
+      });
+
+      describe('when having a context inside a context with beforeAll', function() {
+        beforeAll(function() {
+          this.id = 3;
+          this.name = 'Maria'
+        });
+
+        describe('when overriding a context property with beforeEach and beforeAll', function() {
+          it('Override the context from beforeAll with beforeEach', function() {
+            expect(this.id).toEqual(2);
+          });
+        });
+
+        describe('when overriding a context property with beforeAll', function() {
+          it('Override the context from beforeAll with beforeAll', function() {
+            expect(this.name).toEqual('Maria');
+          });
+        });
+
+        describe('when overriding context with beforeEach', function() {
+          beforeEach(function() {
+            this.id = 4;
+            this.name = 'Robert';
+          });
+
+          it('Override the context from beforeEach with beforeEach', function() {
+            expect(this.id).toEqual(4);
+          });
+
+          it('Override the context from beforeEach with beforeEach', function() {
+            expect(this.name).toEqual('Robert');
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
whenever a new context is generated (through the use of `UserContext.fromExisting`, if a property is also an Object, properties may leak between examples)

This PR tries to fix this issue

## Description
This PR will try to, anytime the context is being created from an existing one, once a property is an object, this will be also duplicated

### Problems
  an object might be an instance of a simple structure or might be something else with a different constructor which might pose a problem for clonning ... I am still thinking about the best way to solve it

## Motivation and Context
sometimes the object stored is being modified by specs and this is being shared between specs, when it should not

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

