### PR TITLE
Updated reporting to support specified messages in custom matchers an…

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -3438,33 +3438,19 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         actual = args[2],
         englishyPredicate = matcherName.replace(/[A-Z]/g, function(s) { return ' ' + s.toLowerCase(); }),
         customMatcher = matcherName.indexOf('Because') > 0 ? true : false;
-      var expected, customMsg;
+      var expected = args[3],
+        customMsg = args[4] || '';
         if (customMatcher){
-          expected = [];
-          expected.push(args[3]);
-          customMsg = args[4] || '';
-          englishyPredicate = englishyPredicate.replace(' because', '');
+          englishyPredicate = englishyPredicate.replace(' because', '')
           }
-        else{
-          expected = args.slice(3);  
-          customMsg = '';
-        }
       var message = 'Expected ' +
         j$.pp(actual) +
         (isNot ? ' not ' : ' ') +
-        englishyPredicate;
-      if (expected.length > 0) {
-        for (var i = 0; i < expected.length; i++) {
-          if (i > 0) {
-            message += ',';
-          }
-          message += ' ' + j$.pp(expected[i]);
-          if (customMatcher) { 
-            message += ' ' + customMsg;
-          }
+        englishyPredicate + ' ' +
+        j$.pp(expected)
+        if (customMatcher) {
+          message += ' ' + customMsg;
         }
-      }
-
       return message + '.';
     }
   };

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -2908,8 +2908,6 @@ getJasmineRequireObj().Expectation = function(j$) {
     if (result.message) {
       if (j$.isFunction_(result.message)) {
         return result.message();
-      } else {
-        return result.message;
       }
     }
 
@@ -3048,7 +3046,7 @@ getJasmineRequireObj().buildExpectationResult = function() {
 
     function message() {
       if (options.passed) {
-        return 'Passed.';
+        return `Passed: ${options.message}`;
       } else if (options.message) {
         return options.message;
       } else if (options.error) {
@@ -3059,7 +3057,7 @@ getJasmineRequireObj().buildExpectationResult = function() {
 
     function stack() {
       if (options.passed) {
-        return '';
+        return options.message;
       }
 
       var error = options.error;
@@ -3106,10 +3104,6 @@ getJasmineRequireObj().Expector = function(j$) {
 
   Expector.prototype.buildMessage = function(result) {
     var self = this;
-
-    if (result.pass) {
-      return '';
-    }
 
     var msg = this.filters.buildFailureMessage(result, this.matcherName, this.args, this.util, defaultMessage);
     return this.filters.modifyFailureMessage(msg || defaultMessage());
@@ -3442,20 +3436,32 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         matcherName = args[0],
         isNot = args[1],
         actual = args[2],
-        expected = args.slice(3),
-        englishyPredicate = matcherName.replace(/[A-Z]/g, function(s) { return ' ' + s.toLowerCase(); });
-
+        englishyPredicate = matcherName.replace(/[A-Z]/g, function(s) { return ' ' + s.toLowerCase(); }),
+        customMatcher = matcherName.indexOf('Because') > 0 ? true : false;
+      var expected, customMsg;
+        if (customMatcher){
+          expected = []
+          expected.push(args[3]);
+          customMsg = args[4] || '';
+          englishyPredicate = englishyPredicate.replace(' because', '')
+          }
+        else{
+          expected = args.slice(3);  
+          customMsg = '';
+        }
       var message = 'Expected ' +
         j$.pp(actual) +
         (isNot ? ' not ' : ' ') +
         englishyPredicate;
-
       if (expected.length > 0) {
         for (var i = 0; i < expected.length; i++) {
           if (i > 0) {
             message += ',';
           }
           message += ' ' + j$.pp(expected[i]);
+          if (customMatcher) { 
+            message += ' ' + customMsg;
+          }
         }
       }
 

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -3046,7 +3046,7 @@ getJasmineRequireObj().buildExpectationResult = function() {
 
     function message() {
       if (options.passed) {
-        return `Passed: ${options.message}`;
+        return 'Passed: ' + options.message;
       } else if (options.message) {
         return options.message;
       } else if (options.error) {
@@ -3440,10 +3440,10 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         customMatcher = matcherName.indexOf('Because') > 0 ? true : false;
       var expected, customMsg;
         if (customMatcher){
-          expected = []
+          expected = [];
           expected.push(args[3]);
           customMsg = args[4] || '';
-          englishyPredicate = englishyPredicate.replace(' because', '')
+          englishyPredicate = englishyPredicate.replace(' because', '');
           }
         else{
           expected = args.slice(3);  


### PR DESCRIPTION
Updated reporting to support specified messages in custom matchers and output message with passed expectations (not just 'Passed') Note that custom matchers would need to be named along lines of 'toEqualBecause' or 'toBeGreaterThanBecause'.

## Description
Previously, passed expectations were only reported as 'Passed'. This gave no meaningful indication of what comparison had been done, leaving the user unsure as to what had passed, or when. Now the same sort of output as is seen on Failed expectations is shown. I have also added 'Because' support for custom comparisons with bespoke messages. For example: expect(1).toEqual(0,'well this is silly') Would produce 'Expected 1 to equal 0 because well this is silly' in the output.

## Motivation and Context
For tests with numerous expectations, this gives added the user scope to add clarity as to what happened in the test, both good and bad!

## How Has This Been Tested?
Using standard and custom toEqual (toEqualBecause), and toBeGreaterThan (toBeGreaterThanBecause) I created a test with a number of expectations, some designed to fail, some to pass, and also added negated versions. All seemed fine.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document - not found?
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

