### PR TITLE
Improve error handling in CI test launcher

### DIFF
--- a/ci.js
+++ b/ci.js
@@ -121,12 +121,10 @@ async function getResults(driver) {
 }
 
 function cleanup() {
-  return Promise.resolve().then(() => {
-    return Promise.all([
-      driver ? driver.close() : true,
-      new Promise(resolve => server ? server.close(resolve) : resolve())
-    ]);
-  }).catch(error => {
+  return Promise.all([
+    driver ? driver.close() : true,
+    new Promise(resolve => server ? server.close(resolve) : resolve())
+  ]).catch(error => {
     console.error(error);
   });
 }

--- a/ci.js
+++ b/ci.js
@@ -120,6 +120,17 @@ async function getResults(driver) {
   return {specResults: flatten(specResults), failedSuiteResults: flatten(failedSuiteResults)};
 }
 
+function cleanup() {
+  return Promise.resolve().then(() => {
+    return Promise.all([
+      driver ? driver.close() : true,
+      new Promise(resolve => server ? server.close(resolve) : resolve())
+    ]);
+  }).catch(error => {
+    console.error(error);
+  });
+}
+
 (async function () {
   await new Promise(resolve => {
     console.log("Creating an express app for browers to run the tests...")
@@ -202,7 +213,6 @@ async function getResults(driver) {
   if (useSauce) {
     driver.executeScript(`sauce:job-result=${process.exitCode === 0}`);
   }
-})().finally(() => {
-  return Promise.all([driver.close(), new Promise(resolve => server.close(resolve))]);
-});
-
+})().catch(error => {
+  console.error(error);
+}).then(cleanup);


### PR DESCRIPTION
## Description
Small tweaks to the `ci.js` test launcher:

- Ensure that if an error occurs in the launcher (mismatched Chrome browser + ChromeDriver version, or missing GeckoDriver, etc.), the details of the error will be logged to console.
- Ensure that if the driver fails to start, the server still gets closed down, allowing the test launcher to exit immediately instead of hanging forever.
- As a side benefit, the `ci.js` launcher now works in latest node v8.x _and_ v10.x.  (Although I'm fine bringing the `.finally` back if this isn't important -- we only have ~6 months to live on node 8.)

## Motivation and Context
Minor improvements that make it easier for new contributors to run CI tests in the browser locally.  Probably has no effect on CI (although for corner cases, may improve debugging).

## How Has This Been Tested?
- So far, tested locally only, with latest Safari, Chrome, and Firefox.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

