### PR TITLE
Add toBeRejectedWithError matcher

### DIFF
--- a/spec/core/matchers/async/toBeRejectedWithErrorSpec.js
+++ b/spec/core/matchers/async/toBeRejectedWithErrorSpec.js
@@ -1,0 +1,100 @@
+describe('#toBeRejectedWithError', function () {
+  it('passes when Error type matches', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject(new TypeError('foo'));
+
+    return matcher.compare(actual, TypeError).then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+    });
+  });
+
+  it('passes when Error type and message matches', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject(new TypeError('foo'));
+
+    return matcher.compare(actual, TypeError, 'foo').then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+    });
+  });
+
+  it('passes when Error message matches a string', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject(new Error('foo'));
+
+    return matcher.compare(actual, 'foo').then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+    });
+  });
+
+  it('passes when Error message matches a RegExp', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject(new Error('foo'));
+
+    return matcher.compare(actual, /foo/).then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+    });
+  });
+
+  it('passes when Error message is empty', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject(new Error());
+
+    return matcher.compare(actual, '').then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+    });
+  });
+
+  it('fails when resolved', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = Promise.resolve(new Error('foo'));
+
+    return matcher.compare(actual, 'foo').then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: false }));
+    });
+  });
+
+  it('fails when rejected with non Error type', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject('foo');
+
+    return matcher.compare(actual, 'foo').then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: false }));
+    });
+  });
+
+  it('fails when Error type mismatches', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject(new Error('foo'));
+
+    return matcher.compare(actual, TypeError, 'foo').then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: false }));
+    });
+  });
+
+  it('fails when Error message mismatches', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject(new Error('foo'));
+
+    return matcher.compare(actual, 'bar').then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({ pass: false }));
+    });
+  });
+});

--- a/spec/core/matchers/async/toBeRejectedWithErrorSpec.js
+++ b/spec/core/matchers/async/toBeRejectedWithErrorSpec.js
@@ -6,7 +6,10 @@ describe('#toBeRejectedWithError', function () {
       actual = Promise.reject(new TypeError('foo'));
 
     return matcher.compare(actual, TypeError).then(function (result) {
-      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: true,
+        message: 'Expected a promise not to be rejected with TypeError, but it was.'
+      }));
     });
   });
 
@@ -17,7 +20,10 @@ describe('#toBeRejectedWithError', function () {
       actual = Promise.reject(new TypeError('foo'));
 
     return matcher.compare(actual, TypeError, 'foo').then(function (result) {
-      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: true,
+        message: 'Expected a promise not to be rejected with TypeError: \'foo\', but it was.'
+      }));
     });
   });
 
@@ -28,7 +34,10 @@ describe('#toBeRejectedWithError', function () {
       actual = Promise.reject(new Error('foo'));
 
     return matcher.compare(actual, 'foo').then(function (result) {
-      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: true,
+        message: 'Expected a promise not to be rejected with Error: \'foo\', but it was.'
+      }));
     });
   });
 
@@ -39,7 +48,10 @@ describe('#toBeRejectedWithError', function () {
       actual = Promise.reject(new Error('foo'));
 
     return matcher.compare(actual, /foo/).then(function (result) {
-      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: true,
+        message: 'Expected a promise not to be rejected with Error: /foo/, but it was.'
+      }));
     });
   });
 
@@ -50,7 +62,24 @@ describe('#toBeRejectedWithError', function () {
       actual = Promise.reject(new Error());
 
     return matcher.compare(actual, '').then(function (result) {
-      expect(result).toEqual(jasmine.objectContaining({ pass: true }));
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: true,
+        message: 'Expected a promise not to be rejected with Error: \'\', but it was.'
+      }));
+    });
+  });
+
+  it('passes when no arguments', function () {
+    jasmine.getEnv().requirePromises();
+
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = Promise.reject(new Error());
+
+    return matcher.compare(actual, void 0).then(function (result) {
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: true,
+        message: 'Expected a promise not to be rejected with Error, but it was.'
+      }));
     });
   });
 
@@ -61,7 +90,10 @@ describe('#toBeRejectedWithError', function () {
       actual = Promise.resolve(new Error('foo'));
 
     return matcher.compare(actual, 'foo').then(function (result) {
-      expect(result).toEqual(jasmine.objectContaining({ pass: false }));
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: false,
+        message: 'Expected a promise to be rejected but it was resolved.'
+      }));
     });
   });
 
@@ -72,7 +104,10 @@ describe('#toBeRejectedWithError', function () {
       actual = Promise.reject('foo');
 
     return matcher.compare(actual, 'foo').then(function (result) {
-      expect(result).toEqual(jasmine.objectContaining({ pass: false }));
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: false,
+        message: 'Expected a promise to be rejected with Error: \'foo\' but it was rejected with \'foo\'.'
+      }));
     });
   });
 
@@ -83,7 +118,10 @@ describe('#toBeRejectedWithError', function () {
       actual = Promise.reject(new Error('foo'));
 
     return matcher.compare(actual, TypeError, 'foo').then(function (result) {
-      expect(result).toEqual(jasmine.objectContaining({ pass: false }));
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: false,
+        message: 'Expected a promise to be rejected with TypeError: \'foo\' but it was rejected with type Error.'
+      }));
     });
   });
 
@@ -94,7 +132,10 @@ describe('#toBeRejectedWithError', function () {
       actual = Promise.reject(new Error('foo'));
 
     return matcher.compare(actual, 'bar').then(function (result) {
-      expect(result).toEqual(jasmine.objectContaining({ pass: false }));
+      expect(result).toEqual(jasmine.objectContaining({
+        pass: false,
+        message: 'Expected a promise to be rejected with Error: \'bar\' but it was rejected with Error: foo.'
+      }));
     });
   });
 });

