### PR TITLE
allow custom matchers to be async

### DIFF
--- a/spec/core/ExpectationSpec.js
+++ b/spec/core/ExpectationSpec.js
@@ -195,6 +195,79 @@ describe('Expectation', function() {
     });
   });
 
+  it('reports a passing result to the spec when the promise comparison passes', function() {
+    var matchers = {
+        toFoo: function() {
+          return {
+            compare: function() {
+              return Promise.resolve({ pass: true });
+            }
+          };
+        }
+      },
+      util = {
+        buildFailureMessage: jasmine.createSpy('buildFailureMessage')
+      },
+      addExpectationResult = jasmine.createSpy('addExpectationResult'),
+      expectation;
+
+    expectation = jasmineUnderTest.Expectation.factory({
+      customMatchers: matchers,
+      util: util,
+      actual: 'an actual',
+      addExpectationResult: addExpectationResult
+    });
+
+    return expectation.toFoo('hello')
+      .then(function () {
+        expect(addExpectationResult).toHaveBeenCalledWith(true, {
+          matcherName: 'toFoo',
+          passed: true,
+          message: '',
+          error: undefined,
+          expected: 'hello',
+          actual: 'an actual',
+          errorForStack: undefined
+        });
+      });
+  });
+
+  it('reports a failing result and a custom fail message to the spec when the promise comparison fails', function() {
+    var matchers = {
+        toFoo: function() {
+          return {
+            compare: function() {
+              return Promise.resolve({
+                pass: false,
+                message: 'I am a custom message'
+              });
+            }
+          };
+        }
+      },
+      addExpectationResult = jasmine.createSpy('addExpectationResult'),
+      expectation;
+
+    expectation = jasmineUnderTest.Expectation.factory({
+      actual: 'an actual',
+      customMatchers: matchers,
+      addExpectationResult: addExpectationResult
+    });
+
+    return expectation.toFoo('hello')
+      .then(function () {
+        expect(addExpectationResult).toHaveBeenCalledWith(false, {
+          matcherName: 'toFoo',
+          passed: false,
+          expected: 'hello',
+          actual: 'an actual',
+          message: 'I am a custom message',
+          error: undefined,
+          errorForStack: undefined
+        });
+      });
+  });
+
   it('reports a failing result with a custom fail message function to the spec when the comparison fails', function() {
     var matchers = {
         toFoo: function() {

--- a/spec/core/ExpectationSpec.js
+++ b/spec/core/ExpectationSpec.js
@@ -218,18 +218,17 @@ describe('Expectation', function() {
       addExpectationResult: addExpectationResult
     });
 
-    return expectation.toFoo('hello')
-      .then(function () {
-        expect(addExpectationResult).toHaveBeenCalledWith(true, {
-          matcherName: 'toFoo',
-          passed: true,
-          message: '',
-          error: undefined,
-          expected: 'hello',
-          actual: 'an actual',
-          errorForStack: undefined
-        });
+    return expectation.toFoo('hello').then(function() {
+      expect(addExpectationResult).toHaveBeenCalledWith(true, {
+        matcherName: 'toFoo',
+        passed: true,
+        message: '',
+        error: undefined,
+        expected: 'hello',
+        actual: 'an actual',
+        errorForStack: undefined
       });
+    });
   });
 
   it('reports a failing result and a custom fail message to the spec when the promise comparison fails', function() {
@@ -254,18 +253,17 @@ describe('Expectation', function() {
       addExpectationResult: addExpectationResult
     });
 
-    return expectation.toFoo('hello')
-      .then(function () {
-        expect(addExpectationResult).toHaveBeenCalledWith(false, {
-          matcherName: 'toFoo',
-          passed: false,
-          expected: 'hello',
-          actual: 'an actual',
-          message: 'I am a custom message',
-          error: undefined,
-          errorForStack: undefined
-        });
+    return expectation.toFoo('hello').then(function() {
+      expect(addExpectationResult).toHaveBeenCalledWith(false, {
+        matcherName: 'toFoo',
+        passed: false,
+        expected: 'hello',
+        actual: 'an actual',
+        message: 'I am a custom message',
+        error: undefined,
+        errorForStack: undefined
       });
+    });
   });
 
   it('reports a failing result with a custom fail message function to the spec when the comparison fails', function() {

--- a/src/core/Expectation.js
+++ b/src/core/Expectation.js
@@ -98,7 +98,16 @@ getJasmineRequireObj().Expectation = function(j$) {
   function wrapSyncCompare(name, matcherFactory) {
     return function() {
       var result = this.expector.compare(name, matcherFactory, arguments);
-      this.expector.processResult(result);
+      if (j$.isPromiseLike(result)) {
+        var self = this;
+
+        return result
+          .then(function(promiseResult) {
+            self.expector.processResult(promiseResult);
+          });
+      } else {
+        this.expector.processResult(result);
+      }
     };
   }
 

--- a/src/core/Expectation.js
+++ b/src/core/Expectation.js
@@ -101,10 +101,9 @@ getJasmineRequireObj().Expectation = function(j$) {
       if (j$.isPromiseLike(result)) {
         var self = this;
 
-        return result
-          .then(function(promiseResult) {
-            self.expector.processResult(promiseResult);
-          });
+        return result.then(function(promiseResult) {
+          self.expector.processResult(promiseResult);
+        });
       } else {
         this.expector.processResult(result);
       }


### PR DESCRIPTION
Allow custom matchers to be asynchronous.

## Description
<!--- Describe your changes in detail -->

If a custom matcher returns a `Promise` then you can await the call to `expect`

```js
jasmine.addMatchers({
  toMatchAsync: () => {
    return {
      compare: async (actual, expected) => {
        const value = await doSomethingAsync(actual);
        const result = {
          pass: value === expected
        };
        result.message = await getAsyncMessage(expected, result.pass);
        return result;
      }
    };
  }
});

it('matches an async value', async () => {
  await expect(1).toMatchAsync(1);
});
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR allows adding asynchronous matchers like #1732 but allows `expectAsync` to keep the requirement that it is passed a `Promise` object.

Fixes #1703 
Fixes https://github.com/jasmine/jasmine/pull/1732#issuecomment-509472042

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added two tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

