### PR TITLE
Adds width to root level html-reporter class

### DIFF
--- a/lib/jasmine-core/jasmine.css
+++ b/lib/jasmine-core/jasmine.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 body { overflow-y: scroll; }
 
-.jasmine_html-reporter { background-color: #eee; padding: 5px; margin: -8px; font-size: 11px; font-family: Monaco, "Lucida Console", monospace; line-height: 14px; color: #333; }
+.jasmine_html-reporter { width: 100%; background-color: #eee; padding: 5px; margin: -8px; font-size: 11px; font-family: Monaco, "Lucida Console", monospace; line-height: 14px; color: #333; }
 
 .jasmine_html-reporter a { text-decoration: none; }
 

--- a/src/html/_HTMLReporter.scss
+++ b/src/html/_HTMLReporter.scss
@@ -27,6 +27,7 @@ body {
 }
 
 .jasmine_html-reporter {
+  width: 100%;
   background-color: $page-background-color;
   padding: 5px;
   margin: -8px;
@@ -305,7 +306,7 @@ body {
 
       &.jasmine-excluded a {
         color: $neutral-color;
-      } 
+      }
     }
   }
 
@@ -329,7 +330,7 @@ body {
 
       &.jasmine-excluded a:before {
         content: $passing-mark + $space;
-      } 
+      }
     }
   }
 


### PR DESCRIPTION
I'm seeing test failures falling off the page. Somehow the element with class .html-reporter is expanding beyond the width of the page. This is fixed by adding width: 100% to the class .html-reporter. 

## Description
<!--- Describe your changes in detail -->
See https://github.com/dfederm/karma-jasmine-html-reporter/issues/27 and https://github.com/dfederm/karma-jasmine-html-reporter/pull/28 for why I'm submitting here.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This prevents page overflow in angular unit tests and should be benign in other contexts.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually, solves the problem
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

