### PR TITLE
Optimized clearTimeout cpu usage

### DIFF
--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -5,26 +5,29 @@ getJasmineRequireObj().QueueRunner = function(j$) {
 
   function once(fn) {
     var called = false;
-    return function() {
+    return function(arg) {
       if (!called) {
         called = true;
-        fn.apply(null, arguments);
+        // Direct call using single parameter, because cleanup/next does not need more
+        fn(arg);
       }
       return null;
     };
   }
 
+  function emptyFn() {}
+
   function QueueRunner(attrs) {
     var queueableFns = attrs.queueableFns || [];
     this.queueableFns = queueableFns.concat(attrs.cleanupFns || []);
     this.firstCleanupIx = queueableFns.length;
-    this.onComplete = attrs.onComplete || function() {};
+    this.onComplete = attrs.onComplete || emptyFn;
     this.clearStack = attrs.clearStack || function(fn) {fn();};
-    this.onException = attrs.onException || function() {};
+    this.onException = attrs.onException || emptyFn;
     this.userContext = attrs.userContext || new j$.UserContext();
     this.timeout = attrs.timeout || {setTimeout: setTimeout, clearTimeout: clearTimeout};
-    this.fail = attrs.fail || function() {};
-    this.globalErrors = attrs.globalErrors || { pushListener: function() {}, popListener: function() {} };
+    this.fail = attrs.fail || emptyFn;
+    this.globalErrors = attrs.globalErrors || { pushListener: emptyFn, popListener: emptyFn };
     this.completeOnFirstError = !!attrs.completeOnFirstError;
     this.errored = false;
 
@@ -66,7 +69,9 @@ getJasmineRequireObj().QueueRunner = function(j$) {
         next(error);
       },
       cleanup = once(function cleanup() {
-        self.clearTimeout(timeoutId);
+        if (timeoutId !== void 0) {
+          self.clearTimeout(timeoutId);
+        }
         self.globalErrors.popListener(handleError);
       }),
       next = once(function next(err) {


### PR DESCRIPTION
Hi

I optimized CPU usage Jasmine uses when running tests. See screen shots for before after

**Before**
![before](https://user-images.githubusercontent.com/2021355/45176834-dc045c80-b219-11e8-9c78-8b135cbf7c09.png)


**After**
![after](https://user-images.githubusercontent.com/2021355/45176840-ddce2000-b219-11e8-96a2-6fa9c6deae5d.png)

Its mostly about not calling `clearTimeout` when timeoutId is not number. This PR reduces `clearTimeout` cost by 50%, or 10% of total time. I believe rewriting `QueueRunner` to pure functional form could benefit also, but that is larger task to do. 