### PR TITLE
Introduce .andThen spy strategy series

### DIFF
--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -199,6 +199,17 @@ describe('Spies', function () {
       expect(spy()).toEqual(3);
     });
 
+    it("can execute plans in series after being set with separate calls to andThen", function() {
+      var spy = env.createSpy('foo');
+      spy.and.returnValue(1);
+      spy.andThen.callFake(function() { return 1 + 1; });
+      spy.andThen.returnValue(3);
+
+      expect(spy()).toEqual(1);
+      expect(spy()).toEqual(2);
+      expect(spy()).toEqual(3);
+    });
+
     it("can execute plans that raise errors in series", function() {
       var spy = env.createSpy('foo');
       spy.and.throwError('Error A')
@@ -223,11 +234,10 @@ describe('Spies', function () {
       expect(spy()).toEqual(2);
     });
 
-    it("adds a future plan even if there is no plan set yet", function() {
+    it("sets the current plan if no plan was configured yet", function() {
       var spy = env.createSpy('foo');
       spy.andThen.returnValue(1);
 
-      expect(spy()).toBeUndefined();
       expect(spy()).toEqual(1);
     });
 

--- a/src/core/Spy.js
+++ b/src/core/Spy.js
@@ -79,6 +79,8 @@ getJasmineRequireObj().Spy = function (j$) {
      * spyOn(someObj, 'func').and.returnValue(42);
      */
     wrapper.and = strategyDispatcher.and;
+    wrapper.andThen = strategyDispatcher.andThen;
+
     /**
      * Specifies a strategy to be used for calls to the spy that have the
      * specified arguments.
@@ -106,6 +108,7 @@ getJasmineRequireObj().Spy = function (j$) {
     });
 
     this.and = baseStrategy;
+    this.andThen = baseStrategy.plannedProxy;
 
     this.exec = function(spy, args) {
       var strategy = argsStrategies.get(args);
@@ -122,7 +125,10 @@ getJasmineRequireObj().Spy = function (j$) {
     };
 
     this.withArgs = function() {
-      return { and: argsStrategies.getOrCreate(arguments) };
+      return {
+        and: argsStrategies.getOrCreate(arguments),
+        andThen: argsStrategies.getOrCreate(arguments).plannedProxy
+      };
     };
   }
 

--- a/src/core/SpyStrategy.js
+++ b/src/core/SpyStrategy.js
@@ -76,7 +76,11 @@ getJasmineRequireObj().SpyStrategy = function(j$) {
     proxy.getSpy = obj.getSpy.bind(obj);
     proxy.isConfigured = obj.isConfigured.bind(obj);
     proxy._applyPlan = function(plan) {
-      obj._planned.push(plan);
+      if (obj.isConfigured()) {
+        obj._planned.push(plan);
+      } else {
+        obj._planned = [plan];
+      }
     };
 
     return proxy;


### PR DESCRIPTION
## Description
Propose an implementation of `.andThen`, which is a new spy strategy wrapper that allows the user to specify a series of different strategies.

```
mySpy.and.throwError('No dice')
    .andThen.returnValue('OK')
    .andThen.stub();

mySpy();    // => throws error
mySpy();    // => returns 'OK'
mySpy();    // => returns undefined
```

### Changes to existing public interfaces

- Anywhere the user can say `.and`, they can now say `.andThen` instead, to enqueue "future" plans instead of assigning the current plan.

- Interacting directly with `spy.and.plan` behaves as expected, although assigning to it now issues a deprecation warning.

### New public interfaces

Ideally I'd like there to be no new surface area at all, but that's tough in Javascript :).

- New publicly accessible keys:
  - `spy.and._applyPlan`
  - `spy.and._planned`
  - `spy.and.plannedProxy`
  - `spy.and.deprecated`

Keys `_applyPlan` and `_planned` are explicitly implementation details (shame on anyone who relies on those in a test).  I didn't underscore `plannedProxy` or `deprecated` currently, but probably could if we wanted to be real sticklers about tell peopling "do not rely on the existence of these".

(The end user can get ahold of `deprecated` from their `getEnv()` anyway, so there's no real reason for them to care about it here.)

### Caveats/negative interactions

This functionality makes an existing bug worse.

Today, spy strategy assignment chains into the base spy and not the `withArgs` context, meaning:

```
spy.withArgs(1).and.returnValue('a').and.returnValue('b');

spy(1);    // => 'a' (user expects 'b')
spy();     // => 'b'
```

Today you could argue that this is non-problem because there's no reason for the end user to do this, but that changes with `.andThen` chains:

```
spy.withArgs(1).and.returnValue('a').andThen.returnValue('b');

spy(1);    // => 'a'
spy(1);    // => 'a' (user expects 'b')
spy();     // => undefined
spy();     // => 'b'
```

I think this is just an existing problem with `withArgs()` that should be fixed, so I didn't tackle it in this PR.

### Alternatives
While writing these I did think of some potential changes we could make...

- If you want to consider `.and.then` instead of `.andThen`, that would isolate all the changes in the SpyStrategy (could remove any impact on the StrategyDispatcher).  Not sure which is better from a user perspective.  I suppose you could also bat around `.and.next` etc.  There is a danger in _any_ method just called "then" being mistaken for a Promise I suppose.  (Could interactive very negatively with some popular linting rules.)

- If we _want_ to hide more implementation detail in SpyStrategy, it's possible to wrap up some stuff (like _planned) into local state in the constructor and expose it only through methods we create in the constructor, instead of prototype methods.  (My take is you've moved away from that, as I remember SpyStrategy used to be super locked down and is now more open.)

- If we _don't_ care to deprecate `spy.and.plan = `, there is an alternative to creating an `.applyPlan` method.  (My first version of this functionality actually just used plan assignment everywhere, and override the plannedProxy's behavior so that `plannedProxy.plan =` enqueues instead of overwriting.)  This approach actually touches a lot _less_ of SpyStrategy, but you wouldn't want to include the deprecation warning in that case.  Also, having an assignment that doesn't assign probably breaks the rule of least surprise.

### Testing
Open to feedback on testing approach here!

I added some unit tests to `SpyStrategySpec`, for basic lines-of-code coverage.  I think the more useful/important unit tests are in `SpySpec`, though, as I would treat these as the "end user spec" -- these describe how the overall interface behaves for the end user.

## Motivation and Context
Provide a standardized way to specify a _series of behaviors_ to execute in series for a spy, without having to implement custom helpers or provide multiple `returnValues`-style variants for every strategy.

## How Has This Been Tested?
- Currently unit tested in node

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

> Added a non-breaking deprecation warning in one instance.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
