### PR TITLE
Fix #1651: add support for nodejs experimental-modules stacktraces

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -6463,9 +6463,21 @@ getJasmineRequireObj().SpyStrategy = function(j$) {
 
 getJasmineRequireObj().StackTrace = function(j$) {
   function StackTrace(error) {
-    var lines = error.stack
-      .split('\n')
-      .filter(function(line) { return line !== ''; });
+    var lines = [ 'unknown result!' ];
+    if (Array.isArray(error.stack)) {
+      /** 
+       * node --experimental-modules (v11.9 at least)
+       * esm stackstraces are are composed of an array of "CallSite"
+       * 
+       * TODO: See later if this behavior need to be adapted again
+       */
+      lines = error.stack.map(function(site) { return site.toString(); });
+    } else {
+      /* normal handling */
+      lines = error.stack
+        .split('\n')
+        .filter(function(line) { return line !== ''; });
+    }
 
     var extractResult = extractMessage(error.message, lines);
 

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -6463,21 +6463,9 @@ getJasmineRequireObj().SpyStrategy = function(j$) {
 
 getJasmineRequireObj().StackTrace = function(j$) {
   function StackTrace(error) {
-    var lines = [ 'unknown result!' ];
-    if (Array.isArray(error.stack)) {
-      /** 
-       * node --experimental-modules (v11.9 at least)
-       * esm stackstraces are are composed of an array of "CallSite"
-       * 
-       * TODO: See later if this behavior need to be adapted again
-       */
-      lines = error.stack.map(function(site) { return site.toString(); });
-    } else {
-      /* normal handling */
-      lines = error.stack
-        .split('\n')
-        .filter(function(line) { return line !== ''; });
-    }
+    var lines = error.stack
+      .split('\n')
+      .filter(function(line) { return line !== ''; });
 
     var extractResult = extractMessage(error.message, lines);
 

--- a/src/core/StackTrace.js
+++ b/src/core/StackTrace.js
@@ -1,8 +1,21 @@
 getJasmineRequireObj().StackTrace = function(j$) {
   function StackTrace(error) {
-    var lines = error.stack
-      .split('\n')
-      .filter(function(line) { return line !== ''; });
+
+    var lines = [ 'unknown result!' ];
+    if (typeof(error.stack) == 'string') {
+      /* normal handling */
+      lines = error.stack
+        .split('\n')
+        .filter(function(line) { return line !== ''; });
+      } else {
+      /** 
+       * node --experimental-modules (v11.9 at least)
+       * esm stackstraces are are composed of an array of "CallSite"
+       * 
+       * TODO: See later if this behavior need to be adapted again
+       */
+      lines = error.stack.map(function(site) { return site.toString(); });
+    }
 
     var extractResult = extractMessage(error.message, lines);
 


### PR DESCRIPTION
Add support for nodejs --experimental-modules.

## Description
When using node --experimental-modules, the stackstrace are not string anymore, they are an array of "CallSites".
> See https://nodejs.org/api/esm.html

## Motivation and Context
Jasmine was failing with something like [...] .split('\n') [...]

## How Has This Been Tested?
This is difficult to test with the current setup, because you need to restart node with --node-modules.
I did test that by running tests on my own project.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [?] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [no] I have added tests to cover my changes.
- [yes] All new and existing tests passed.
