### PR TITLE
Allow individual spyOn/spyOnProperty calls to allow respy

### DIFF
--- a/spec/core/SpyRegistrySpec.js
+++ b/spec/core/SpyRegistrySpec.js
@@ -64,6 +64,21 @@ describe('SpyRegistry', function() {
       }).toThrowError(/has already been spied upon/);
     });
 
+    it('allows overriding respy by passing respy option as true', function() {
+      var spies = [],
+        spyRegistry = new jasmineUnderTest.SpyRegistry({
+          currentSpies: function() {
+            return spies;
+          },
+          createSpy: createSpy
+        }),
+        subject = { spiedFunc: function() {} };
+
+      var originalSpy = spyRegistry.spyOn(subject, 'spiedFunc');
+
+      expect(spyRegistry.spyOn(subject, 'spiedFunc', true)).toBe(originalSpy);
+    });
+
     it('checks if it can be spied upon', function() {
       var scope = {};
 
@@ -264,6 +279,46 @@ describe('SpyRegistry', function() {
         var originalSpy = spyRegistry.spyOnProperty(subject, 'spiedProp');
 
         expect(spyRegistry.spyOnProperty(subject, 'spiedProp')).toBe(
+          originalSpy
+        );
+      });
+
+      it('returns the original spy if respy option is passed as true', function() {
+        var spyRegistry = new jasmineUnderTest.SpyRegistry({
+            createSpy: createSpy
+          }),
+          subject = {};
+
+        Object.defineProperty(subject, 'spiedProp', {
+          get: function() {
+            return 1;
+          },
+          configurable: true
+        });
+
+        var originalSpy = spyRegistry.spyOnProperty(subject, 'spiedProp');
+
+        expect(spyRegistry.spyOnProperty(subject, 'spiedProp', 'get', true)).toBe(
+          originalSpy
+        );
+      });
+
+      it('returns the original spy if respy option is passed as third parameter', function() {
+        var spyRegistry = new jasmineUnderTest.SpyRegistry({
+            createSpy: createSpy
+          }),
+          subject = {};
+
+        Object.defineProperty(subject, 'spiedProp', {
+          get: function() {
+            return 1;
+          },
+          configurable: true
+        });
+
+        var originalSpy = spyRegistry.spyOnProperty(subject, 'spiedProp');
+
+        expect(spyRegistry.spyOnProperty(subject, 'spiedProp', true)).toBe(
           originalSpy
         );
       });

--- a/spec/core/SpyRegistrySpec.js
+++ b/spec/core/SpyRegistrySpec.js
@@ -298,9 +298,9 @@ describe('SpyRegistry', function() {
 
         var originalSpy = spyRegistry.spyOnProperty(subject, 'spiedProp');
 
-        expect(spyRegistry.spyOnProperty(subject, 'spiedProp', 'get', true)).toBe(
-          originalSpy
-        );
+        expect(
+          spyRegistry.spyOnProperty(subject, 'spiedProp', 'get', true)
+        ).toBe(originalSpy);
       });
 
       it('returns the original spy if respy option is passed as third parameter', function() {

--- a/src/core/SpyRegistry.js
+++ b/src/core/SpyRegistry.js
@@ -1,8 +1,8 @@
 getJasmineRequireObj().SpyRegistry = function(j$) {
-  var spyOnMsg = j$.formatErrorMsg('<spyOn>', 'spyOn(<object>, <methodName>)');
+  var spyOnMsg = j$.formatErrorMsg('<spyOn>', 'spyOn(<object>, <methodName>, [allowRespy])');
   var spyOnPropertyMsg = j$.formatErrorMsg(
     '<spyOnProperty>',
-    'spyOnProperty(<object>, <propName>, [accessType])'
+    'spyOnProperty(<object>, <propName>, [accessType], [allowRespy])'
   );
 
   function SpyRegistry(options) {
@@ -19,8 +19,11 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
       this.respy = allow;
     };
 
-    this.spyOn = function(obj, methodName) {
+    this.spyOn = function(obj, methodName, allowRespy) {
       var getErrorMsg = spyOnMsg;
+      if (allowRespy === undefined) {
+        allowRespy = this.respy;
+      }
 
       if (j$.util.isUndefined(obj) || obj === null) {
         throw new Error(
@@ -39,7 +42,7 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
       }
 
       if (obj[methodName] && j$.isSpy(obj[methodName])) {
-        if (this.respy) {
+        if (allowRespy) {
           return obj[methodName];
         } else {
           throw new Error(
@@ -84,10 +87,18 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
       return spiedMethod;
     };
 
-    this.spyOnProperty = function(obj, propertyName, accessType) {
+    this.spyOnProperty = function(obj, propertyName, accessType, allowRespy) {
       var getErrorMsg = spyOnPropertyMsg;
 
-      accessType = accessType || 'get';
+      if (typeof accessType === 'boolean') {
+        accessType = 'get';
+        allowRespy = accessType;
+      } else {
+        accessType = accessType || 'get';
+        if (allowRespy === undefined) {
+          allowRespy = this.respy;
+        }
+      }
 
       if (j$.util.isUndefined(obj)) {
         throw new Error(
@@ -127,7 +138,7 @@ getJasmineRequireObj().SpyRegistry = function(j$) {
       }
 
       if (j$.isSpy(descriptor[accessType])) {
-        if (this.respy) {
+        if (allowRespy) {
           return descriptor[accessType];
         } else {
           throw new Error(

--- a/src/core/SpyRegistry.js
+++ b/src/core/SpyRegistry.js
@@ -1,5 +1,8 @@
 getJasmineRequireObj().SpyRegistry = function(j$) {
-  var spyOnMsg = j$.formatErrorMsg('<spyOn>', 'spyOn(<object>, <methodName>, [allowRespy])');
+  var spyOnMsg = j$.formatErrorMsg(
+    '<spyOn>',
+    'spyOn(<object>, <methodName>, [allowRespy])'
+  );
   var spyOnPropertyMsg = j$.formatErrorMsg(
     '<spyOnProperty>',
     'spyOnProperty(<object>, <propName>, [accessType], [allowRespy])'

--- a/src/core/requireInterface.js
+++ b/src/core/requireInterface.js
@@ -215,10 +215,11 @@ getJasmineRequireObj().interface = function(jasmine, env) {
      * @global
      * @param {Object} obj - The object upon which to install the {@link Spy}.
      * @param {String} methodName - The name of the method to replace with a {@link Spy}.
+     * @param {boolean} [allowRespy] - Whether to allow respying if the method is already a {@link Spy}.
      * @returns {Spy}
      */
-    spyOn: function(obj, methodName) {
-      return env.spyOn(obj, methodName);
+    spyOn: function(obj, methodName, allowRespy) {
+      return env.spyOn(obj, methodName, allowRespy);
     },
 
     /**
@@ -229,10 +230,11 @@ getJasmineRequireObj().interface = function(jasmine, env) {
      * @param {Object} obj - The object upon which to install the {@link Spy}
      * @param {String} propertyName - The name of the property to replace with a {@link Spy}.
      * @param {String} [accessType=get] - The access type (get|set) of the property to {@link Spy} on.
+     * @param {boolean} [allowRespy] - Whether to allow respying if the method is already a {@link Spy}.
      * @returns {Spy}
      */
-    spyOnProperty: function(obj, methodName, accessType) {
-      return env.spyOnProperty(obj, methodName, accessType);
+    spyOnProperty: function(obj, methodName, accessType, allowRespy) {
+      return env.spyOnProperty(obj, methodName, accessType, allowRespy);
     },
 
     /**


### PR DESCRIPTION
## Description

Add an optional final parameter to `spyOn` and `spyOnProperty` that allows the user to override `allowRespy` to `true`, even if the global default is `false`.

(Or, allows you to override `allowRespy` to `false` if the global default is `true` -- not sure if there's a use case here, but the behavior is consistent.)

## Motivation and Context

This change is designed to fill a particular API hole today: if you have a sprawling spec and a test needs to override the behavior of a property, but that property is already a spy, it's not possible to do this unless you go and _save_ the original result of the `spyOnProperty` call (which may be difficult, if you're dealing with a tapestry of test helpers and beforeEach's etc.).  This probably means the spec has some code smell, but at least you won't be blocked anymore:

```
spyOnProperty(myModule, 'previouslySpiedProp', 'set', true).and.throwError('you cannot set that');
```

This isn't an API hole for function spies, but, I've added it there as well just for consistency.

```
spyOn(myModule, 'foo');
spyOn(myModule, 'foo').and.stub();  // <-- error!

// Just replace with:
myModule.foo.and.stub();

// Or, now, offered for consistency:
spyOn(myModule, 'foo', true).and.stub();
```

## How Has This Been Tested?
- local: Node 8, Node 10, Chrome, Firefox

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

