### PR TITLE
Add status marks to standalone

### DIFF
--- a/src/html/_HTMLReporter.scss
+++ b/src/html/_HTMLReporter.scss
@@ -16,6 +16,11 @@ $empty-color: #eff543;
 $neutral-color: #bababa;
 $jasmine-color: #8a4182;
 
+$passing-mark: "\02022";
+$failing-mark: "\d7";
+$pending-mark: "*";
+$space: "\0020";
+
 $font-size: 11px;
 $large-font-size: 14px;
 
@@ -120,7 +125,7 @@ body {
 
         &:before {
           color: $passing-color;
-          content: "\02022";
+          content: $passing-mark;
         }
       }
 
@@ -129,7 +134,7 @@ body {
 
         &:before {
           color: $failing-color;
-          content: "\d7";
+          content: $failing-mark;
           font-weight: bold;
           margin-left: -1px;
         }
@@ -140,7 +145,7 @@ body {
 
           &:before {
             color: $neutral-color;
-            content: "\02022";
+            content: $passing-mark;
           }
         }
 
@@ -153,7 +158,7 @@ body {
         line-height: 17px;
         &:before {
           color: $pending-color;
-          content: "*";
+          content: $pending-mark;
         }
       }
 
@@ -162,7 +167,7 @@ body {
 
         &:before {
           color: $pending-color;
-          content: "\02022";
+          content: $passing-mark;
         }
       }
     }
@@ -299,6 +304,30 @@ body {
 
       &.jasmine-excluded a {
         color: $neutral-color;
+      } 
+    }
+  }
+
+  .jasmine-specs {
+    li {
+      &.jasmine-passed a:before {
+        content: $passing-mark + $space;
+      }
+
+      &.jasmine-failed a:before {
+        content: $failing-mark + $space;
+      }
+
+      &.jasmine-empty a:before {
+        content: $pending-mark + $space;
+      }
+
+      &.jasmine-pending a:before {
+        content: $passing-mark + $space;
+      }
+
+      &.jasmine-excluded a:before {
+        content: $passing-mark + $space;
       } 
     }
   }


### PR DESCRIPTION
This adds status marks next to each spec in the Spec List. Here's what it looks like:

![screenshot from 2018-09-26 21-12-09](https://user-images.githubusercontent.com/28028994/46117751-f609dd00-c1d0-11e8-87f9-bb4b7d5e8ef9.png)

## Description
The only changes are to `src/html/_HTMLReporter.scss`. I defined variables for the status marks used as well as for a space. These variables are then used to specify the `content` attribute for the `.jasmine-specs li.jasmine-<status> a:before` selectors. For good measure, I also refactored the other places in the same file that use the status marks for which we now have variables.

## Motivation and Context
I outlined the motivation and context in [#1596](https://github.com/jasmine/jasmine/issues/1596). As suggested there in the response by @slackersoft, I didn't make the status marks optional.

## How Has This Been Tested?
This still passes all the specs tested by `bundle exec rake jasmine` except for the ones that were already empty or pending.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.