### PR TITLE
Fix: don't attempt to normalize PNGs (gitattributes)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+*.png -text


### PR DESCRIPTION
## Description
Recently, a change was made to `.gitattributes` that accidentally includes PNG files.  This causes odd behavior in git as you swap between branches (git thinks you should check in a version of the PNG with LF changes in it, which of course would be a broken binary).

> Note: I considered whitelisting text files instead; however, there are a dozen different types of text files that are usefully normalized (js, md, txt, py, json, sh, jst, etc.), and only 1 binary.  So I think it's easier to just turn off normalization as we need it.

## Motivation and Context
Avoid incorrect "file changed" messages from git for contributors.

## How Has This Been Tested?
Tested locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.