### PR TITLE
Support Error.stack in globalErrors.

### DIFF
--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -2046,6 +2046,7 @@ describe("Env integration", function() {
           passed: false,
           globalErrorType: 'load',
           message: 'Uncaught SyntaxError: Unexpected end of input',
+          stack: 'a stack',
           filename: 'borkenSpec.js',
           lineno: 42
         },
@@ -2053,6 +2054,7 @@ describe("Env integration", function() {
           passed: false,
           globalErrorType: 'load',
           message: 'Uncaught Error: ENOCHEESE',
+          stack: undefined,
           filename: undefined,
           lineno: undefined
         }
@@ -2062,7 +2064,7 @@ describe("Env integration", function() {
     });
 
     env.addReporter(reporter);
-    global.onerror('Uncaught SyntaxError: Unexpected end of input', 'borkenSpec.js', 42);
+    global.onerror('Uncaught SyntaxError: Unexpected end of input', 'borkenSpec.js', 42, undefined, {stack: 'a stack'});
     global.onerror('Uncaught Error: ENOCHEESE');
 
     env.execute();

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -100,11 +100,12 @@ getJasmineRequireObj().Env = function(j$) {
 
     if (!options.suppressLoadErrors) {
       installGlobalErrors();
-      globalErrors.pushListener(function(message, filename, lineno) {
+      globalErrors.pushListener(function(message, filename, lineno, colNo, err) {
         topSuite.result.failedExpectations.push({
           passed: false,
           globalErrorType: 'load',
           message: message,
+          stack: err && err.stack,
           filename: filename,
           lineno: lineno
         });


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror#window.onerror

<!--- Provide a general summary of your changes in the Title above -->

## Description
If and only if the errorObject is passed to onError,  add the stack to  the failedExpectation.

## Motivation and Context
failedExpections from global errors are inconsistent with those from specs.  By adding back the .stack property they are closer.

## How Has This Been Tested?
Add to the existing unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

