### PR TITLE
Extend spyOnAllFunctions to include prototype and parent methods

### DIFF
--- a/src/core/SpyRegistry.js
+++ b/src/core/SpyRegistry.js
@@ -125,13 +125,25 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
         throw new Error('spyOnAllFunctions could not find an object to spy upon');
       }
 
-      for (var prop in obj) {
-        if (Object.prototype.hasOwnProperty.call(obj, prop) && obj[prop] instanceof Function) {
-          var descriptor = Object.getOwnPropertyDescriptor(obj, prop);
-          if ((descriptor.writable || descriptor.set) && descriptor.configurable) {
-            this.spyOn(obj, prop);
+      var pointer = obj,
+          props = [],
+          prop,
+          descriptor;
+
+      while (pointer) {
+        for (prop in pointer) {
+          if (Object.prototype.hasOwnProperty.call(pointer, prop) && pointer[prop] instanceof Function) {
+            descriptor = Object.getOwnPropertyDescriptor(pointer, prop);
+            if ((descriptor.writable || descriptor.set) && descriptor.configurable) {
+              props.push(prop);
+            }
           }
         }
+        pointer = Object.getPrototypeOf(pointer);
+      }
+
+      for (var i = 0; i < props.length; i++) {
+        this.spyOn(obj, props[i]);
       }
 
       return obj;


### PR DESCRIPTION
## Description
When calling `spyOnAllFunctions`, spy on all enumerable & configurable functions detected on the object, the object's prototype, and anywhere up the object's prototype chain.

Closes #1677.

## Implementation Notes

I actually thought this would require _more_ checks, but it appears to me that all the functions I'm worried about (mostly `Object.prototype` functions) are already marked non-configurable and non-enumerable, so none of this code ever even sees them.

I'm unsure whether there's a supported environment out there that might, for example, not have a `getPrototypeOf` function.  If so, we can wrap that line and just immediately exit out of the loop.  (In an environment that old, the prototype chain methods just won't be included.)

## Motivation and Context
This change enables `spyOnAllFunctions` to be used on complex APIs (like those created by many libraries) where the object has a mix of bound functions, prototype methods, parent classes, etc.  The goal is that in most cases, if a function is something you'd call on an object, that function will end up being spied.

## How Has This Been Tested?
Unit tests updated and run in node 8, node 10, Chrome, Firefox & Safari.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

