### PR TITLE
add custom async matchers

### DIFF
--- a/spec/core/AsyncExpectationSpec.js
+++ b/spec/core/AsyncExpectationSpec.js
@@ -225,6 +225,587 @@ describe('AsyncExpectation', function() {
     });
   });
 
+  describe('async matchers', function() {
+    it('makes custom matchers available to this expectation', function() {
+      var asyncMatchers = {
+          toFoo: function() {},
+          toBar: function() {}
+        },
+        expectation;
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        customAsyncMatchers: asyncMatchers
+      });
+
+      expect(expectation.toFoo).toBeDefined();
+      expect(expectation.toBar).toBeDefined();
+    });
+
+    it("wraps matchers's compare functions, passing in matcher dependencies", function() {
+      var fakeCompare = function() {
+          return Promise.resolve({ pass: true });
+        },
+        matcherFactory = jasmine
+          .createSpy('matcher')
+          .and.returnValue({ compare: fakeCompare }),
+        matchers = {
+          toFoo: matcherFactory
+        },
+        util = {
+          buildFailureMessage: jasmine.createSpy('buildFailureMessage')
+        },
+        customEqualityTesters = ['a'],
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        expectation;
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        util: util,
+        customAsyncMatchers: matchers,
+        customEqualityTesters: customEqualityTesters,
+        actual: 'an actual',
+        addExpectationResult: addExpectationResult
+      });
+
+      return expectation.toFoo('hello').then(function() {
+        expect(matcherFactory).toHaveBeenCalledWith(
+          util,
+          customEqualityTesters
+        );
+      });
+    });
+
+    it("wraps matchers's compare functions, passing the actual and expected", function() {
+      var fakeCompare = jasmine
+          .createSpy('fake-compare')
+          .and.returnValue(Promise.resolve({ pass: true })),
+        matchers = {
+          toFoo: function() {
+            return {
+              compare: fakeCompare
+            };
+          }
+        },
+        util = {
+          buildFailureMessage: jasmine.createSpy('buildFailureMessage')
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        expectation;
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        util: util,
+        customAsyncMatchers: matchers,
+        actual: 'an actual',
+        addExpectationResult: addExpectationResult
+      });
+
+      return expectation.toFoo('hello').then(function() {
+        expect(fakeCompare).toHaveBeenCalledWith('an actual', 'hello');
+      });
+    });
+
+    it('reports a passing result to the spec when the comparison passes', function() {
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({ pass: true });
+              }
+            };
+          }
+        },
+        util = {
+          buildFailureMessage: jasmine.createSpy('buildFailureMessage')
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        customAsyncMatchers: matchers,
+        util: util,
+        actual: 'an actual',
+        addExpectationResult: addExpectationResult
+      });
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(true, {
+          matcherName: 'toFoo',
+          passed: true,
+          message: '',
+          error: undefined,
+          expected: 'hello',
+          actual: 'an actual',
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it('reports a failing result to the spec when the comparison fails', function() {
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({ pass: false });
+              }
+            };
+          }
+        },
+        util = {
+          buildFailureMessage: function() {
+            return '';
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        customAsyncMatchers: matchers,
+        util: util,
+        actual: 'an actual',
+        addExpectationResult: addExpectationResult
+      });
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toFoo',
+          passed: false,
+          expected: 'hello',
+          actual: 'an actual',
+          message: '',
+          error: undefined,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it('reports a failing result and a custom fail message to the spec when the comparison fails', function() {
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({
+                  pass: false,
+                  message: 'I am a custom message'
+                });
+              }
+            };
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        actual: 'an actual',
+        customAsyncMatchers: matchers,
+        addExpectationResult: addExpectationResult
+      });
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toFoo',
+          passed: false,
+          expected: 'hello',
+          actual: 'an actual',
+          message: 'I am a custom message',
+          error: undefined,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it('reports a failing result with a custom fail message function to the spec when the comparison fails', function() {
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({
+                  pass: false,
+                  message: function() {
+                    return 'I am a custom message';
+                  }
+                });
+              }
+            };
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        customAsyncMatchers: matchers,
+        actual: 'an actual',
+        addExpectationResult: addExpectationResult
+      });
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toFoo',
+          passed: false,
+          expected: 'hello',
+          actual: 'an actual',
+          message: 'I am a custom message',
+          error: undefined,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it('reports a passing result to the spec when the comparison fails for a negative expectation', function() {
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({ pass: false });
+              }
+            };
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        actual = 'an actual',
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        customAsyncMatchers: matchers,
+        actual: 'an actual',
+        addExpectationResult: addExpectationResult
+      }).not;
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(true, {
+          matcherName: 'toFoo',
+          passed: true,
+          message: '',
+          error: undefined,
+          expected: 'hello',
+          actual: actual,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it('reports a failing result to the spec when the comparison passes for a negative expectation', function() {
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({ pass: true });
+              }
+            };
+          }
+        },
+        util = {
+          buildFailureMessage: function() {
+            return 'default message';
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        actual = 'an actual',
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        customAsyncMatchers: matchers,
+        actual: 'an actual',
+        util: util,
+        addExpectationResult: addExpectationResult
+      }).not;
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toFoo',
+          passed: false,
+          expected: 'hello',
+          actual: actual,
+          message: 'default message',
+          error: undefined,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it('reports a failing result and a custom fail message to the spec when the comparison passes for a negative expectation', function() {
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({
+                  pass: true,
+                  message: 'I am a custom message'
+                });
+              }
+            };
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        actual = 'an actual',
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        customAsyncMatchers: matchers,
+        actual: 'an actual',
+        addExpectationResult: addExpectationResult
+      }).not;
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toFoo',
+          passed: false,
+          expected: 'hello',
+          actual: actual,
+          message: 'I am a custom message',
+          error: undefined,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it("reports a passing result to the spec when the 'not' comparison passes, given a negativeCompare", function() {
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({ pass: true });
+              },
+              negativeCompare: function() {
+                return Promise.resolve({ pass: true });
+              }
+            };
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        actual = 'an actual',
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        customAsyncMatchers: matchers,
+        actual: 'an actual',
+        addExpectationResult: addExpectationResult
+      }).not;
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(true, {
+          matcherName: 'toFoo',
+          passed: true,
+          expected: 'hello',
+          actual: actual,
+          message: '',
+          error: undefined,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it("reports a failing result and a custom fail message to the spec when the 'not' comparison fails, given a negativeCompare", function() {
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({ pass: true });
+              },
+              negativeCompare: function() {
+                return Promise.resolve({
+                  pass: false,
+                  message: "I'm a custom message"
+                });
+              }
+            };
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        actual = 'an actual',
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        customAsyncMatchers: matchers,
+        actual: 'an actual',
+        addExpectationResult: addExpectationResult
+      }).not;
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toFoo',
+          passed: false,
+          expected: 'hello',
+          actual: actual,
+          message: "I'm a custom message",
+          error: undefined,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it('reports a custom error message to the spec', function() {
+      var customError = new Error('I am a custom error');
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({
+                  pass: false,
+                  message: 'I am a custom message',
+                  error: customError
+                });
+              }
+            };
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        actual: 'an actual',
+        customAsyncMatchers: matchers,
+        addExpectationResult: addExpectationResult
+      });
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toFoo',
+          passed: false,
+          expected: 'hello',
+          actual: 'an actual',
+          message: 'I am a custom message',
+          error: customError,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it("reports a custom message to the spec when a 'not' comparison fails", function() {
+      var customError = new Error('I am a custom error');
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({
+                  pass: true,
+                  message: 'I am a custom message',
+                  error: customError
+                });
+              }
+            };
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        actual: 'an actual',
+        customAsyncMatchers: matchers,
+        addExpectationResult: addExpectationResult
+      }).not;
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toFoo',
+          passed: false,
+          expected: 'hello',
+          actual: 'an actual',
+          message: 'I am a custom message',
+          error: customError,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+
+    it("reports a custom message func to the spec when a 'not' comparison fails", function() {
+      var customError = new Error('I am a custom error');
+      var matchers = {
+          toFoo: function() {
+            return {
+              compare: function() {
+                return Promise.resolve({
+                  pass: true,
+                  message: function() {
+                    return 'I am a custom message';
+                  },
+                  error: customError
+                });
+              }
+            };
+          }
+        },
+        addExpectationResult = jasmine.createSpy('addExpectationResult'),
+        errorWithStack = new Error('errorWithStack'),
+        expectation;
+
+      spyOn(jasmineUnderTest.util, 'errorWithStack').and.returnValue(
+        errorWithStack
+      );
+
+      expectation = jasmineUnderTest.Expectation.asyncFactory({
+        actual: 'an actual',
+        customAsyncMatchers: matchers,
+        addExpectationResult: addExpectationResult
+      }).not;
+
+      return expectation.toFoo('hello').then(function() {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toFoo',
+          passed: false,
+          expected: 'hello',
+          actual: 'an actual',
+          message: 'I am a custom message',
+          error: customError,
+          errorForStack: errorWithStack
+        });
+      });
+    });
+  });
+
   function dummyPromise() {
     return new Promise(function(resolve, reject) {});
   }

