### PR TITLE
Add custom message for toBe() matcher when object equality check fails

### DIFF
--- a/spec/core/matchers/toBeSpec.js
+++ b/spec/core/matchers/toBeSpec.js
@@ -7,11 +7,30 @@ describe("toBe", function() {
     expect(result.pass).toBe(true);
   });
 
-  it("fails when actual !== expected", function() {
+  it("fails with no message when actual !== expected", function() {
     var matcher = jasmineUnderTest.matchers.toBe(),
       result;
 
     result = matcher.compare(1, 2);
     expect(result.pass).toBe(false);
+    expect(result.message).toBeUndefined();
+  });
+
+  it("fails with a custom message when expected is an array", function() {
+    var matcher = jasmineUnderTest.matchers.toBe(),
+    result;
+
+    result = matcher.compare([1], [1]);
+    expect(result.pass).toBe(false);
+    expect(result.message).toBe("Expected [ 1 ] to be [ 1 ]. Tip: To check for deep equality, use .toEqual() instead of .toBe().")
+  });
+
+  it("fails with a custom message when expected is an object", function() {
+    var matcher = jasmineUnderTest.matchers.toBe(),
+    result;
+
+    result = matcher.compare({foo: "bar"}, {foo: "bar"});
+    expect(result.pass).toBe(false);
+    expect(result.message).toBe("Expected Object({ foo: 'bar' }) to be Object({ foo: 'bar' }). Tip: To check for deep equality, use .toEqual() instead of .toBe().")
   });
 });

--- a/src/core/matchers/toBe.js
+++ b/src/core/matchers/toBe.js
@@ -1,4 +1,4 @@
-getJasmineRequireObj().toBe = function() {
+getJasmineRequireObj().toBe = function($j) {
   /**
    * {@link expect} the actual value to be `===` to the expected value.
    * @function
@@ -8,10 +8,14 @@ getJasmineRequireObj().toBe = function() {
    * expect(thing).toBe(realThing);
    */
   function toBe() {
+    
     return {
       compare: function(actual, expected) {
+        var customMessage = 'Expected ' + $j.pp(expected) + ' to be ' + $j.pp(actual) + '. Tip: To check for deep equality, use .toEqual() instead of .toBe().';
+        
         return {
-          pass: actual === expected
+          pass: actual === expected,
+          message: typeof expected === 'object' ? customMessage : undefined,
         };
       }
     };


### PR DESCRIPTION
## Description
This commit adds a tip to the failure messaging for toBe() when expected is an object (or array).

## Motivation and Context
This should help with confusion that people sometimes have between toBe() and toEqual(). See https://github.com/jasmine/jasmine/issues/1614

## How Has This Been Tested?
Two new tests (one for array, one for object) have been added to toBeSpec.js to check for the new message. The existing failure case was updated to assert that the default messaging was not affected. All other tests are passing.

(Side note: I wasn't able to find where the default error message is generated. If there's a more appropriate place for the custom message to be built, I'm open to feedback!)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I use Jasmine every day at work and I love it! Glad to be making my first pull request to this library. 