### PR TITLE
Allow users to set a default spy strategy

### DIFF
--- a/spec/core/integration/DefaultSpyStrategySpec.js
+++ b/spec/core/integration/DefaultSpyStrategySpec.js
@@ -1,0 +1,68 @@
+describe('Default Spy Strategy (Integration)', function() {
+  var env;
+
+  beforeEach(function() {
+    env = new jasmineUnderTest.Env();
+    env.configure({random: false});
+  });
+
+  it('allows defining a default spy strategy', function(done) {
+    env.describe('suite with default strategy', function() {
+      env.beforeEach(function() {
+        env.setDefaultSpyStrategy(function (and) {
+          and.returnValue(42);
+        });
+      });
+
+      env.it('spec in suite', function() {
+        var spy = env.createSpy('something');
+        expect(spy()).toBe(42);
+      });
+    });
+
+    env.it('spec not in suite', function() {
+      var spy = env.createSpy('something');
+      expect(spy()).toBeUndefined();
+    });
+
+    function jasmineDone(result) {
+      expect(result.overallStatus).toEqual('passed');
+      done();
+    }
+
+    env.addReporter({ jasmineDone: jasmineDone });
+    env.execute();
+  });
+
+  it('uses the default spy strategy defined when the spy is created', function (done) {
+    env.it('spec', function() {
+      var a = env.createSpy('a');
+      env.setDefaultSpyStrategy(function (and) { and.returnValue(42); });
+      var b = env.createSpy('b');
+      env.setDefaultSpyStrategy(function (and) { and.stub(); });
+      var c = env.createSpy('c');
+      env.setDefaultSpyStrategy();
+      var d = env.createSpy('d');
+
+      expect(a()).toBeUndefined();
+      expect(b()).toBe(42);
+      expect(c()).toBeUndefined();
+      expect(d()).toBeUndefined();
+
+      // Check our assumptions about which spies are "configured" (this matters because
+      // spies that use withArgs() behave differently if they are not configured).
+      expect(a.and.isConfigured()).toBe(false);
+      expect(b.and.isConfigured()).toBe(true);
+      expect(c.and.isConfigured()).toBe(true);
+      expect(d.and.isConfigured()).toBe(false);
+    });
+
+    function jasmineDone(result) {
+      expect(result.overallStatus).toEqual('passed');
+      done();
+    }
+
+    env.addReporter({ jasmineDone: jasmineDone });
+    env.execute();
+  });
+});

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -210,9 +210,13 @@ getJasmineRequireObj().Env = function(j$) {
 
     this.setDefaultSpyStrategy = function(defaultStrategyFn) {
       if (!currentRunnable()) {
-        throw new Error('Default spy strategy must be set in a before function or a spec');
+        throw new Error(
+          'Default spy strategy must be set in a before function or a spec'
+        );
       }
-      runnableResources[currentRunnable().id].defaultStrategyFn = defaultStrategyFn;
+      runnableResources[
+        currentRunnable().id
+      ].defaultStrategyFn = defaultStrategyFn;
     };
 
     this.addSpyStrategy = function(name, fn) {
@@ -304,7 +308,8 @@ getJasmineRequireObj().Env = function(j$) {
         resources.customMatchers = j$.util.clone(
           runnableResources[parentRunnableId].customMatchers
         );
-        resources.defaultStrategyFn = runnableResources[parentRunnableId].defaultStrategyFn;
+        resources.defaultStrategyFn =
+          runnableResources[parentRunnableId].defaultStrategyFn;
       }
 
       runnableResources[id] = resources;

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -208,6 +208,13 @@ getJasmineRequireObj().Env = function(j$) {
       }
     });
 
