### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/jasmine-core.gemspec
+++ b/jasmine-core.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.description = %q{Test your JavaScript without any framework dependencies, in any environment, and with a nice descriptive syntax.}
   s.email = %q{jasmine-js@googlegroups.com}
   s.homepage = "http://jasmine.github.io"
-  s.rubyforge_project = "jasmine-core"
   s.license = "MIT"
 
   s.files         = Dir.glob("./lib/**/*")


### PR DESCRIPTION
## Description

Drop an EOL'd property.

## Motivation and Context

Cleanup.

## How Has This Been Tested?

The RubyGems property rubyforge_project is removed without a replacement.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

