### PR TITLE
Fixes issue where PhantomJS 2 and IE 10 - 11 crashes when reporting SVG Element equality

### DIFF
--- a/spec/core/matchers/toEqualSpec.js
+++ b/spec/core/matchers/toEqualSpec.js
@@ -624,6 +624,99 @@ describe("toEqual", function() {
       expect(compareEquals(actual, expected).message).toEqual(message);
     });
 
+    it("reports mismatches between SVG nodes", function () {
+      var nodeA = this.doc.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+        nodeB = this.doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+      nodeA.setAttribute('height', '50');
+      nodeB.setAttribute('height', '30');
+
+      var rect = this.doc.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      rect.setAttribute('width', '50');
+      nodeA.appendChild(rect);
+
+      expect(nodeA.isEqualNode(nodeB)).toBe(false);
+      var actual = {a: nodeA},
+        expected = {a: nodeB},
+        message = 'Expected $.a = <svg height="50">...</svg> to equal <svg height="30">.';
+
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
+    it("reports whole DOM node when attribute contains > character", function () {
+      var nodeA = this.doc.createElement('div'),
+        nodeB = this.doc.createElement('div');
+
+      nodeA.setAttribute('thing', '>>>');
+      nodeB.setAttribute('thing', 'bar');
+
+      expect(nodeA.isEqualNode(nodeB)).toBe(false);
+      var actual = {a: nodeA},
+        expected = {a: nodeB},
+        message = 'Expected $.a = <div thing=">>>"> to equal <div thing="bar">.';
+
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
+    it('reports no content when DOM node has multiple empty text nodes', function () {
+      var nodeA = this.doc.createElement('div'),
+        nodeB = this.doc.createElement('div');
+
+      nodeA.appendChild(this.doc.createTextNode(''));
+      nodeA.appendChild(this.doc.createTextNode(''));
+      nodeA.appendChild(this.doc.createTextNode(''));
+      nodeA.appendChild(this.doc.createTextNode(''));
+
+      expect(nodeA.isEqualNode(nodeB)).toBe(false);
+      var actual = {a: nodeA},
+        expected = {a: nodeB},
+        message = 'Expected $.a = <div> to equal <div>.';
+
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
+    it('reports content when DOM node has non empty text node', function () {
+      var nodeA = this.doc.createElement('div'),
+        nodeB = this.doc.createElement('div');
+
+      nodeA.appendChild(this.doc.createTextNode('Hello Jasmine!'));
+
+      expect(nodeA.isEqualNode(nodeB)).toBe(false);
+      var actual = {a: nodeA},
+        expected = {a: nodeB},
+        message = 'Expected $.a = <div>...</div> to equal <div>.';
+
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
+    it('reports empty DOM attributes', function () {
+      var nodeA = this.doc.createElement('div'),
+        nodeB = this.doc.createElement('div');
+
+      nodeA.setAttribute('contenteditable', '');
+
+      expect(nodeA.isEqualNode(nodeB)).toBe(false);
+      var actual = {a: nodeA},
+        expected = {a: nodeB},
+        message = 'Expected $.a = <div contenteditable> to equal <div>.';
+
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
+    it('reports 0 attr value as non empty DOM attribute', function () {
+      var nodeA = this.doc.createElement('div'),
+        nodeB = this.doc.createElement('div');
+
+      nodeA.setAttribute('contenteditable', 0);
+
+      expect(nodeA.isEqualNode(nodeB)).toBe(false);
+      var actual = {a: nodeA},
+        expected = {a: nodeB},
+        message = 'Expected $.a = <div contenteditable="0"> to equal <div>.';
+
+      expect(compareEquals(actual, expected).message).toEqual(message);
+    });
+
     it("reports mismatches between a DOM node and a bare Object", function() {
       var actual = {a: this.doc.createElement('div')},
       expected = {a: {}},

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -240,7 +240,7 @@ getJasmineRequireObj().pp = function(j$) {
       out += ' ' + attr.name;
 
       if (attr.value !== '') {
-        out += '="' + attrs[i].value + '"';
+        out += '="' + attr.value + '"';
       }
     }
 

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -228,15 +228,29 @@ getJasmineRequireObj().pp = function(j$) {
   };
 
   PrettyPrinter.prototype.emitDomElement = function(el) {
-    var closingTag = '</' + el.tagName.toLowerCase() + '>';
+    var tagName = el.tagName.toLowerCase(),
+      attrs = el.attributes,
+      i,
+      len = attrs.length,
+      out = '<' + tagName,
+      attr;
 
-    if (el.innerHTML === '') {
-      this.append(el.outerHTML.replace(closingTag, ''));
-    } else {
-      var tagEnd = el.outerHTML.indexOf('>');
-      this.append(el.outerHTML.substring(0, tagEnd + 1));
-      this.append('...' + closingTag);
+    for (i = 0; i < len; i++) {
+      attr = attrs[i];
+      out += ' ' + attr.name;
+
+      if (attr.value !== '') {
+        out += '="' + attrs[i].value + '"';
+      }
     }
+
+    out += '>';
+
+    if (el.childElementCount !== 0 || el.textContent !== '') {
+      out += '...</' + tagName + '>';
+    }
+
+    this.append(out);
   };
 
   PrettyPrinter.prototype.formatProperty = function(obj, property, isGetter) {


### PR DESCRIPTION
This PR fixes issue https://github.com/jasmine/jasmine/issues/1618

## Description
IE <= 11 and PhantomJS 2.x does not have innerHTML and outerHTML properties in SVG elements. This PR changes pretty printer to loop through attributes instead of relying on innerHTML, outerHTML and indexOf('<')

This PR fixes another edge case too where HTML attribute contained `>` character.

`el.childElementCount !== 0 || el.textContent !== ''` check is used so that it works same way as it did before. Multiple empty text nodes are not considered as content and any non text child element is.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Note: Jasmine repository tests are ran in NodeJS so I tested phantomJS and IE manually ( edit: Seems like travis does the job too 👍 ).
