### PR TITLE
Print global errors encountered during CI runs

### DIFF
--- a/ci.js
+++ b/ci.js
@@ -198,6 +198,7 @@ function cleanup() {
   const details = await driver.executeScript(`
       return {
         overallStatus: jsApiReporter.runDetails.overallStatus,
+        overallFailures: jsApiReporter.runDetails.failedExpectations,
         executionTime: jsApiReporter.executionTime(),
         random: jsApiReporter.runDetails.order.random,
         seed: jsApiReporter.runDetails.order.seed
@@ -207,6 +208,12 @@ function cleanup() {
   console.log(`Finished in ${details.executionTime / 1000} second(s)`);
   console.log(`Randomized with seed ${details.seed} ( ${host}/?random=${details.random}&seed=${details.seed} )`);
   process.exitCode = details.overallStatus === 'passed' ? 0 : 1;
+
+  // Print details of global errors encountered during the test run. (Most likely,
+  // some type of file loading or syntax error.)
+  if (details.overallFailures && details.overallFailures.length > 0) {
+    console.error('Failures encountered during test run:', JSON.stringify(details.overallFailures, undefined, 2));
+  }
 
   if (useSauce) {
     driver.executeScript(`sauce:job-result=${process.exitCode === 0}`);


### PR DESCRIPTION
## Description
Ensure that if syntax/load errors (or any other global error that doesn't result in a spec failure) are encountered during a test run, the failure details are printed for debugging at the end of the run.

## Motivation and Context
Discovered after accidentally putting a raw `async () =>` expression in a unit test :).

Note that if a syntax/load error occurs during the test, it already _correctly_ exits with a non-zero exit code.  You just can't tell what the issue is.

## How Has This Been Tested?
Tested using local runs.

**Example with a raw async function in PhantomJS**
```
$ JASMINE_BROWSER=phantomjs node ci.js
.
.
.
Finished in 3.359 second(s)
Randomized with seed 59725 ( http://localhost:5555/?random=true&seed=59725 )
Failures encountered during test run: [
  {
    "passed": false,
    "globalErrorType": "load",
    "message": "SyntaxError: Unexpected token 'function'",
    "stack": null,
    "filename": "http://localhost:5555/spec/core/EnvSpec.js",
    "lineno": 204
  }
]
```

**Example with intentional syntax soup, in Chrome**
```
$ JASMINE_BROWSER=chrome node ci.js
.
.
.
993 spec(s), 1 failure(s), 6 pending spec(s)
Finished in 2.205 second(s)
Randomized with seed 91027 ( http://localhost:5555/?random=true&seed=91027 )
Failures encountered during test run: [
  {
    "filename": "http://localhost:5555/spec/core/EnvSpec.js",
    "globalErrorType": "load",
    "lineno": 204,
    "message": "Uncaught SyntaxError: missing ) after argument list",
    "passed": false,
    "stack": "SyntaxError: missing ) after argument list"
  }
]
```

**Example with no errors**
```
$ JASMINE_BROWSER=chrome node ci.js
.
.
.
1022 spec(s), 0 failure(s), 6 pending spec(s)
Finished in 2.102 second(s)
Randomized with seed 24703 ( http://localhost:5555/?random=true&seed=24703 )
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
