### PR TITLE
spyOnProperty respects the allowRespy flag

### DIFF
--- a/spec/core/SpyRegistrySpec.js
+++ b/spec/core/SpyRegistrySpec.js
@@ -137,22 +137,6 @@ describe("SpyRegistry", function() {
       }).toThrowError(/does not have access type/);
     });
 
-    it("checks if it has already been spied upon", function() {
-      var spyRegistry = new jasmineUnderTest.SpyRegistry({createSpy: createSpy}),
-        subject = {};
-
-      Object.defineProperty(subject, 'spiedProp', {
-        get: function() { return 1; },
-        configurable: true
-      });
-
-      spyRegistry.spyOnProperty(subject, 'spiedProp');
-
-      expect(function() {
-        spyRegistry.spyOnProperty(subject, 'spiedProp');
-      }).toThrowError(/has already been spied upon/);
-    });
-
     it("checks if it can be spied upon", function() {
       var subject = {};
 
@@ -211,6 +195,40 @@ describe("SpyRegistry", function() {
 
       expect(subject.spiedProperty).toEqual(returnValue);
       expect(setter).toEqual(spy);
+    });
+
+    describe("when the property is already spied upon", function() {
+      it("throws an error if respy is not allowed", function() {
+        var spyRegistry = new jasmineUnderTest.SpyRegistry({createSpy: createSpy}),
+          subject = {};
+
+        Object.defineProperty(subject, 'spiedProp', {
+          get: function() { return 1; },
+          configurable: true
+        });
+
+        spyRegistry.spyOnProperty(subject, 'spiedProp');
+
+        expect(function() {
+          spyRegistry.spyOnProperty(subject, 'spiedProp');
+        }).toThrowError(/spiedProp#get has already been spied upon/);
+      });
+
+      it("returns the original spy if respy is allowed", function() {
+        var spyRegistry = new jasmineUnderTest.SpyRegistry({createSpy: createSpy}),
+          subject = {};
+
+        spyRegistry.allowRespy(true);
+
+        Object.defineProperty(subject, 'spiedProp', {
+          get: function() { return 1; },
+          configurable: true
+        });
+
+        var originalSpy = spyRegistry.spyOnProperty(subject, 'spiedProp');
+
+        expect(spyRegistry.spyOnProperty(subject, 'spiedProp')).toBe(originalSpy);
+      });
     });
   });
 

--- a/src/core/SpyRegistry.js
+++ b/src/core/SpyRegistry.js
@@ -27,7 +27,7 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
       }
 
       if (obj[methodName] && j$.isSpy(obj[methodName])  ) {
-        if ( !!this.respy ){
+        if (this.respy) {
           return obj[methodName];
         }else {
           throw new Error(getErrorMsg(methodName + ' has already been spied upon'));
@@ -91,8 +91,11 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
       }
 
       if (j$.isSpy(descriptor[accessType])) {
-        //TODO?: should this return the current spy? Downside: may cause user confusion about spy state
-        throw new Error(propertyName + ' has already been spied upon');
+        if (this.respy) {
+          return descriptor[accessType];
+        } else {
+          throw new Error(propertyName + '#' + accessType + ' has already been spied upon');
+        }
       }
 
       var originalDescriptor = j$.util.clone(descriptor),


### PR DESCRIPTION
## Description
The `spyOnProperty` method was added in 2015, and included a comment wondering whether we should allow "respy" (returning the original spy if you attempt to spy on the same property again).

Since then the question has been answered (in 2016): if `allowRespy` is on, return the original spy; if it's not, throw an error (the current behavior).

## Motivation and Context
Make `spyOnProperty` behavior consistent with `spyOn` behavior.

## How Has This Been Tested?
- Local unit tests: node 8, node 10, chrome, firefox.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

