### PR TITLE
PrettyPrinter survives if objects throw in toString

### DIFF
--- a/spec/core/PrettyPrintSpec.js
+++ b/spec/core/PrettyPrintSpec.js
@@ -457,11 +457,17 @@ describe('jasmineUnderTest.pp', function() {
       // Valid: an actual number
       baz: 3,
       // Valid: an actual Error object
-      qux: new Error('bar')
+      qux: new Error('bar'),
+      //
+      baddy: {
+        toString: function() {
+          throw new Error('I am a bad toString');
+        }
+      }
     };
 
     expect(jasmineUnderTest.pp(obj)).toEqual(
-      'Object({ foo: [object Number], bar: [object Object], baz: 3, qux: Error: bar })'
+      'Object({ foo: [object Number], bar: [object Object], baz: 3, qux: Error: bar, baddy: has-invalid-toString-method })'
     );
   });
 });

--- a/src/core/PrettyPrinter.js
+++ b/src/core/PrettyPrinter.js
@@ -9,11 +9,16 @@ getJasmineRequireObj().pp = function(j$) {
   function hasCustomToString(value) {
     // value.toString !== Object.prototype.toString if value has no custom toString but is from another context (e.g.
     // iframe, web worker)
-    return (
-      j$.isFunction_(value.toString) &&
-      value.toString !== Object.prototype.toString &&
-      value.toString() !== Object.prototype.toString.call(value)
-    );
+    try {
+      return (
+        j$.isFunction_(value.toString) &&
+        value.toString !== Object.prototype.toString &&
+        value.toString() !== Object.prototype.toString.call(value)
+      );
+    } catch (e) {
+      // The custom toString() threw.
+      return true;
+    }
   }
 
   PrettyPrinter.prototype.format = function(value) {
@@ -59,7 +64,11 @@ getJasmineRequireObj().pp = function(j$) {
         !j$.isArray_(value) &&
         hasCustomToString(value)
       ) {
-        this.emitScalar(value.toString());
+        try {
+          this.emitScalar(value.toString());
+        } catch (e) {
+          this.emitScalar('has-invalid-toString-method');
+        }
       } else if (j$.util.arrayContains(this.seen, value)) {
         this.emitScalar(
           '<circular reference: ' +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a test that fails demonstrating that toBe does not work if the objects have a faulty toString().