--- a/src/core/matchers/async/toBeRejectedWithError.js
+++ b/src/core/matchers/async/toBeRejectedWithError.js
@@ -33,11 +33,11 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
 
   function matchError(actual, expected) {
     if (!j$.isError_(actual)) {
-      return fail(expected, 'not rejected with Error.');
+      return fail(expected, 'rejected with ' + j$.pp(actual));
     }
 
     if (!(actual instanceof expected.error)) {
-      return fail(expected, 'rejected with type ' + j$.fnNameFor(actual.constructor) + '.');
+      return fail(expected, 'rejected with type ' + j$.fnNameFor(actual.constructor));
     }
 
     var actualMessage = actual.message;
@@ -50,20 +50,20 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
       return pass(expected);
     }
 
-    return fail(expected, 'rejected with ' + j$.pp(actual) + '.');
+    return fail(expected, 'rejected with ' + j$.pp(actual));
   }
 
   function pass(expected) {
     return {
       pass: true,
-      message: 'Expected a promise to be rejected with ' + expected.printValue + '.'
+      message: 'Expected a promise not to be rejected with ' + expected.printValue + ', but it was.'
     };
   }
 
   function fail(expected, message) {
     return {
       pass: false,
-      message: 'Expected a promise to be rejected with ' + expected.printValue + ' but it was ' + message
+      message: 'Expected a promise to be rejected with ' + expected.printValue + ' but it was ' + message + '.'
     };
   }
 
@@ -82,7 +82,7 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
     return {
       error: error,
       message: message,
-      printValue: j$.fnNameFor(error) + ': ' + j$.pp(message)
+      printValue: j$.fnNameFor(error) + (typeof message === 'undefined' ? '' : ': ' + j$.pp(message))
     };
   }
 };

--- a/src/core/matchers/async/toBeRejectedWithError.js
+++ b/src/core/matchers/async/toBeRejectedWithError.js
@@ -1,0 +1,88 @@
+getJasmineRequireObj().toBeRejectedWithError = function(j$) {
+  /**
+   * Expect a promise to be rejected with a value matched to the expected
+   * @function
+   * @async
+   * @name async-matchers#toBeRejectedWithError
+   * @param {Error} [expected] - `Error` constructor the object that was thrown needs to be an instance of. If not provided, `Error` will be used.
+   * @param {RegExp|String} [message] - The message that should be set on the thrown `Error`
+   * @example
+   * await expectAsync(aPromise).toBeRejectedWithError(MyCustomError, 'Error message');
+   * await expectAsync(aPromise).toBeRejectedWithError(MyCustomError, /Error message/);
+   * await expectAsync(aPromise).toBeRejectedWithError(MyCustomError);
+   * await expectAsync(aPromise).toBeRejectedWithError('Error message');
+   * return expectAsync(aPromise).toBeRejectedWithError(/Error message/);
+   */
+  return function toBeRejectedWithError() {
+    return {
+      compare: function(actualPromise, arg1, arg2) {
+        var expected = getExpectedFromArgs(arg1, arg2);
+
+        return actualPromise.then(
+          function() {
+            return {
+              pass: false,
+              message: 'Expected a promise to be rejected but it was resolved.'
+            };
+          },
+          function(actualValue) { return matchError(actualValue, expected); }
+        );
+      }
+    };
+  };
+
+  function matchError(actual, expected) {
+    if (!j$.isError_(actual)) {
+      return fail(expected, 'not rejected with Error.');
+    }
+
+    if (!(actual instanceof expected.error)) {
+      return fail(expected, 'rejected with type ' + j$.fnNameFor(actual.constructor) + '.');
+    }
+
+    var actualMessage = actual.message;
+
+    if (actualMessage === expected.message || typeof expected.message === 'undefined') {
+      return pass(expected);
+    }
+
+    if (expected.message instanceof RegExp && expected.message.test(actualMessage)) {
+      return pass(expected);
+    }
+
+    return fail(expected, 'rejected with ' + j$.pp(actual) + '.');
+  }
+
+  function pass(expected) {
+    return {
+      pass: true,
+      message: 'Expected a promise to be rejected with ' + expected.printValue + '.'
+    };
+  }
+
+  function fail(expected, message) {
+    return {
+      pass: false,
+      message: 'Expected a promise to be rejected with ' + expected.printValue + ' but it was ' + message
+    };
+  }
+
+
+  function getExpectedFromArgs(arg1, arg2) {
+    var error, message;
+
+    if (typeof arg1 === 'function' && j$.isError_(arg1.prototype)) {
+      error = arg1;
+      message = arg2;
+    } else {
+      error = Error;
+      message = arg1;
+    }
+
+    return {
+      error: error,
+      message: message,
+      printValue: j$.fnNameFor(error) + ': ' + j$.pp(message)
+    };
+  }
+};

--- a/src/core/matchers/requireAsyncMatchers.js
+++ b/src/core/matchers/requireAsyncMatchers.js
@@ -3,7 +3,8 @@ getJasmineRequireObj().requireAsyncMatchers = function(jRequire, j$) {
       'toBeResolved',
       'toBeRejected',
       'toBeResolvedTo',
-      'toBeRejectedWith'
+      'toBeRejectedWith',
+      'toBeRejectedWithError'
     ],
     matchers = {};
 


### PR DESCRIPTION
## Description
Allow to use async match similar to `toThrowError`, like

`await expectAsync(aPromise).toBeRejectedWithError(MyCustomError, /Error message/);`

## Motivation and Context
Fixes #1625 

## How Has This Been Tested?
specs are included, tested in node, ie8

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

