### PR TITLE
Print error message when available

### DIFF
--- a/spec/core/ExceptionFormatterSpec.js
+++ b/spec/core/ExceptionFormatterSpec.js
@@ -40,8 +40,8 @@ describe("ExceptionFormatter", function() {
     it('formats thrown exceptions with message but no name', function() {
       var unnamedError = {message: 'This is an unnamed error message.'};
 
-      exceptionFormatter = new jasmineUnderTest.ExceptionFormatter(),
-      message = exceptionFormatter.message(unnamedError);
+      var exceptionFormatter = new jasmineUnderTest.ExceptionFormatter(),
+          message = exceptionFormatter.message(unnamedError);
 
       expect(message).toEqual('This is an unnamed error message.');
     });

--- a/spec/core/ExceptionFormatterSpec.js
+++ b/spec/core/ExceptionFormatterSpec.js
@@ -37,6 +37,15 @@ describe("ExceptionFormatter", function() {
       expect(message).toEqual('A Classic Mistake: you got your foo in my bar');
     });
 
+    it('formats thrown exceptions with message but no name', function() {
+      var unnamedError = {message: 'This is an unnamed error message.'};
+
+      exceptionFormatter = new jasmineUnderTest.ExceptionFormatter(),
+      message = exceptionFormatter.message(unnamedError);
+
+      expect(message).toEqual('This is an unnamed error message.');
+    });
+
     it("formats thrown exceptions that aren't errors", function() {
       var thrown = "crazy error",
           exceptionFormatter = new jasmineUnderTest.ExceptionFormatter(),

--- a/spec/core/ExceptionFormatterSpec.js
+++ b/spec/core/ExceptionFormatterSpec.js
@@ -37,13 +37,26 @@ describe("ExceptionFormatter", function() {
       expect(message).toEqual('A Classic Mistake: you got your foo in my bar');
     });
 
-    it('formats thrown exceptions with message but no name', function() {
+    it('formats unnamed exceptions with message', function() {
       var unnamedError = {message: 'This is an unnamed error message.'};
 
       var exceptionFormatter = new jasmineUnderTest.ExceptionFormatter(),
           message = exceptionFormatter.message(unnamedError);
 
       expect(message).toEqual('This is an unnamed error message.');
+    });
+
+    it('formats empty exceptions with toString format', function() {
+      var EmptyError = function() {};
+      EmptyError.prototype.toString = function() {
+        return '[EmptyError]';
+      };
+      var emptyError = new EmptyError();
+
+      var exceptionFormatter = new jasmineUnderTest.ExceptionFormatter(),
+          message = exceptionFormatter.message(emptyError);
+
+      expect(message).toEqual('[EmptyError] thrown');
     });
 
     it("formats thrown exceptions that aren't errors", function() {

--- a/src/core/ExceptionFormatter.js
+++ b/src/core/ExceptionFormatter.js
@@ -7,6 +7,8 @@ getJasmineRequireObj().ExceptionFormatter = function(j$) {
 
       if (error.name && error.message) {
         message += error.name + ': ' + error.message;
+      } else if (error.message) {
+        message += error.message;
       } else {
         message += error.toString() + ' thrown';
       }


### PR DESCRIPTION
## Description
With the current set up, error message is only printed out when error name is available.
The new set up ensures error message is always printed when available.

## Motivation and Context
There are situations where the ErrorEvent object does not have a `name` property, but the message is still relevant. For more details see #1594

## How Has This Been Tested?
To be done.

## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] My change does _not_ require updates of documentation.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

