### PR TITLE
Fixed flipped JSDoc.

### DIFF
--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -66,7 +66,7 @@ getJasmineRequireObj().Clock = function() {
      * The clock will be {@link Clock#install|install}ed before the function is called and {@link Clock#uninstall|uninstall}ed in a `finally` after the function completes.
      * @name Clock#withMock
      * @function
-     * @param {closure} Function The function to be called.
+     * @param {Function} closure The function to be called.
      */
     self.withMock = function(closure) {
       this.install();


### PR DESCRIPTION
## Description
Fixed JSDoc in Clock.js: `@param {Function} closure The function to be called.` instead of `@param {closure} Function The function to be called.`

## Motivation and Context
Required for generation of valid documentation.

## How Has This Been Tested?
-

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

