### PR TITLE
Prevent error in case of non string value in 's' parameter

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -5487,7 +5487,7 @@ getJasmineRequireObj().pp = function(j$) {
       return { value: s, truncated: false };
     }
 
-    s = s.substring(0, maxlen - 4) + ' ...';
+    s = ('' + s).substring(0, maxlen - 4) + ' ...';
     return { value: s, truncated: true };
   }
 


### PR DESCRIPTION
ERROR: TypeError: undefined is not a constructor (evaluating 's.substring(0, maxlen - 4)') truncate

<!--- Provide a general summary of your changes in the Title above -->
PhantomJS 2.1.1 (Windows 8.0.0). error shown i console/karma report

## Description
<!--- Describe your changes in detail -->
Make method more safe to input

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ERROR: TypeError: undefined is not a constructor (evaluating 's.substring(0, maxlen - 4)') truncate

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested with modification in my project node_modules folder

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

