### PR TITLE
Import prototype methods from original object before spying

### DIFF
--- a/src/core/Spy.js
+++ b/src/core/Spy.js
@@ -1,4 +1,6 @@
 getJasmineRequireObj().Spy = function (j$) {
+  // Allows copying objects even when spyOn(window, 'Object'); happened.
+  var copyObject = Object.assign;
 
   var nextOrder = (function() {
     var order = 0;
@@ -68,6 +70,17 @@ getJasmineRequireObj().Spy = function (j$) {
       }
 
       wrapper[prop] = originalFn[prop];
+    }
+
+    // Prototype must be delegated to the original function. If this is not done
+    // spying on objects such as Array or Function may make the tests to fail or
+    // Jasmine to crash.
+    if (!wrapper.prototype) wrapper.prototype = {};
+    if (originalFn && originalFn.prototype) {
+      wrapper.prototype = copyObject(
+        originalFn.prototype,
+        wrapper.prototype,
+      );
     }
 
     /**

--- a/src/core/Spy.js
+++ b/src/core/Spy.js
@@ -77,9 +77,9 @@ getJasmineRequireObj().Spy = function (j$) {
       wrapper.prototype = {};
     }
 
-    if (originalFn && originalFn.prototype) {
+    if (originalFn && originalFn.prototype && j$.Object.assign) {
       wrapper.prototype =
-        Object.assign(originalFn.prototype, wrapper.prototype);
+        j$.Object.assign(originalFn.prototype, wrapper.prototype);
     }
 
     /**

--- a/src/core/Spy.js
+++ b/src/core/Spy.js
@@ -1,6 +1,4 @@
 getJasmineRequireObj().Spy = function (j$) {
-  // Allows copying objects even when spyOn(window, 'Object'); happened.
-  var copyObject = Object.assign;
 
   var nextOrder = (function() {
     var order = 0;
@@ -77,7 +75,7 @@ getJasmineRequireObj().Spy = function (j$) {
     // Jasmine to crash.
     if (!wrapper.prototype) wrapper.prototype = {};
     if (originalFn && originalFn.prototype) {
-      wrapper.prototype = copyObject(
+      wrapper.prototype = Object.assign(
         originalFn.prototype,
         wrapper.prototype,
       );

--- a/src/core/Spy.js
+++ b/src/core/Spy.js
@@ -73,12 +73,13 @@ getJasmineRequireObj().Spy = function (j$) {
     // Prototype must be delegated to the original function. If this is not done
     // spying on objects such as Array or Function may make the tests to fail or
     // Jasmine to crash.
-    if (!wrapper.prototype) wrapper.prototype = {};
+    if (!wrapper.prototype) {
+      wrapper.prototype = {};
+    }
+
     if (originalFn && originalFn.prototype) {
-      wrapper.prototype = Object.assign(
-        originalFn.prototype,
-        wrapper.prototype,
-      );
+      wrapper.prototype =
+        Object.assign(originalFn.prototype, wrapper.prototype);
     }
 
     /**

--- a/src/core/requireCore.js
+++ b/src/core/requireCore.js
@@ -24,7 +24,7 @@ var getJasmineRequireObj = (function (jasmineGlobal) {
     var j$ = {};
 
     jRequire.base(j$, jasmineGlobal);
-    if (Object) { j$.Object = Object; }
+    j$.Object = Object || {};
     j$.util = jRequire.util(j$);
     j$.errors = jRequire.errors();
     j$.formatErrorMsg = jRequire.formatErrorMsg();

--- a/src/core/requireCore.js
+++ b/src/core/requireCore.js
@@ -24,6 +24,7 @@ var getJasmineRequireObj = (function (jasmineGlobal) {
     var j$ = {};
 
     jRequire.base(j$, jasmineGlobal);
+    if (Object) { j$.Object = Object; }
     j$.util = jRequire.util(j$);
     j$.errors = jRequire.errors();
     j$.formatErrorMsg = jRequire.formatErrorMsg();


### PR DESCRIPTION
Potential fix for #1573.

## Description
Spied objects copy the prototype of their original objects.

## Motivation and Context
When spying on global objects such as Function or Array, in combination with methods which relies on these objects (e.g. jasmine.clock.install()) the tests fails or Jasmine throws errors.

## How Has This Been Tested?
[See comment](https://github.com/jasmine/jasmine/issues/1573#issuecomment-421585251) on #1573

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] Tests cannot be added as they need to rely on "window" object.
- [x] All new and existing tests passed.

