### PR TITLE
Fix statefulness bugs for test reexecution

### DIFF
--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -916,30 +916,6 @@ describe("Env integration", function() {
     env.execute();
   });
 
-  it('removes a spy from the top suite after the run is complete', function(done) {
-    var env = new jasmineUnderTest.Env(),
-      originalFoo = function() {},
-      testObj = {
-        foo: originalFoo
-      };
-
-    env.beforeAll(function() {
-      env.spyOn(testObj, 'foo');
-    });
-
-    env.it('spec', function() {
-      expect(jasmineUnderTest.isSpy(testObj.foo)).toBe(true);
-    });
-
-    env.addReporter({
-      jasmineDone: function() {
-        expect(jasmineUnderTest.isSpy(testObj.foo)).toBe(false);
-        done();
-      }
-    });
-
-    env.execute();
-  });
 
   it("Mock clock can be installed and used in tests", function(done) {
     var globalSetTimeout = jasmine.createSpy('globalSetTimeout').and.callFake(function(cb, t) { setTimeout(cb, t); }),

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -249,10 +249,11 @@ getJasmineRequireObj().Env = function(j$) {
         delete runnableResources[id];
     };
 
-    var beforeAndAfterFns = function(suite) {
+    var beforeAndAfterFns = function(_suite) {
       return function() {
         var befores = [],
           afters = [];
+        var suite = _suite;  // Allow this to be called multiple times.
 
         while(suite) {
           befores = befores.concat(suite.beforeFns);
@@ -552,7 +553,6 @@ getJasmineRequireObj().Env = function(j$) {
         currentlyExecutingSuites.push(topSuite);
 
         processor.execute(function () {
-          clearResourcesForRunnable(topSuite.id);
           currentlyExecutingSuites.pop();
           var overallStatus, incompleteReason;
 


### PR DESCRIPTION
## Description

 - Don't dispose top-level suite, since it's never recreated.
 - Allow beforeAndAfterFns() to be called multiple times.

## Motivation and Context

This lets me run jasmine.getEnv().execute() in /debug.html to rerun all tests without reloading the page.

NOTE: This means that spies creates in the top-level suite will never be torn down (to allow reruns with them).
That is bad practice; don't do that.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

