### PR TITLE
[TBD] Create SpyObj with its own calls counter

### DIFF
--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -141,6 +141,25 @@ describe('Spies', function () {
         env.createSpyObj('BaseName', {});
       }).toThrow("createSpyObj requires a non-empty array or object of method names to create spies for");
     });
+
+    describe("spies", function() {
+      it("counts all calls of spied methods", function() {
+        var spyObj = env.createSpyObj(['method1', 'method2']);
+        spyObj.method1();
+        spyObj.method2();
+
+        expect(spyObj.spies.calls.count()).toEqual(2);
+      });
+
+      it("tracks the params from each execution", function() {
+        var spyObj = env.createSpyObj(['method1', 'method2']);
+        spyObj.method1("a");
+        spyObj.method2("b", "c");
+
+        expect(spyObj.spies.calls.argsFor(0)).toEqual(["a"]);
+        expect(spyObj.spies.calls.argsFor(1)).toEqual(["b", "c"]);
+      });
+    });
   });
 
   it("can use different strategies for different arguments", function() {

--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -144,15 +144,17 @@ describe('Spies', function () {
 
     describe("spies", function() {
       it("counts all calls of spied methods", function() {
-        var spyObj = env.createSpyObj(['method1', 'method2']);
+        var spyObj = env.createSpyObj('BaseName', ['method1', 'method2']);
         spyObj.method1();
         spyObj.method2();
 
         expect(spyObj.spies.calls.count()).toEqual(2);
+        expect(spyObj.method1.calls.count()).toEqual(1);
+        expect(spyObj.method2.calls.count()).toEqual(1);
       });
 
       it("tracks the params from each execution", function() {
-        var spyObj = env.createSpyObj(['method1', 'method2']);
+        var spyObj = env.createSpyObj('BaseName', ['method1', 'method2']);
         spyObj.method1("a");
         spyObj.method2("b", "c");
 

--- a/src/core/CallTracker.js
+++ b/src/core/CallTracker.js
@@ -3,15 +3,20 @@ getJasmineRequireObj().CallTracker = function(j$) {
   /**
    * @namespace Spy#calls
    */
-  function CallTracker() {
+  function CallTracker(spyObj) {
     var calls = [];
     var opts = {};
+    var spyObjCalls = (spyObj && spyObj.calls) ? spyObj.calls : null;
 
     this.track = function(context) {
       if(opts.cloneArgs) {
         context.args = j$.util.cloneArgs(context.args);
       }
       calls.push(context);
+
+      if (spyObjCalls && spyObjCalls.track) {
+        spyObjCalls.track(context);
+      }
     };
 
     /**

--- a/src/core/Spy.js
+++ b/src/core/Spy.js
@@ -13,7 +13,7 @@ getJasmineRequireObj().Spy = function (j$) {
    * @constructor
    * @name Spy
    */
-  function Spy(name, originalFn, customStrategies) {
+  function Spy(name, originalFn, customStrategies, spyObj) {
     var numArgs = (typeof originalFn === 'function' ? originalFn.length : 0),
       wrapper = makeFunc(numArgs, function () {
         return spy.apply(this, Array.prototype.slice.call(arguments));
@@ -26,7 +26,7 @@ getJasmineRequireObj().Spy = function (j$) {
         },
         customStrategies: customStrategies
       }),
-      callTracker = new j$.CallTracker(),
+      callTracker = new j$.CallTracker(spyObj),
       spy = function () {
         /**
          * @name Spy.callData

--- a/src/core/SpyFactory.js
+++ b/src/core/SpyFactory.js
@@ -32,13 +32,13 @@ getJasmineRequireObj().SpyFactory = function(j$) {
 
       if (j$.isArray_(methodNames)) {
         for (var i = 0; i < methodNames.length; i++) {
-          obj[methodNames[i]] = this.createSpy(baseName + '.' + methodNames[i]);
+          obj[methodNames[i]] = self.createSpy(baseName + '.' + methodNames[i]);
           spiesWereSet = true;
         }
       } else if (j$.isObject_(methodNames)) {
         for (var key in methodNames) {
           if (methodNames.hasOwnProperty(key)) {
-            obj[key] = this.createSpy(baseName + '.' + key);
+            obj[key] = self.createSpy(baseName + '.' + key);
             obj[key].and.returnValue(methodNames[key]);
             spiesWereSet = true;
           }

--- a/src/core/SpyFactory.js
+++ b/src/core/SpyFactory.js
@@ -1,10 +1,20 @@
 getJasmineRequireObj().SpyFactory = function(j$) {
 
+  function SpyObject() {
+    this.calls = new j$.CallTracker();
+    this.methods = [];
+    this.spies = [];
+  }
+
   function SpyFactory(getCustomStrategies) {
     var self = this;
+    var spyObj = new SpyObject();
 
     this.createSpy = function(name, originalFn) {
-      return j$.Spy(name, originalFn, getCustomStrategies());
+      var spy = j$.Spy(name, originalFn, getCustomStrategies(), spyObj);
+      spyObj.methods.push(name);
+      spyObj.spies.push(spy);
+      return spy;
     };
 
     this.createSpyObj = function(baseName, methodNames) {
@@ -15,18 +25,20 @@ getJasmineRequireObj().SpyFactory = function(j$) {
         baseName = 'unknown';
       }
 
-      var obj = {};
+      var obj = {
+        'spies': spyObj
+      };
       var spiesWereSet = false;
 
       if (j$.isArray_(methodNames)) {
         for (var i = 0; i < methodNames.length; i++) {
-          obj[methodNames[i]] = self.createSpy(baseName + '.' + methodNames[i]);
+          obj[methodNames[i]] = this.createSpy(baseName + '.' + methodNames[i]);
           spiesWereSet = true;
         }
       } else if (j$.isObject_(methodNames)) {
         for (var key in methodNames) {
           if (methodNames.hasOwnProperty(key)) {
-            obj[key] = self.createSpy(baseName + '.' + key);
+            obj[key] = this.createSpy(baseName + '.' + key);
             obj[key].and.returnValue(methodNames[key]);
             spiesWereSet = true;
           }

--- a/src/core/SpyFactory.js
+++ b/src/core/SpyFactory.js
@@ -3,7 +3,6 @@ getJasmineRequireObj().SpyFactory = function(j$) {
   function SpyObject() {
     this.calls = new j$.CallTracker();
     this.methods = [];
-    this.spies = [];
   }
 
   function SpyFactory(getCustomStrategies) {
@@ -11,10 +10,9 @@ getJasmineRequireObj().SpyFactory = function(j$) {
     var spyObj = new SpyObject();
 
     this.createSpy = function(name, originalFn) {
-      var spy = j$.Spy(name, originalFn, getCustomStrategies(), spyObj);
-      spyObj.methods.push(name);
-      spyObj.spies.push(spy);
-      return spy;
+      var newSpy = j$.Spy(name, originalFn, getCustomStrategies(), spyObj);
+      spyObj.methods.push(newSpy);
+      return newSpy;
     };
 
     this.createSpyObj = function(baseName, methodNames) {


### PR DESCRIPTION
_NOTE: This is still a draft, but review and discussion needed to be able to proceed._

## Description
createSpyObj returns an object with a spies properties. This spies properties keeps track of the methods and spies installed; as well as having a callCounter installed for all of them.

CallCounter can now have a parent CallCounter to which it delegates the tracking when it happens.

## Motivation and Context
See #1568

## How Has This Been Tested?
Run grunt execSpecsInNode.

Added two test cases to illustrate, but probably more tests can be added. To be discussed here.

Currently two existing tests are failing. This is "expected" because it verifies that createSpyObj has no properties. However, we have created a `spies` property for all. Decisions about how to deal with this are yet to be discussed here.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Marking as breaking change for two reasons:
1. We may need to forbid createSpyObj('name', ['spies']); as it would be overlap.
1. Two tests are currently failing as we would expect no properties, but spies property is created.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

