### PR TITLE
Fix toBeCloseTo matcher for Node.js 12 and Chrome 74

### DIFF
--- a/spec/core/matchers/toBeCloseToSpec.js
+++ b/spec/core/matchers/toBeCloseToSpec.js
@@ -90,4 +90,18 @@ describe("toBeCloseTo", function() {
     result = matcher.compare(1.23, 1.234);
     expect(result.pass).toBe(true);
   });
+
+  it("handles edge cases with rounding", function () {
+    var matcher = jasmineUnderTest.matchers.toBeCloseTo(),
+      result;
+
+    // these cases resulted in false negatives in version of V8 
+    // included in Node.js 12 and Chrome 74 (and Edge Chromium)
+    result = matcher.compare(4.030904708957288, 4.0309, 5);
+    expect(result.pass).toBe(true);
+    result = matcher.compare(4.82665525779431,4.82666, 5);
+    expect(result.pass).toBe(true);
+    result = matcher.compare(-2.82665525779431, -2.82666, 5);
+    expect(result.pass).toBe(true);
+  });
 });

--- a/src/core/matchers/toBeCloseTo.js
+++ b/src/core/matchers/toBeCloseTo.js
@@ -26,7 +26,7 @@ getJasmineRequireObj().toBeCloseTo = function() {
         var maxDelta = Math.pow(10, -precision) / 2;
 
         return {
-          pass: Math.round(delta * pow) / pow <= maxDelta
+          pass: Math.round(delta * pow) <= maxDelta * pow
         };
       }
     };


### PR DESCRIPTION
Change the final comparison in the toBeCloseTo matcher to include a multiplication instead of a division. The original division caused some rounding issues in newer versions of V8. 

## Description
Changing the division to a multiplication resolves the rounding error.
 
## Motivation and Context
See #1695 

## How Has This Been Tested?
Tested local on Node 8 and 10

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

