### PR TITLE
When catching a global error in Node.js, print the type of error

### DIFF
--- a/spec/core/GlobalErrorsSpec.js
+++ b/spec/core/GlobalErrorsSpec.js
@@ -98,9 +98,11 @@ describe("GlobalErrors", function() {
     errors.pushListener(handler);
 
     var addedListener = fakeGlobal.process.on.calls.argsFor(0)[1];
-    addedListener(new Error('bar'));
+    const expectedError = new Error('bar');
+    addedListener(expectedError);
 
-    expect(handler).toHaveBeenCalledWith(new Error('bar'));
+    expect(handler).toHaveBeenCalledWith(expectedError);
+    expect(expectedError.jasmineMessage).toBe('Uncaught exception: Error: bar');
 
     errors.uninstall();
 
@@ -127,10 +129,12 @@ describe("GlobalErrors", function() {
 
     errors.pushListener(handler);
 
-    var addedListener = fakeGlobal.process.on.calls.argsFor(0)[1];
-    addedListener(new Error('bar'));
+    var addedListener = fakeGlobal.process.on.calls.argsFor(1)[1];
+    const expectedError = new Error('bar');
+    addedListener(expectedError);
 
-    expect(handler).toHaveBeenCalledWith(new Error('bar'));
+    expect(handler).toHaveBeenCalledWith(expectedError);
+    expect(expectedError.jasmineMessage).toBe('Unhandled promise rejection: Error: bar');
 
     errors.uninstall();
 

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -1942,10 +1942,10 @@ describe("Env integration", function() {
 
     reporter.jasmineDone.and.callFake(function() {
       expect(reporter.suiteDone).toHaveFailedExpectationsForRunnable('async suite', [
-        /^(((Uncaught )?Error: suite( thrown)?)|(suite thrown))$/
+        /^(((Uncaught )?(exception: )?Error: suite( thrown)?)|(suite thrown))$/
       ]);
       expect(reporter.specDone).toHaveFailedExpectationsForRunnable('suite async spec', [
-        /^(((Uncaught )?Error: spec( thrown)?)|(spec thrown))$/
+        /^(((Uncaught )?(exception: )?Error: spec( thrown)?)|(spec thrown))$/
       ]);
       done();
     });

--- a/src/core/ExceptionFormatter.js
+++ b/src/core/ExceptionFormatter.js
@@ -1,11 +1,15 @@
 getJasmineRequireObj().ExceptionFormatter = function(j$) {
 
+  var ignoredProperties = ['name', 'message', 'stack', 'fileName', 'sourceURL', 'line', 'lineNumber', 'column', 'description', 'jasmineMessage'];
+
   function ExceptionFormatter(options) {
     var jasmineFile = (options && options.jasmineFile) || j$.util.jasmineFile();
     this.message = function(error) {
       var message = '';
 
-      if (error.name && error.message) {
+      if (error.jasmineMessage) {
+        message += error.jasmineMessage;
+      } else if (error.name && error.message) {
         message += error.name + ': ' + error.message;
       } else if (error.message) {
         message += error.message;
@@ -63,12 +67,11 @@ getJasmineRequireObj().ExceptionFormatter = function(j$) {
         return;
       }
 
-      var ignored = ['name', 'message', 'stack', 'fileName', 'sourceURL', 'line', 'lineNumber', 'column', 'description'];
       var result = {};
       var empty = true;
 
       for (var prop in error) {
-        if (j$.util.arrayContains(ignored, prop)) {
+        if (j$.util.arrayContains(ignoredProperties, prop)) {
           continue;
         }
         result[prop] = error[prop];

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -78,7 +78,7 @@ getJasmineRequireObj().QueueRunner = function(j$) {
         cleanup();
 
         if (j$.isError_(err)) {
-          if (!(err instanceof StopExecutionError)) {
+          if (!(err instanceof StopExecutionError) && !err.jasmineMessage) {
             self.fail(err);
           }
           self.errored = errored = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`GlobalErrors.js` now adds a new `jasmineMessage` property to errors. This is picked up by `ExceptionFormatter.js` and used in preference to the regular `message` property in order to provide a more detailed message.

## Motivation and Context
Currently when Jasmine catches an unhandled promise rejection or an uncaught exception it fails the test with that `Error`. This is unclear, it is not possible to distinguish between the different errors below.

```
it('global uncaught exception', (done) => {
    setTimeout(() => { throw new Error('bad'); }, 0);
    setTimeout(done, 10);
});

it('regular uncaught exception', () => {
    throw new Error('bad');
});

it('global unhandled rejection', (done) => {
    setTimeout(() => Promise.reject(new Error('bad')), 0);
    setTimeout(done, 10);
});

it('regular unhandled rejection', () => {
    return Promise.reject(new Error('bad'));
});
```

## How Has This Been Tested?
I have run the full test suite in the following environments:
- Node.js 11
- Firefox 63
- Chrome 70

Additionally I ran the four specs above in Node.js and they produced this output. I have trimmed the stack traces as they are not relevant.
```
1) global uncaught exception
  Message:
    Uncaught exception: Error: bad
  Stack: <trimmed>

2) regular uncaught exception
  Message:
    Error: bad
  Stack: <trimmed>

3) global unhandled rejection
  Message:
    Unhandled promise rejection: Error: bad
  Stack: <trimmed>

4) regular unhandled rejection
  Message:
    Error: bad
  Stack: <trimmed>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

