### PR TITLE
Add toBeRejectedWithError matcher

### DIFF
--- a/spec/core/matchers/async/toBeRejectedWithErrorSpec.js
+++ b/spec/core/matchers/async/toBeRejectedWithErrorSpec.js
@@ -1,0 +1,63 @@
+describe('#toBeRejectedWith', function () {
+  it('should return true if the promise is rejected with the expected value', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWith(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject({error: 'PEBCAK'});
+
+    return matcher.compare(actual, {error: 'PEBCAK'}).then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+    });
+  });
+
+  it('should fail if the promise resolves', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWith(jasmineUnderTest.matchersUtil),
+      actual = Promise.resolve();
+
+    return matcher.compare(actual, '').then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: false }));
+    });
+  });
+
+  it('should fail if the promise is rejected with a different value', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWith(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject('A Bad Apple');
+
+    return matcher.compare(actual, 'Some Cool Thing').then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: false,
+        message: "Expected a promise to be rejected with 'Some Cool Thing' but it was rejected with 'A Bad Apple'.",
+      }));
+    });
+  });
+
+  it('should build its error correctly when negated', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWith(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject(true);
+
+    return matcher.compare(actual, true).then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: true,
+        message: 'Expected a promise not to be rejected with true.'
+      }));
+    });
+  });
+
+  it('should support custom equality testers', function () {
+    jasmine.getEnv().requirePromises();
+
+    var customEqualityTesters = [function() { return true; }],
+      matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWith(jasmineUnderTest.matchersUtil, customEqualityTesters),
+      actual = Promise.reject('actual');
+
+    return matcher.compare(actual, 'expected').then(function(result) {
+      expect(result).toEqual(jasmine.objectContaining({pass: true}));
+    });
+  });
+});

--- a/src/core/matchers/async/toBeRejectedWithError.js
+++ b/src/core/matchers/async/toBeRejectedWithError.js
@@ -1,0 +1,46 @@
+getJasmineRequireObj().toBeRejectedWith = function(j$) {
+  /**
+   * Expect a promise to be rejected with a value equal to the expected, using deep equality comparison.
+   * @function
+   * @async
+   * @name async-matchers#toBeRejectedWith
+   * @param {Object} expected - Value that the promise is expected to be rejected with
+   * @example
+   * await expectAsync(aPromise).toBeRejectedWith({prop: 'value'});
+   * @example
+   * return expectAsync(aPromise).toBeRejectedWith({prop: 'value'});
+   */
+  return function toBeRejectedWith(util, customEqualityTesters) {
+    return {
+      compare: function(actualPromise, expectedValue) {
+        function prefix(passed) {
+          return 'Expected a promise ' +
+            (passed ? 'not ' : '') +
+            'to be rejected with ' + j$.pp(expectedValue);
+        }
+
+        return actualPromise.then(
+          function() {
+          return {
+            pass: false,
+            message: prefix(false) + ' but it was resolved.'
+          };
+        },
+        function(actualValue) {
+          if (util.equals(actualValue, expectedValue, customEqualityTesters)) {
+            return {
+              pass: true,
+              message: prefix(true) + '.'
+            };
+          } else {
+            return {
+              pass: false,
+              message: prefix(false) + ' but it was rejected with ' + j$.pp(actualValue) + '.'
+            };
+          }
+        }
+        );
+      }
+    };
+  };
+};


### PR DESCRIPTION
## Description
Allow to use async match similar to `toThrowError`, like

`await expectAsync(aPromise).toBeRejectedWithError(MyCustomError, /Error message/);`

## Motivation and Context
Fixes #1625 

## How Has This Been Tested?
specs are included, tested in node, ie8

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

