### PR TITLE
Updated arrayContaining to require actual values to be arrays

### DIFF
--- a/spec/core/asymmetric_equality/ArrayContainingSpec.js
+++ b/spec/core/asymmetric_equality/ArrayContainingSpec.js
@@ -31,6 +31,12 @@ describe("ArrayContaining", function() {
     expect(containing.asymmetricMatch(["bar"])).toBe(false);
   });
 
+  it("does not match when the actual is not an array", function() {
+    var containing = new jasmineUnderTest.ArrayContaining(["foo"]);
+
+    expect(containing.asymmetricMatch("foo")).toBe(false);
+  });
+
   it("jasmineToStrings itself", function() {
     var containing = new jasmineUnderTest.ArrayContaining([]);
 

--- a/src/core/asymmetric_equality/ArrayContaining.js
+++ b/src/core/asymmetric_equality/ArrayContaining.js
@@ -8,6 +8,13 @@ getJasmineRequireObj().ArrayContaining = function(j$) {
       throw new Error('You must provide an array to arrayContaining, not ' + j$.pp(this.sample) + '.');
     }
 
+    // If the actual parameter is not an array, we can fail immediately, since it couldn't
+    // possibly be an "array containing" anything. However, we also want an empty sample
+    // array to match anything, so we need to double-check we aren't in that case
+    if (!j$.isArray_(other) && this.sample.length > 0) {
+      return false;
+    }
+
     for (var i = 0; i < this.sample.length; i++) {
       var item = this.sample[i];
       if (!j$.matchersUtil.contains(other, item, customTesters)) {


### PR DESCRIPTION
If the actual value of a test was a string, this was matching against arrays
that contained the strings. This was due to the use of the contains matcher,
which against string looks for substrings, when it was intended to look for
array elements.

Resolves #1745

<!--- Provide a general summary of your changes in the Title above -->

## Description
I added a quick check to see that the actual value was truly an array, and failed if not. This broke an existing test, "ArrayContaining matches any actual to an empty array". Personally, I disagree with that test -- I think it should be more along the lines of "ArrayContaining matches any actual *array* to an empty array". However, since you carefully called it out specifically with a non-array matching, I presume there's a good design reason to have this, so I added a check to ensure all existing tests passed.

Also, I know this is a fast PR -- the issue hasn't had time for discussion, yet. It may be that this is intended design behavior for arrayContaining (though it was quite shocking to me). Nevertheless, curiosity got me and I had to dig into the jasmine code to figure out why. Thought I would share my findings as a PR.
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