--- a/spec/core/AsyncExpectationSpec.js
+++ b/spec/core/AsyncExpectationSpec.js
@@ -242,6 +242,8 @@ describe('AsyncExpectation', function() {
     });
 
     it("wraps matchers's compare functions, passing in matcher dependencies", function() {
+      jasmine.getEnv().requirePromises();
+
       var fakeCompare = function() {
           return Promise.resolve({ pass: true });
         },
@@ -275,6 +277,8 @@ describe('AsyncExpectation', function() {
     });
 
     it("wraps matchers's compare functions, passing the actual and expected", function() {
+      jasmine.getEnv().requirePromises();
+
       var fakeCompare = jasmine
           .createSpy('fake-compare')
           .and.returnValue(Promise.resolve({ pass: true })),
@@ -304,6 +308,8 @@ describe('AsyncExpectation', function() {
     });
 
     it('reports a passing result to the spec when the comparison passes', function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {
@@ -345,6 +351,8 @@ describe('AsyncExpectation', function() {
     });
 
     it('reports a failing result to the spec when the comparison fails', function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {
@@ -388,6 +396,8 @@ describe('AsyncExpectation', function() {
     });
 
     it('reports a failing result and a custom fail message to the spec when the comparison fails', function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {
@@ -428,6 +438,8 @@ describe('AsyncExpectation', function() {
     });
 
     it('reports a failing result with a custom fail message function to the spec when the comparison fails', function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {
@@ -470,6 +482,8 @@ describe('AsyncExpectation', function() {
     });
 
     it('reports a passing result to the spec when the comparison fails for a negative expectation', function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {
@@ -508,6 +522,8 @@ describe('AsyncExpectation', function() {
     });
 
     it('reports a failing result to the spec when the comparison passes for a negative expectation', function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {
@@ -552,6 +568,8 @@ describe('AsyncExpectation', function() {
     });
 
     it('reports a failing result and a custom fail message to the spec when the comparison passes for a negative expectation', function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {
@@ -593,6 +611,8 @@ describe('AsyncExpectation', function() {
     });
 
     it("reports a passing result to the spec when the 'not' comparison passes, given a negativeCompare", function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {
@@ -634,6 +654,8 @@ describe('AsyncExpectation', function() {
     });
 
     it("reports a failing result and a custom fail message to the spec when the 'not' comparison fails, given a negativeCompare", function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {
@@ -678,6 +700,8 @@ describe('AsyncExpectation', function() {
     });
 
     it('reports errorWithStack when a custom error message is returned', function() {
+      jasmine.getEnv().requirePromises();
+
       var customError = new Error('I am a custom error');
       var matchers = {
           toFoo: function() {
@@ -720,6 +744,8 @@ describe('AsyncExpectation', function() {
     });
 
     it("reports a custom message to the spec when a 'not' comparison fails", function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {
@@ -760,6 +786,8 @@ describe('AsyncExpectation', function() {
     });
 
     it("reports a custom message func to the spec when a 'not' comparison fails", function() {
+      jasmine.getEnv().requirePromises();
+
       var matchers = {
           toFoo: function() {
             return {

--- a/spec/core/AsyncExpectationSpec.js
+++ b/spec/core/AsyncExpectationSpec.js
@@ -677,7 +677,7 @@ describe('AsyncExpectation', function() {
       });
     });
 
-    it('reports a custom error message to the spec', function() {
+    it('reports errorWithStack when a custom error message is returned', function() {
       var customError = new Error('I am a custom error');
       var matchers = {
           toFoo: function() {
@@ -713,22 +713,20 @@ describe('AsyncExpectation', function() {
           expected: 'hello',
           actual: 'an actual',
           message: 'I am a custom message',
-          error: customError,
+          error: undefined,
           errorForStack: errorWithStack
         });
       });
     });
 
     it("reports a custom message to the spec when a 'not' comparison fails", function() {
-      var customError = new Error('I am a custom error');
       var matchers = {
           toFoo: function() {
             return {
               compare: function() {
                 return Promise.resolve({
                   pass: true,
-                  message: 'I am a custom message',
-                  error: customError
+                  message: 'I am a custom message'
                 });
               }
             };
@@ -755,14 +753,13 @@ describe('AsyncExpectation', function() {
           expected: 'hello',
           actual: 'an actual',
           message: 'I am a custom message',
-          error: customError,
+          error: undefined,
           errorForStack: errorWithStack
         });
       });
     });
 
     it("reports a custom message func to the spec when a 'not' comparison fails", function() {
-      var customError = new Error('I am a custom error');
       var matchers = {
           toFoo: function() {
             return {
@@ -771,8 +768,7 @@ describe('AsyncExpectation', function() {
                   pass: true,
                   message: function() {
                     return 'I am a custom message';
-                  },
-                  error: customError
+                  }
                 });
               }
             };
@@ -799,7 +795,7 @@ describe('AsyncExpectation', function() {
           expected: 'hello',
           actual: 'an actual',
           message: 'I am a custom message',
-          error: customError,
+          error: undefined,
           errorForStack: errorWithStack
         });
       });

--- a/spec/core/AsyncExpectationSpec.js
+++ b/spec/core/AsyncExpectationSpec.js
@@ -35,7 +35,7 @@ describe('AsyncExpectation', function() {
           false,
           jasmine.objectContaining({
             passed: false,
-            message: 'Expected a promise not to be resolved.'
+            message: 'Expected [object Promise] not to be resolved.'
           })
         );
       });
@@ -193,7 +193,7 @@ describe('AsyncExpectation', function() {
           expect(addExpectationResult).toHaveBeenCalledWith(
             false,
             jasmine.objectContaining({
-              message: 'Some context: Expected a promise not to be resolved.'
+              message: 'Some context: Expected [object Promise] not to be resolved.'
             })
           );
         });

--- a/spec/core/AsyncExpectationSpec.js
+++ b/spec/core/AsyncExpectationSpec.js
@@ -193,7 +193,8 @@ describe('AsyncExpectation', function() {
           expect(addExpectationResult).toHaveBeenCalledWith(
             false,
             jasmine.objectContaining({
-              message: 'Some context: Expected [object Promise] not to be resolved.'
+              message:
+                'Some context: Expected [object Promise] not to be resolved.'
             })
           );
         });

--- a/spec/core/AsyncExpectationSpec.js
+++ b/spec/core/AsyncExpectationSpec.js
@@ -16,16 +16,6 @@ describe('AsyncExpectation', function() {
         'expectAsync is unavailable because the environment does not support promises.'
       );
     });
-
-    it('throws an Error if the argument is not a promise', function() {
-      jasmine.getEnv().requirePromises();
-      function f() {
-        jasmineUnderTest.Expectation.asyncFactory({ actual: 'not a promise' });
-      }
-      expect(f).toThrowError(
-        'Expected expectAsync to be called with a promise.'
-      );
-    });
   });
 
   describe('#not', function() {

--- a/spec/core/integration/CustomAsyncMatchersSpec.js
+++ b/spec/core/integration/CustomAsyncMatchersSpec.js
@@ -1,0 +1,72 @@
+describe('Custom Async Matchers (Integration)', function() {
+  var env;
+
+  beforeEach(function() {
+    env = new jasmineUnderTest.Env();
+    env.configure({random: false});
+  });
+
+  it('passes the spec if the custom async matcher passes', function(done) {
+    env.it('spec using custom async matcher', function() {
+      env.addAsyncMatchers({
+        toBeReal: function() {
+          return { compare: function() { return Promise.resolve({ pass: true }); } };
+        }
+      });
+
+      return env.expectAsync(true).toBeReal();
+    });
+
+    var specExpectations = function(result) {
+      expect(result.status).toEqual('passed');
+    };
+
+    env.addReporter({ specDone: specExpectations, jasmineDone: done });
+    env.execute();
+  });
+
+  it('uses the negative compare function for a negative comparison, if provided', function(done) {
+    env.it('spec with custom negative comparison matcher', function() {
+      env.addAsyncMatchers({
+        toBeReal: function() {
+          return {
+            compare: function() { return Promise.resolve({ pass: true }); },
+            negativeCompare: function() { return Promise.resolve({ pass: true }); }
+          };
+        }
+      });
+
+      return env.expectAsync(true).not.toBeReal();
+    });
+
+    var specExpectations = function(result) {
+      expect(result.status).toEqual('passed');
+    };
+
+    env.addReporter({ specDone: specExpectations, jasmineDone: done });
+    env.execute();
+  });
+
+  it('generates messages with the same rules as built in matchers absent a custom message', function(done) {
+    env.it('spec with an expectation', function() {
+      env.addAsyncMatchers({
+        toBeReal: function() {
+          return {
+            compare: function() {
+              return Promise.resolve({ pass: false });
+            }
+          };
+        }
+      });
+
+      return env.expectAsync('a').toBeReal();
+    });
+
+    var specExpectations = function(result) {
+      expect(result.failedExpectations[0].message).toEqual("Expected 'a' to be real.");
+    };
+
+    env.addReporter({ specDone: specExpectations, jasmineDone: done });
+    env.execute();
+  });
+});

--- a/spec/core/integration/CustomAsyncMatchersSpec.js
+++ b/spec/core/integration/CustomAsyncMatchersSpec.js
@@ -7,6 +7,8 @@ describe('Custom Async Matchers (Integration)', function() {
   });
 
   it('passes the spec if the custom async matcher passes', function(done) {
+    jasmine.getEnv().requirePromises();
+
     env.it('spec using custom async matcher', function() {
       env.addAsyncMatchers({
         toBeReal: function() {
@@ -26,6 +28,8 @@ describe('Custom Async Matchers (Integration)', function() {
   });
 
   it('uses the negative compare function for a negative comparison, if provided', function(done) {
+    jasmine.getEnv().requirePromises();
+
     env.it('spec with custom negative comparison matcher', function() {
       env.addAsyncMatchers({
         toBeReal: function() {
@@ -48,6 +52,8 @@ describe('Custom Async Matchers (Integration)', function() {
   });
 
   it('generates messages with the same rules as built in matchers absent a custom message', function(done) {
+    jasmine.getEnv().requirePromises();
+
     env.it('spec with an expectation', function() {
       env.addAsyncMatchers({
         toBeReal: function() {

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -2432,20 +2432,20 @@ describe("Env integration", function() {
       suiteDone: suiteDone,
       jasmineDone: function(result) {
         expect(result.failedExpectations).toEqual([jasmine.objectContaining({
-            message: 'Expected a promise to be rejected.'
+            message: 'Expected [object Promise] to be rejected.'
         })]);
 
         expect(specDone).toHaveBeenCalledWith(jasmine.objectContaining({
           description: 'has an async failure',
           failedExpectations: [jasmine.objectContaining({
-            message: 'Expected a promise to be rejected.'
+            message: 'Expected [object Promise] to be rejected.'
           })]
         }));
 
         expect(suiteDone).toHaveBeenCalledWith(jasmine.objectContaining({
           description: 'a suite',
           failedExpectations: [jasmine.objectContaining({
-            message: 'Expected a promise to be rejected.'
+            message: 'Expected [object Promise] to be rejected.'
           })]
         }));
 

--- a/spec/core/matchers/async/toBeRejectedSpec.js
+++ b/spec/core/matchers/async/toBeRejectedSpec.js
@@ -20,4 +20,17 @@ describe('toBeRejected', function() {
       expect(result).toEqual(jasmine.objectContaining({pass: false}));
     });
   });
+
+  it('fails if actual is not a promise', function() {
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejected(jasmineUnderTest.matchersUtil),
+      actual = 'not a promise';
+
+    function f() {
+      return matcher.compare(actual);
+    }
+
+    expect(f).toThrowError(
+      'Expected toBeRejected to be called on a promise.'
+    );
+  });
 });

--- a/spec/core/matchers/async/toBeRejectedWithErrorSpec.js
+++ b/spec/core/matchers/async/toBeRejectedWithErrorSpec.js
@@ -138,4 +138,17 @@ describe('#toBeRejectedWithError', function () {
       }));
     });
   });
+
+  it('fails if actual is not a promise', function() {
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWithError(jasmineUnderTest.matchersUtil),
+      actual = 'not a promise';
+
+    function f() {
+      return matcher.compare(actual);
+    }
+
+    expect(f).toThrowError(
+      'Expected toBeRejectedWithError to be called on a promise.'
+    );
+  });
 });

--- a/spec/core/matchers/async/toBeRejectedWithSpec.js
+++ b/spec/core/matchers/async/toBeRejectedWithSpec.js
@@ -60,4 +60,17 @@ describe('#toBeRejectedWith', function () {
       expect(result).toEqual(jasmine.objectContaining({pass: true}));
     });
   });
+
+  it('fails if actual is not a promise', function() {
+    var matcher = jasmineUnderTest.asyncMatchers.toBeRejectedWith(jasmineUnderTest.matchersUtil),
+      actual = 'not a promise';
+
+    function f() {
+      return matcher.compare(actual);
+    }
+
+    expect(f).toThrowError(
+      'Expected toBeRejectedWith to be called on a promise.'
+    );
+  });
 });

--- a/spec/core/matchers/async/toBeResolvedSpec.js
+++ b/spec/core/matchers/async/toBeResolvedSpec.js
@@ -20,4 +20,17 @@ describe('toBeResolved', function() {
       expect(result).toEqual(jasmine.objectContaining({pass: false}));
     });
   });
+
+  it('fails if actual is not a promise', function() {
+    var matcher = jasmineUnderTest.asyncMatchers.toBeResolved(jasmineUnderTest.matchersUtil),
+      actual = 'not a promise';
+
+    function f() {
+      return matcher.compare(actual);
+    }
+
+    expect(f).toThrowError(
+      'Expected toBeResolved to be called on a promise.'
+    );
+  });
 });

--- a/spec/core/matchers/async/toBeResolvedToSpec.js
+++ b/spec/core/matchers/async/toBeResolvedToSpec.js
@@ -63,4 +63,17 @@ describe('#toBeResolvedTo', function() {
       expect(result).toEqual(jasmine.objectContaining({pass: true}));
     });
   });
+
+  it('fails if actual is not a promise', function() {
+    var matcher = jasmineUnderTest.asyncMatchers.toBeResolvedTo(jasmineUnderTest.matchersUtil),
+      actual = 'not a promise';
+
+    function f() {
+      return matcher.compare(actual);
+    }
+
+    expect(f).toThrowError(
+      'Expected toBeResolvedTo to be called on a promise.'
+    );
+  });
 });

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -297,7 +297,6 @@ getJasmineRequireObj().Env = function(j$) {
         util: j$.matchersUtil,
         customEqualityTesters: runnableResources[spec.id].customEqualityTesters,
         customMatchers: runnableResources[spec.id].customMatchers,
-        customAsyncMatchers: runnableResources[spec.id].customAsyncMatchers,
         actual: actual,
         addExpectationResult: addExpectationResult
       });
@@ -311,6 +310,7 @@ getJasmineRequireObj().Env = function(j$) {
       return j$.Expectation.asyncFactory({
         util: j$.matchersUtil,
         customEqualityTesters: runnableResources[spec.id].customEqualityTesters,
+        customAsyncMatchers: runnableResources[spec.id].customAsyncMatchers,
         actual: actual,
         addExpectationResult: addExpectationResult
       });

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -266,6 +266,19 @@ getJasmineRequireObj().Env = function(j$) {
       }
     };
 
+    this.addAsyncMatchers = function(matchersToAdd) {
+      if (!currentRunnable()) {
+        throw new Error(
+          'Async Matchers must be added in a before function or a spec'
+        );
+      }
+      var customAsyncMatchers =
+        runnableResources[currentRunnable().id].customAsyncMatchers;
+      for (var matcherName in matchersToAdd) {
+        customAsyncMatchers[matcherName] = matchersToAdd[matcherName];
+      }
+    };
+
     j$.Expectation.addCoreMatchers(j$.matchers);
     j$.Expectation.addAsyncCoreMatchers(j$.asyncMatchers);
 
@@ -284,6 +297,7 @@ getJasmineRequireObj().Env = function(j$) {
         util: j$.matchersUtil,
         customEqualityTesters: runnableResources[spec.id].customEqualityTesters,
         customMatchers: runnableResources[spec.id].customMatchers,
+        customAsyncMatchers: runnableResources[spec.id].customAsyncMatchers,
         actual: actual,
         addExpectationResult: addExpectationResult
       });
@@ -311,6 +325,7 @@ getJasmineRequireObj().Env = function(j$) {
         spies: [],
         customEqualityTesters: [],
         customMatchers: {},
+        customAsyncMatchers: {},
         customSpyStrategies: {},
         defaultStrategyFn: undefined
       };
@@ -321,6 +336,9 @@ getJasmineRequireObj().Env = function(j$) {
         );
         resources.customMatchers = j$.util.clone(
           runnableResources[parentRunnableId].customMatchers
+        );
+        resources.customAsyncMatchers = j$.util.clone(
+          runnableResources[parentRunnableId].customAsyncMatchers
         );
         resources.defaultStrategyFn =
           runnableResources[parentRunnableId].defaultStrategyFn;

--- a/src/core/Expectation.js
+++ b/src/core/Expectation.js
@@ -1,10 +1,4 @@
 getJasmineRequireObj().Expectation = function(j$) {
-  var promiseForMessage = {
-    jasmineToString: function() {
-      return 'a promise';
-    }
-  };
-
   /**
    * Matchers that come with Jasmine out of the box.
    * @namespace matchers
@@ -117,7 +111,7 @@ getJasmineRequireObj().Expectation = function(j$) {
       return this.expector
         .compare(name, matcherFactory, arguments)
         .then(function(result) {
-          self.expector.processResult(result, errorForStack, promiseForMessage);
+          self.expector.processResult(result, errorForStack);
         });
     };
   }

--- a/src/core/Expectation.js
+++ b/src/core/Expectation.js
@@ -172,7 +172,7 @@ getJasmineRequireObj().Expectation = function(j$) {
         return matcher.compare.apply(this, arguments).then(negate);
       }
 
-      return defaultNegativeCompare;
+      return matcher.negativeCompare || defaultNegativeCompare;
     },
     buildFailureMessage: negatedFailureMessage
   };

--- a/src/core/Expectation.js
+++ b/src/core/Expectation.js
@@ -62,8 +62,12 @@ getJasmineRequireObj().Expectation = function(j$) {
       );
     }
 
-    if (!j$.isPromiseLike(this.expector.actual)) {
-      throw new Error('Expected expectAsync to be called with a promise.');
+    var customAsyncMatchers = options.customAsyncMatchers || {};
+    for (var matcherName in customAsyncMatchers) {
+      this[matcherName] = wrapAsyncCompare(
+        matcherName,
+        customAsyncMatchers[matcherName]
+      );
     }
   }
 

--- a/src/core/Expector.js
+++ b/src/core/Expector.js
@@ -70,10 +70,8 @@ getJasmineRequireObj().Expector = function(j$) {
 
   Expector.prototype.processResult = function(
     result,
-    errorForStack,
-    actualOverride
+    errorForStack
   ) {
-    this.args[0] = actualOverride || this.args[0];
     var message = this.buildMessage(result);
 
     if (this.expected.length === 1) {

--- a/src/core/Expector.js
+++ b/src/core/Expector.js
@@ -68,10 +68,7 @@ getJasmineRequireObj().Expector = function(j$) {
     return result;
   };
 
-  Expector.prototype.processResult = function(
-    result,
-    errorForStack
-  ) {
+  Expector.prototype.processResult = function(result, errorForStack) {
     var message = this.buildMessage(result);
 
     if (this.expected.length === 1) {

--- a/src/core/Expector.js
+++ b/src/core/Expector.js
@@ -84,7 +84,7 @@ getJasmineRequireObj().Expector = function(j$) {
       matcherName: this.matcherName,
       passed: result.pass,
       message: message,
-      error: errorForStack ? undefined : result.error,
+      error: result.error,
       errorForStack: errorForStack || undefined,
       actual: this.actual,
       expected: this.expected // TODO: this may need to be arrayified/sliced

--- a/src/core/Expector.js
+++ b/src/core/Expector.js
@@ -84,7 +84,7 @@ getJasmineRequireObj().Expector = function(j$) {
       matcherName: this.matcherName,
       passed: result.pass,
       message: message,
-      error: result.error,
+      error: errorForStack ? undefined : result.error,
       errorForStack: errorForStack || undefined,
       actual: this.actual,
       expected: this.expected // TODO: this may need to be arrayified/sliced

--- a/src/core/matchers/async/toBeRejected.js
+++ b/src/core/matchers/async/toBeRejected.js
@@ -10,9 +10,12 @@ getJasmineRequireObj().toBeRejected = function(j$) {
    * @example
    * return expectAsync(aPromise).toBeRejected();
    */
-  return function toBeResolved(util) {
+  return function toBeRejected(util) {
     return {
       compare: function(actual) {
+        if (!j$.isPromiseLike(actual)) {
+          throw new Error('Expected toBeRejected to be called on a promise.');
+        }
         return actual.then(
           function() { return {pass: false}; },
           function() { return {pass: true}; }

--- a/src/core/matchers/async/toBeRejectedWith.js
+++ b/src/core/matchers/async/toBeRejectedWith.js
@@ -14,6 +14,10 @@ getJasmineRequireObj().toBeRejectedWith = function(j$) {
   return function toBeRejectedWith(util, customEqualityTesters) {
     return {
       compare: function(actualPromise, expectedValue) {
+        if (!j$.isPromiseLike(actualPromise)) {
+          throw new Error('Expected toBeRejectedWith to be called on a promise.');
+        }
+
         function prefix(passed) {
           return 'Expected a promise ' +
             (passed ? 'not ' : '') +

--- a/src/core/matchers/async/toBeRejectedWithError.js
+++ b/src/core/matchers/async/toBeRejectedWithError.js
@@ -17,6 +17,10 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
   return function toBeRejectedWithError() {
     return {
       compare: function(actualPromise, arg1, arg2) {
+        if (!j$.isPromiseLike(actualPromise)) {
+          throw new Error('Expected toBeRejectedWithError to be called on a promise.');
+        }
+
         var expected = getExpectedFromArgs(arg1, arg2);
 
         return actualPromise.then(

--- a/src/core/matchers/async/toBeResolved.js
+++ b/src/core/matchers/async/toBeResolved.js
@@ -13,6 +13,10 @@ getJasmineRequireObj().toBeResolved = function(j$) {
   return function toBeResolved(util) {
     return {
       compare: function(actual) {
+        if (!j$.isPromiseLike(actual)) {
+          throw new Error('Expected toBeResolved to be called on a promise.');
+        }
+
         return actual.then(
           function() { return {pass: true}; },
           function() { return {pass: false}; }

--- a/src/core/matchers/async/toBeResolvedTo.js
+++ b/src/core/matchers/async/toBeResolvedTo.js
@@ -14,6 +14,10 @@ getJasmineRequireObj().toBeResolvedTo = function(j$) {
   return function toBeResolvedTo(util, customEqualityTesters) {
     return {
       compare: function(actualPromise, expectedValue) {
+        if (!j$.isPromiseLike(actualPromise)) {
+          throw new Error('Expected toBeResolvedTo to be called on a promise.');
+        }
+
         function prefix(passed) {
           return 'Expected a promise ' +
             (passed ? 'not ' : '') +

--- a/src/core/requireInterface.js
+++ b/src/core/requireInterface.js
@@ -303,6 +303,20 @@ getJasmineRequireObj().interface = function(jasmine, env) {
   };
 
   /**
+   * Add custom async matchers for the current scope of specs.
+   *
+   * _Note:_ This is only callable from within a {@link beforeEach}, {@link it}, or {@link beforeAll}.
+   * @name jasmine.addMatchers
+   * @since 3.5.0
+   * @function
+   * @param {Object} matchers - Keys from this object will be the new async matcher names.
+   * @see custom_matcher
+   */
+  jasmine.addAsyncMatchers = function(matchers) {
+    return env.addAsyncMatchers(matchers);
+  };
+
+  /**
    * Get the currently booted mock {Clock} for this Jasmine environment.
    * @name jasmine.clock
    * @since 2.0.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add custom async matchers with `jasmine.addAsyncMatchers()`

## Description
<!--- Describe your changes in detail -->

add custom async matchers with `jasmine.addAsyncMatchers()`

I removed the requirement for expectAsync to be passed a promise so it would be closer to [Async Matchers](https://jestjs.io/docs/en/expect.html#async-matchers) in Jest.

```js
jasmine.addAsyncMatchers({
  toMatchAsync: () => {
    return {
      compare: async (actual, expected) => {
        const value = await doSomethingAsync(actual);
        const result = {
          pass: value === expected
        };
        result.message = await getAsyncMessage(expected, result.pass);
        return result;
      }
    };
  }
});

it('matches an async value', async () => {
  await expectAsync(1).toMatchAsync(1);
});
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Now custom matchers and can do something asynchronous with the `actual` or `expected` values.

fixes #1703

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added tests in AsyncExpectationSpec.js

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