+    this.setDefaultSpyStrategy = function(defaultStrategyFn) {
+      if (!currentRunnable()) {
+        throw new Error('Default spy strategy must be set in a before function or a spec');
+      }
+      runnableResources[currentRunnable().id].defaultStrategyFn = defaultStrategyFn;
+    };
+
     this.addSpyStrategy = function(name, fn) {
       if (!currentRunnable()) {
         throw new Error(
@@ -286,7 +293,8 @@ getJasmineRequireObj().Env = function(j$) {
         spies: [],
         customEqualityTesters: [],
         customMatchers: {},
-        customSpyStrategies: {}
+        customSpyStrategies: {},
+        defaultStrategyFn: undefined
       };
 
       if (runnableResources[parentRunnableId]) {
@@ -296,6 +304,7 @@ getJasmineRequireObj().Env = function(j$) {
         resources.customMatchers = j$.util.clone(
           runnableResources[parentRunnableId].customMatchers
         );
+        resources.defaultStrategyFn = runnableResources[parentRunnableId].defaultStrategyFn;
       }
 
       runnableResources[id] = resources;
@@ -719,6 +728,15 @@ getJasmineRequireObj().Env = function(j$) {
         }
 
         return {};
+      },
+      function getDefaultStrategyFn() {
+        var runnable = currentRunnable();
+
+        if (runnable) {
+          return runnableResources[runnable.id].defaultStrategyFn;
+        }
+
+        return undefined;
       },
       function getPromise() {
         return customPromise || global.Promise;

--- a/src/core/Spy.js
+++ b/src/core/Spy.js
@@ -12,7 +12,7 @@ getJasmineRequireObj().Spy = function(j$) {
    * @constructor
    * @name Spy
    */
-  function Spy(name, originalFn, customStrategies, getPromise) {
+  function Spy(name, originalFn, customStrategies, defaultStrategyFn, getPromise) {
     var numArgs = typeof originalFn === 'function' ? originalFn.length : 0,
       wrapper = makeFunc(numArgs, function() {
         return spy.apply(this, Array.prototype.slice.call(arguments));
@@ -126,6 +126,10 @@ getJasmineRequireObj().Spy = function(j$) {
       return strategyDispatcher.withArgs.apply(strategyDispatcher, arguments);
     };
     wrapper.calls = callTracker;
+
+    if (defaultStrategyFn) {
+      defaultStrategyFn(wrapper.and);
+    }
 
     return wrapper;
   }

--- a/src/core/Spy.js
+++ b/src/core/Spy.js
@@ -12,7 +12,13 @@ getJasmineRequireObj().Spy = function(j$) {
    * @constructor
    * @name Spy
    */
-  function Spy(name, originalFn, customStrategies, defaultStrategyFn, getPromise) {
+  function Spy(
+    name,
+    originalFn,
+    customStrategies,
+    defaultStrategyFn,
+    getPromise
+  ) {
     var numArgs = typeof originalFn === 'function' ? originalFn.length : 0,
       wrapper = makeFunc(numArgs, function() {
         return spy.apply(this, Array.prototype.slice.call(arguments));

--- a/src/core/SpyFactory.js
+++ b/src/core/SpyFactory.js
@@ -3,7 +3,13 @@ getJasmineRequireObj().SpyFactory = function(j$) {
     var self = this;
 
     this.createSpy = function(name, originalFn) {
-      return j$.Spy(name, originalFn, getCustomStrategies(), getDefaultStrategyFn(), getPromise);
+      return j$.Spy(
+        name,
+        originalFn,
+        getCustomStrategies(),
+        getDefaultStrategyFn(),
+        getPromise
+      );
     };
 
     this.createSpyObj = function(baseName, methodNames) {

--- a/src/core/SpyFactory.js
+++ b/src/core/SpyFactory.js
@@ -1,9 +1,9 @@
 getJasmineRequireObj().SpyFactory = function(j$) {
-  function SpyFactory(getCustomStrategies, getPromise) {
+  function SpyFactory(getCustomStrategies, getDefaultStrategyFn, getPromise) {
     var self = this;
 
     this.createSpy = function(name, originalFn) {
-      return j$.Spy(name, originalFn, getCustomStrategies(), getPromise);
+      return j$.Spy(name, originalFn, getCustomStrategies(), getDefaultStrategyFn(), getPromise);
     };
 
     this.createSpyObj = function(baseName, methodNames) {

--- a/src/core/requireInterface.js
+++ b/src/core/requireInterface.js
@@ -330,5 +330,21 @@ getJasmineRequireObj().interface = function(jasmine, env) {
     return env.addSpyStrategy(name, factory);
   };
 
+  /**
+   * Set the default spy strategy for the current scope of specs.
+   *
+   * _Note:_ This is only callable from within a {@link beforeEach}, {@link it}, or {@link beforeAll}.
+   * @name jasmine.setDefaultSpyStrategy
+   * @function
+   * @param {Function} defaultStrategyFn - a function that assigns a strategy
+   * @example
+   * beforeEach(function() {
+   *   jasmine.setDefaultSpyStrategy(and => and.returnValue(true));
+   * });
+   */
+  jasmine.setDefaultSpyStrategy = function(defaultStrategyFn) {
+    return env.setDefaultSpyStrategy(defaultStrategyFn);
+  };
+
   return jasmineInterface;
 };


### PR DESCRIPTION
## Description

Allow a user to set a "default spy strategy", which assigns the default behavior of any spies created.  You can do this inline in a particular spec, or in a suite's `beforeEach` or a global `beforeEach`, depending on your needs.

## Motivation and Context

If you're creating many spies and don't want to specify their strategies, or want a particular global spy handler, this allows you to do so.

In particular, a strategy like this may be useful, depending on your application:

```
beforeEach(function() {
    jasmine.setDefaultSpyStrategy(and =>
        and.throwError('Unexpected call on spy `' + and.identity + '`')
    );
});
```

## Next Steps

This is a first stab at the concept.  I originally wanted an interface where you would interact directly with a "default spy strategy" property, like this:

    jasmine.defaultSpyStrategy.returnValue(42);

The problem with this is you don't have the flexibility you need to, for example, use properties of _this spy_ (like `and.identity` or `and.originalFn`) in your default function.  So, you really need to have the user provide a callback function, rather than interacting directly with an object.

It might make more sense (a _lot_ more sense), rather than this `and => and.blah()` syntax, to instead have the function be `setSpyDefaults`, which takes a callback function on `spy`.  In this case the user would do:

    jasmine.setSpyDefaults(spy => spy.and.callFake(() => 'You called ' + spy.and.identity));

(Next steps would be to decide what the most intuitive user interface is, then clean up the source + specs.)

## How Has This Been Tested?
Locally on Chrome, node 8, node 10.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

