### PR TITLE
PrettyPrinter handles objects with invalid toString implementations

### DIFF
--- a/spec/core/PrettyPrintSpec.js
+++ b/spec/core/PrettyPrintSpec.js
@@ -333,4 +333,27 @@ describe("jasmineUnderTest.pp", function () {
 
     expect(jasmineUnderTest.pp(obj)).toEqual("null({ foo: 'bar' })");
   });
+
+  it("should gracefully handle objects with invalid toString implementations", function () {
+    var obj = {
+      foo: {
+        toString: function() {
+          // Invalid: toString returning a number
+          return 3;
+        }
+      },
+      bar: {
+        toString: function() {
+          // Invalid: toString returning an object
+          return new Error("bar");
+        }
+      },
+      // Valid: an actual number
+      baz: 3,
+      // Valid: an actual Error object
+      qux: new Error("bar")
+    };
+
+    expect(jasmineUnderTest.pp(obj)).toEqual("Object({ foo: [object Number], bar: [object Error], baz: 3, qux: Error: bar })");
+  });
 });

--- a/spec/core/PrettyPrintSpec.js
+++ b/spec/core/PrettyPrintSpec.js
@@ -344,8 +344,12 @@ describe("jasmineUnderTest.pp", function () {
       },
       bar: {
         toString: function() {
-          // Invalid: toString returning an object
-          return new Error("bar");
+          // Really invalid: a nested bad toString().
+          return {
+            toString: function() {
+              return new Date();
+            }
+          };
         }
       },
       // Valid: an actual number
@@ -354,6 +358,6 @@ describe("jasmineUnderTest.pp", function () {
       qux: new Error("bar")
     };
 
-    expect(jasmineUnderTest.pp(obj)).toEqual("Object({ foo: [object Number], bar: [object Error], baz: 3, qux: Error: bar })");
+    expect(jasmineUnderTest.pp(obj)).toEqual("Object({ foo: [object Number], bar: [object Object], baz: 3, qux: Error: bar })");
   });
 });

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -266,6 +266,12 @@ getJasmineRequireObj().pp = function(j$) {
   };
 
   PrettyPrinter.prototype.append = function(value) {
+    // This check protects us from the rare case where an object has overriden
+    // `toString()` with an invalid implementation (returning a non-string).
+    if (typeof value !== 'string') {
+      value = Object.prototype.toString.call(value);
+    }
+
     var result = truncate(value, j$.MAX_PRETTY_PRINT_CHARS - this.length);
     this.length += result.value.length;
     this.stringParts.push(result.value);


### PR DESCRIPTION
## Description
Protect jasmine's internal pretty printer from objects with invalid `toString()` implementations.

> Impl Note: Uses Object's `toString` situationally, as even `'' + value` will blow up if `value` itself has an invalid toString.  (For e.g.: `j$.pp({ toString: () => ({ toString: () => new Date() }) });`.  Gnarly, right?)

## Motivation and Context
Although rare and not jasmine's "fault", the API for `pp` is probably that it should _always_ return a string, no matter what weird/broken thing is passed to it.  If we can avoid blowing up an otherwise valid test, we should.

## How Has This Been Tested?
- Unit tested locally in node 8, node 10, chrome, & firefox.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

