### PR TITLE
fix(PrettyPrint) jasmine.createSpyObject('xx', 'toString') fails

### DIFF
--- a/spec/core/PrettyPrintSpec.js
+++ b/spec/core/PrettyPrintSpec.js
@@ -285,6 +285,25 @@ describe("jasmineUnderTest.pp", function () {
     expect(jasmineUnderTest.pp(env.createSpy("something"))).toEqual("spy on something");
   });
 
+  it("should stringify spyOn toString properly", function() {
+    var TestObject = {
+      someFunction: function() {}
+    },
+    env = new jasmineUnderTest.Env();
+
+    var spyRegistry = new jasmineUnderTest.SpyRegistry({
+      currentSpies: function() {return [];},
+      createSpy: function(name, originalFn) {
+        return jasmineUnderTest.Spy(name, originalFn);
+      }
+    });
+
+    spyRegistry.spyOn(TestObject, 'toString');
+    const testSpyObj = env.createSpyObj('TheClassName', ['toString']);
+
+    expect(jasmineUnderTest.pp(testSpyObj)).toEqual("spy on TheClassName.toString");
+  });
+
   it("should stringify objects that implement jasmineToString", function () {
     var obj = {
       jasmineToString: function () { return "strung"; }

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -30,6 +30,8 @@ getJasmineRequireObj().pp = function(j$) {
         this.emitString(value);
       } else if (j$.isSpy(value)) {
         this.emitScalar('spy on ' + value.and.identity);
+      } else if (j$.isSpy(value.toString)) {
+        this.emitScalar('spy on ' + value.toString.and.identity);
       } else if (value instanceof RegExp) {
         this.emitScalar(value.toString());
       } else if (typeof value === 'function') {


### PR DESCRIPTION
Add a test that fails because PrettyPrint cannot handle spyOn toString
