### PR TITLE
Provide access to Promise via jasmine.getEnv().Promise

### DIFF
--- a/spec/core/EnvSpec.js
+++ b/spec/core/EnvSpec.js
@@ -233,4 +233,55 @@ describe("Env", function() {
       expect(globalErrors.install).toHaveBeenCalled();
     });
   });
+
+  describe("#Promise", function() {
+    it("defaults to global Promise, if available", function() {
+      var examplePromise = jasmine.createSpyObj('Promise', ['resolve', 'reject']);
+      var exampleGlobal = { Promise: examplePromise };
+      var exampleEnv = new jasmineUnderTest.Env({ global: exampleGlobal });
+      expect(exampleEnv.Promise).toBe(examplePromise);
+    });
+
+    it("defaults to undefined if no global Promise is available", function() {
+      var exampleGlobal = {};
+      var exampleEnv = new jasmineUnderTest.Env({ global: exampleGlobal });
+      expect(exampleEnv.Promise).toBeUndefined();
+    });
+
+    it("defaults to global Promise, if available", function() {
+      var examplePromise = jasmine.createSpyObj('Promise', ['resolve', 'reject']);
+      var exampleGlobal = { Promise: examplePromise };
+      var exampleEnv = new jasmineUnderTest.Env({ global: exampleGlobal });
+      expect(exampleEnv.Promise).toBe(examplePromise);
+    });
+
+    it('allows #configure to override the global Promise', function() {
+      var examplePromise = jasmine.createSpyObj('Promise', ['resolve', 'reject']);
+      var customPromise = jasmine.createSpyObj('Promise', ['resolve', 'reject']);
+      var exampleGlobal = { Promise: examplePromise };
+      var exampleEnv = new jasmineUnderTest.Env({ global: exampleGlobal });
+      expect(exampleEnv.Promise).toBe(examplePromise);
+
+      exampleEnv.configure({ promise: customPromise });
+      expect(exampleEnv.Promise).toBe(customPromise);
+    });
+
+    it('throws an error when attempting to set an invalid custom Promise library', function() {
+      var customPromise = jasmine.createSpy('Promise');
+      var exampleEnv = new jasmineUnderTest.Env();
+
+      expect(function () {
+        exampleEnv.configure({ promise: customPromise });
+      }).toThrowError('Custom promise library missing `resolve`/`reject` functions');
+    });
+
+    it('throws an error if user attempts to assign Promise library directly', function() {
+      var customPromise = jasmine.createSpy('Promise');
+      var exampleEnv = new jasmineUnderTest.Env();
+
+      expect(function () {
+        exampleEnv.Promise = customPromise;
+      }).toThrowError('To set a custom promise library, use `jasmine.getEnv().configure({ promise: ... })`');
+    });
+  });
 });

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -142,7 +142,25 @@ getJasmineRequireObj().Env = function(j$) {
       if (configuration.hasOwnProperty('hideDisabled')) {
         config.hideDisabled = configuration.hideDisabled;
       }
+
+      if (configuration.hasOwnProperty('promise')) {
+        if (typeof configuration.promise.resolve === 'function' &&
+            typeof configuration.promise.reject === 'function') {
+          config.promiseLibrary = configuration.promise;
+        } else {
+          throw new Error('Custom promise library missing `resolve`/`reject` functions');
+        }
+      }
     };
+
+    Object.defineProperty(this, 'Promise', {
+      get: function() {
+        return config.promiseLibrary || global.Promise;
+      },
+      set: function() {
+        throw new Error('To set a custom promise library, use `jasmine.getEnv().configure({ promise: ... })`');
+      }
+    });
 
     /**
      * Get the current configuration for your jasmine environment


### PR DESCRIPTION
## Description
Provide basic access to "the current Promise library" via `jasmine.getEnv().Promise`.  This is a breakout/preparation for https://github.com/jasmine/jasmine/pull/1688, which would make use of a Promise library if it exists.

Here's a quick summary of what we want:

```
// In a browser with no Promise support

expect(jasmine.getEnv().Promise).toBe(undefined);

// In a browser or node env with Promise support

expect(jasmine.getEnv().Promise).toBe(Promise);

// In any environment, where user provides a custom Promise implementation

jasmine.getEnv().configure({ promise: Bluebird });
expect(jasmine.getEnv().Promise).toBe(Bluebird);

// Finally, if a different library overrides the global Promise and we haven't set up
// a custom one, Jasmine should respect that.

expect(jasmine.getEnv().Promise).toBe(undefined);
window.Promise = Bluebird;
expect(jasmine.getEnv().Promise).toBe(Bluebird);
```

## Motivation and Context
This PR sets up the underlying "how do we get a Promise" implementation for other Jasmine functions, and ensures there's a consistent way to use one.

## How Has This Been Tested?
- Currently, unit tested in node only
- Can perform additional manual testing if reviewers are comfortable with the approach

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

> I think the ability to customize the Promise library probably warrants a doc update, although I'm not sure the ability to `configure({ })` is currently documented at all.  Open to any suggestions here.
