### PR TITLE
Pass the error including stacktrace to error handlers and reporters

### DIFF
--- a/spec/core/GlobalErrorsSpec.js
+++ b/spec/core/GlobalErrorsSpec.js
@@ -12,7 +12,7 @@ describe('GlobalErrors', function() {
     expect(handler).toHaveBeenCalledWith('foo');
   });
 
-  it('prefers passing the error including stack to the handler', function() {
+  it('calls the global error handler with all parameters', function() {
     var fakeGlobal = { onerror: null },
       handler = jasmine.createSpy('errorHandler'),
       errors = new jasmineUnderTest.GlobalErrors(fakeGlobal),
@@ -23,7 +23,13 @@ describe('GlobalErrors', function() {
 
     fakeGlobal.onerror(fooError.message, 'foo.js', 1, 1, fooError);
 
-    expect(handler).toHaveBeenCalledWith(fooError);
+    expect(handler).toHaveBeenCalledWith(
+      fooError.message,
+      'foo.js',
+      1,
+      1,
+      fooError
+    );
   });
 
   it('only calls the most recent handler', function() {

--- a/spec/core/GlobalErrorsSpec.js
+++ b/spec/core/GlobalErrorsSpec.js
@@ -12,6 +12,20 @@ describe('GlobalErrors', function() {
     expect(handler).toHaveBeenCalledWith('foo');
   });
 
+  it('prefers passing the error including stack to the handler', function() {
+    var fakeGlobal = { onerror: null },
+      handler = jasmine.createSpy('errorHandler'),
+      errors = new jasmineUnderTest.GlobalErrors(fakeGlobal),
+      fooError = new Error('foo');
+
+    errors.install();
+    errors.pushListener(handler);
+
+    fakeGlobal.onerror(fooError.message, 'foo.js', 1, 1, fooError);
+
+    expect(handler).toHaveBeenCalledWith(fooError);
+  });
+
   it('only calls the most recent handler', function() {
     var fakeGlobal = { onerror: null },
       handler1 = jasmine.createSpy('errorHandler1'),

--- a/spec/core/QueueRunnerSpec.js
+++ b/spec/core/QueueRunnerSpec.js
@@ -514,6 +514,32 @@ describe('QueueRunner', function() {
     });
   });
 
+  it('passes the error instance to exception handlers in HTML browsers', function() {
+    var error = new Error('fake error'),
+      onExceptionCallback = jasmine.createSpy('on exception callback'),
+      queueRunner = new jasmineUnderTest.QueueRunner({
+        onException: onExceptionCallback
+      });
+
+    queueRunner.execute();
+    queueRunner.handleFinalError(error.message, 'fake.js', 1, 1, error);
+
+    expect(onExceptionCallback).toHaveBeenCalledWith(error);
+  });
+
+  it('passes the first argument to exception handlers for compatibility', function() {
+    var error = new Error('fake error'),
+      onExceptionCallback = jasmine.createSpy('on exception callback'),
+      queueRunner = new jasmineUnderTest.QueueRunner({
+        onException: onExceptionCallback
+      });
+
+    queueRunner.execute();
+    queueRunner.handleFinalError(error.message);
+
+    expect(onExceptionCallback).toHaveBeenCalledWith(error.message);
+  });
+
   it('calls exception handlers when an exception is thrown in a fn', function() {
     var queueableFn = {
         type: 'queueable',

--- a/src/core/GlobalErrors.js
+++ b/src/core/GlobalErrors.js
@@ -3,16 +3,14 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
     var handlers = [];
     global = global || j$.getGlobal();
 
-    var onerror = function onerror() {
+    var onerror = function onerror(message, source, lineno, colno, error) {
       var handler = handlers[handlers.length - 1];
 
       if (handler) {
-        // Get error from (message, source, lineno, colno, error)
         var args = Array.prototype.slice.call(arguments, 0);
-        var error = args.find(function(arg) {
-          return arg instanceof Error;
-        });
-        handler.apply(null, error ? [error] : args);
+        // Prefer passing the error to the error handler
+        // to be able to print the stack trace.
+        handler.apply(null, error instanceof Error ? [error] : args);
       } else {
         throw arguments[0];
       }

--- a/src/core/GlobalErrors.js
+++ b/src/core/GlobalErrors.js
@@ -7,7 +7,12 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
       var handler = handlers[handlers.length - 1];
 
       if (handler) {
-        handler.apply(null, Array.prototype.slice.call(arguments, 0));
+        // Get error from (message, source, lineno, colno, error)
+        var args = Array.prototype.slice.call(arguments, 0);
+        var error = args.find(function(arg) {
+          return arg instanceof Error;
+        });
+        handler.apply(null, error ? [error] : args);
       } else {
         throw arguments[0];
       }

--- a/src/core/GlobalErrors.js
+++ b/src/core/GlobalErrors.js
@@ -3,14 +3,11 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
     var handlers = [];
     global = global || j$.getGlobal();
 
-    var onerror = function onerror(message, source, lineno, colno, error) {
+    var onerror = function onerror() {
       var handler = handlers[handlers.length - 1];
 
       if (handler) {
-        var args = Array.prototype.slice.call(arguments, 0);
-        // Prefer passing the error to the error handler
-        // to be able to print the stack trace.
-        handler.apply(null, error instanceof Error ? [error] : args);
+        handler.apply(null, Array.prototype.slice.call(arguments, 0));
       } else {
         throw arguments[0];
       }

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -49,8 +49,11 @@ getJasmineRequireObj().QueueRunner = function(j$) {
 
   QueueRunner.prototype.execute = function() {
     var self = this;
-    this.handleFinalError = function(error) {
-      self.onException(error);
+    this.handleFinalError = function(message, source, lineno, colno, error) {
+      // Older browsers would send the error as the first parameter. HTML5
+      // specifies the the five parameters above. The error instance should
+      // be preffered, otherwise the call stack would get lost.
+      self.onException(error || message);
     };
     this.globalErrors.pushListener(this.handleFinalError);
     this.run(0);


### PR DESCRIPTION
## Description

Instead of the string with the error message, pass the `Error` instance, which includes both the message and the stacktrace.

## Motivation and Context

Attempts to fix #1728.

The [global window error handler](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror#window.onerror) is used to handle errors thrown from within asynchronous functions and tests. The first parameter is the error message only; the fifth parameter is the full error object including the stacktrace. Using the error object instead of the error message lets the reporters log it. (Searching for the first occurrence of an error instance in arguments to work with browsers, which may not comply with the HTML5 standard.)

## How Has This Been Tested?

I created a [minimum project `bug-jasmine-no-async-stacktrace` using `karma`](https://github.com/prantlf/bug-jasmine-no-async-stacktrace) to reproduce the issue and demonstrate the effect of this fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
