### PR TITLE
feat(toBeRejectedTo): implement toBeRejectedTo functionality

### DIFF
--- a/spec/core/AsyncExpectationSpec.js
+++ b/spec/core/AsyncExpectationSpec.js
@@ -108,6 +108,115 @@ describe('AsyncExpectation', function() {
     });
   });
 
+  describe('#toBeRejectedTo', function () {
+    it('should return true if the promise is rejected to the expected value', function () {
+      jasmine.getEnv().requirePromises();
+
+      var actual = Promise.reject({error: 'PEBCAK'});
+      var addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        expectation = new jasmineUnderTest.AsyncExpectation({
+          util: jasmineUnderTest.matchersUtil,
+          actual: actual,
+          addExpectationResult: addExpectationResult
+        });
+
+      return expectation.toBeRejectedTo({error: 'PEBCAK'}).then(function () {
+        expect(addExpectationResult).toHaveBeenCalledWith(true, {
+          matcherName: 'toBeRejectedTo',
+          passed: true,
+          message: '',
+          error: undefined,
+          errorForStack: jasmine.any(Error),
+          actual: actual
+        });
+      });
+
+    });
+
+    it('should fail if the promise resolves', function () {
+      jasmine.getEnv().requirePromises();
+
+      var actual = Promise.resolve('AsyncExpectation error');
+      var addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        expectation = new jasmineUnderTest.AsyncExpectation({
+          util: jasmineUnderTest.matchersUtil,
+          actual: actual,
+          addExpectationResult: addExpectationResult
+        });
+
+      return expectation.toBeRejectedTo('').then(function () {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toBeRejectedTo',
+          passed: false,
+          message: "Expected a promise to be rejected to '' but it was resolved.",
+          error: undefined,
+          errorForStack: jasmine.any(Error),
+          actual: actual
+        });
+      });
+    });
+
+    it('should fail if the promise is rejected to a different value', function () {
+      jasmine.getEnv().requirePromises();
+
+      var actual = Promise.reject('A Bad Apple');
+      var addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        expectation = new jasmineUnderTest.AsyncExpectation({
+          util: jasmineUnderTest.matchersUtil,
+          actual: actual,
+          addExpectationResult: addExpectationResult
+        });
+
+      return expectation.toBeRejectedTo('Some Cool Thing').then(function () {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toBeRejectedTo',
+          passed: false,
+          message: "Expected a promise to be rejected to 'Some Cool Thing' but it was rejected to 'A Bad Apple'.",
+          error: undefined,
+          errorForStack: jasmine.any(Error),
+          actual: actual
+        });
+      });
+    });
+
+    it('should build its error correctly when negated', function () {
+      jasmine.getEnv().requirePromises();
+
+      var addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        expectation = jasmineUnderTest.AsyncExpectation.factory({
+          util: jasmineUnderTest.matchersUtil,
+          actual: Promise.reject(true),
+          addExpectationResult: addExpectationResult
+        });
+
+      return expectation.not.toBeRejectedTo(true).then(function () {
+        expect(addExpectationResult).toHaveBeenCalledWith(false,
+          jasmine.objectContaining({
+            passed: false,
+            message: 'Expected a promise not to be rejected to true.'
+          })
+        );
+      });
+    });
+
+    it('should support custom equality testers', function () {
+      jasmine.getEnv().requirePromises();
+
+      var addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        expectation = new jasmineUnderTest.AsyncExpectation({
+          util: jasmineUnderTest.matchersUtil,
+          customEqualityTesters: [function() { return true; }],
+          actual: Promise.reject('actual'),
+          addExpectationResult: addExpectationResult
+        });
+
+      return expectation.toBeRejectedTo('expected').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(true,
+          jasmine.objectContaining({passed: true}));
+      });
+    });
+  });
+
   describe('#toBeResolvedTo', function() {
     it('passes if the promise is resolved to the expected value', function() {
       jasmine.getEnv().requirePromises();

--- a/src/core/AsyncExpectation.js
+++ b/src/core/AsyncExpectation.js
@@ -23,7 +23,7 @@ getJasmineRequireObj().AsyncExpectation = function(j$) {
       throw new Error('Expected expectAsync to be called with a promise.');
     }
 
-    ['toBeResolved', 'toBeRejected', 'toBeResolvedTo'].forEach(wrapCompare.bind(this));
+    ['toBeResolved', 'toBeRejected', 'toBeResolvedTo', 'toBeRejectedTo'].forEach(wrapCompare.bind(this));
   }
 
   function wrapCompare(name) {
@@ -133,6 +133,49 @@ getJasmineRequireObj().AsyncExpectation = function(j$) {
           pass: false,
           message: prefix(false) + ' but it was rejected.'
         };
+      }
+    );
+  };
+
+  /**
+   * Expect a promise to be rejected to a value equal to the expected, using deep equality comparison.
+   * @function
+   * @async
+   * @name async-matchers#toBeRejectedTo
+   * @param {Object} expected - Value that the promise is expected to reject to
+   * @example
+   * await expectAsync(aPromise).toBeRejectedTo({prop: 'value'});
+   * @example
+   * return expectAsync(aPromise).toBeRejectedTo({prop: 'value'});
+   */
+  AsyncExpectation.prototype.toBeRejectedTo = function(actualPromise, expectedValue) {
+    var self = this;
+
+    function prefix(passed) {
+      return 'Expected a promise ' +
+        (passed ? 'not ' : '') +
+        'to be rejected to ' + j$.pp(expectedValue);
+    }
+
+    return actualPromise.then(
+      function() {
+        return {
+          pass: false,
+          message: prefix(false) + ' but it was resolved.'
+        };
+      },
+      function(actualValue) {
+        if (self.util.equals(actualValue, expectedValue, self.customEqualityTesters)) {
+          return {
+            pass: true,
+            message: prefix(true) + '.'
+          };
+        } else {
+          return {
+            pass: false,
+            message: prefix(false) + ' but it was rejected to ' + j$.pp(actualValue) + '.'
+          };
+        }
       }
     );
   };


### PR DESCRIPTION

Fixes: #1595

## Description

Added functionality to determine whether a promise has been rejected to a
specific value via expectAsync

so now you can do something like

```javascript
return expectAsync(Promise.reject('WHOOPS')).toBeRejectedTo('WHOOPS');
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It seems natural to have the reject equivalent of toBeResolvedTo. I didn't realize another PR was WIP for this issue when I started working on this, but it seems the issue has been inactive for a few weeks.

## How Has This Been Tested?

Unit tests have been written to prove functionality and are all passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

