### PR TITLE
Add support for ArrayBuffers to matcherUtil.equals.

### DIFF
--- a/spec/core/matchers/matchersUtilSpec.js
+++ b/spec/core/matchers/matchersUtilSpec.js
@@ -164,7 +164,7 @@ describe("matchersUtil", function() {
 
       expect(jasmineUnderTest.matchersUtil.equals(a,b)).toBe(true);
     });
-    
+
     it("passes for equivalent Promises (GitHub issue #1314)", function() {
       if (typeof Promise === 'undefined') { return; }
 
@@ -522,6 +522,20 @@ describe("matchersUtil", function() {
       mapB.set(6, 4);
       mapB.set(5, 1);
       expect(jasmineUnderTest.matchersUtil.equals(mapA, mapB)).toBe(false);
+    });
+
+    it("passes for ArrayBuffers with same length and content", function() {
+      var buffer1 = new ArrayBuffer(4);
+      var buffer2 = new ArrayBuffer(4);
+      expect(jasmineUnderTest.matchersUtil.equals(buffer1, buffer2)).toBe(true);
+    });
+
+    it("fails for ArrayBuffers with same length but different content", function() {
+      var buffer1 = new ArrayBuffer(4);
+      var buffer2 = new ArrayBuffer(4);
+      var array1 = new Uint8Array(buffer1);
+      array1[0] = 1;
+      expect(jasmineUnderTest.matchersUtil.equals(buffer1, buffer2)).toBe(false);
     });
 
     describe("when running in an environment with array polyfills", function() {

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -116,6 +116,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       return result;
     }
 
+
     // Identical objects are equal. `0 === -0`, but they aren't identical.
     // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
     if (a === b) {
@@ -167,6 +168,36 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         }
         return result;
       // RegExps are compared by their source patterns and flags.
+      case '[object ArrayBuffer]':
+        // If we have an instance of ArrayBuffer the Uint8Array ctor
+        // will be defined as well
+        var arrayA = new Uint8Array(a);
+        var arrayB = new Uint8Array(b);
+        var arrayALength = arrayA.length;
+        var arrayBLength = arrayB.length;
+
+        diffBuilder.withPath('length', function() {
+          if (arrayALength !== arrayBLength) {
+            diffBuilder.record(arrayALength, arrayBLength);
+            result = false;
+          }
+        });
+
+        for (i = 0; i < arrayALength || i < arrayBLength; i++) {
+          diffBuilder.withPath(i, function() {
+            if (i >= arrayBLength) {
+              diffBuilder.record(arrayA[i], void 0, actualArrayIsLongerFormatter);
+              result = false;
+            } else if (i >= arrayALength){
+              diffBuilder.record(void 0, arrayB[i], actualArrayIsLongerFormatter);
+              result = false;
+            } else if (arrayA[i] !== arrayB[i]) {
+              diffBuilder.record(arrayA[i], arrayB[i]);
+              result = false;
+            }
+          });
+        }
+        return result;
       case '[object RegExp]':
         return a.source == b.source &&
           a.global == b.global &&


### PR DESCRIPTION
Fixes #1687

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added support for using ArrayBuffers in matcherUtils.eq.

## Motivation and Context
ArrayBuffers with same length but different content were comparing as equal when they should not.

## How Has This Been Tested?
Ran tests locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

One issue I am seeing with the change is that I am now referring to Uint8Array (after a guard on ArrayBuffer) but that makes jshint unhappy. I'd like some guidance on how to proceed with that.

