### PR TITLE
Add trusted types support

### DIFF
--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -1,4 +1,29 @@
 jasmineRequire.HtmlReporter = function(j$) {
+  // This is a no-op if not running with a Trusted Types CSP policy, and
+  // lets tests declare that they trust the way that jasmine creates URLs.
+  //
+  // More info about the proposed Trusted Types standard at
+  // https://github.com/WICG/trusted-types
+  var policy = {
+    createURL: function(s) {
+      return s;
+    }
+  };
+  var trustedTypes = window.trustedTypes || window.TrustedTypes;
+  if (trustedTypes) {
+    policy = trustedTypes.createPolicy('jasmine', policy);
+    if (!policy.createURL) {
+      // Install createURL for newer browsers. Only browsers that
+      //     implement an old version of the spec require createURL.
+      //     Should be safe to delete this policy entirely by
+      //     February 2020.
+      // https://github.com/WICG/trusted-types/pull/204
+      policy.createURL = function(s) {
+        return s;
+      };
+    }
+  }
+
   function ResultsStateBuilder() {
     this.topResults = new j$.ResultsNode({}, '', null);
     this.currentParent = this.topResults;
@@ -66,7 +91,7 @@ jasmineRequire.HtmlReporter = function(j$) {
           { className: 'jasmine-banner' },
           createDom('a', {
             className: 'jasmine-title',
-            href: 'http://jasmine.github.io/',
+            href: policy.createURL('http://jasmine.github.io/'),
             target: '_blank'
           }),
           createDom('span', { className: 'jasmine-version' }, j$.version)
@@ -183,7 +208,7 @@ jasmineRequire.HtmlReporter = function(j$) {
             { className: 'jasmine-bar jasmine-skipped' },
             createDom(
               'a',
-              { href: skippedLink, title: 'Run all specs' },
+              { href: policy.createURL(skippedLink), title: 'Run all specs' },
               skippedMessage
             )
           )
@@ -228,7 +253,7 @@ jasmineRequire.HtmlReporter = function(j$) {
             'a',
             {
               title: 'randomized with seed ' + order.seed,
-              href: seedHref(order.seed)
+              href: policy.createURL(seedHref(order.seed))
             },
             order.seed
           )
@@ -300,7 +325,10 @@ jasmineRequire.HtmlReporter = function(j$) {
             createDom('span', {}, 'Spec List | '),
             createDom(
               'a',
-              { className: 'jasmine-failures-menu', href: '#' },
+              {
+                className: 'jasmine-failures-menu',
+                href: policy.createURL('#')
+              },
               'Failures'
             )
           )
@@ -311,7 +339,10 @@ jasmineRequire.HtmlReporter = function(j$) {
             { className: 'jasmine-menu jasmine-bar jasmine-failure-list' },
             createDom(
               'a',
-              { className: 'jasmine-spec-list-menu', href: '#' },
+              {
+                className: 'jasmine-spec-list-menu',
+                href: policy.createURL('#')
+              },
               'Spec List'
             ),
             createDom('span', {}, ' | Failures ')
@@ -385,7 +416,7 @@ jasmineRequire.HtmlReporter = function(j$) {
               },
               createDom(
                 'a',
-                { href: specHref(resultNode.result) },
+                { href: policy.createURL(specHref(resultNode.result)) },
                 resultNode.result.description
               )
             )
@@ -421,7 +452,7 @@ jasmineRequire.HtmlReporter = function(j$) {
               },
               createDom(
                 'a',
-                { href: specHref(resultNode.result) },
+                { href: policy.createURL(specHref(resultNode.result)) },
                 specDescription
               )
             )
@@ -549,7 +580,10 @@ jasmineRequire.HtmlReporter = function(j$) {
         { className: 'jasmine-description' },
         createDom(
           'a',
-          { title: result.description, href: specHref(result) },
+          {
+            title: result.description,
+            href: policy.createURL(specHref(result))
+          },
           result.description
         )
       );
@@ -559,7 +593,7 @@ jasmineRequire.HtmlReporter = function(j$) {
         wrapper.insertBefore(createTextNode(' > '), wrapper.firstChild);
         suiteLink = createDom(
           'a',
-          { href: suiteHref(suite) },
+          { href: policy.createURL(suiteHref(suite)) },
           suite.result.description
         );
         wrapper.insertBefore(suiteLink, wrapper.firstChild);


### PR DESCRIPTION
## Description
Makes the jasmine html reporter compatible with an enforced Trusted Types policy.

This should only be necessary for a limited time, as the next version of the proposed specification will not require any special code for URLS (except javascript: URLS).

## Motivation and Context

Trusted Types is a proposed extension to CSP that would allow sites to opt into stricter checks for certain DOM APIs, where the server can specify a set of policies that are allowed to create trusted values that may be used with potentially dangerous DOM APIs.

While the it is still only a proposed standard, it is a good time for authors of major libraries and frameworks to test the Trusted Types system to determine if it matches their security needs.

This change declares a policy named "jasmine" which is then used to bless the URLs that Jasmine constructs internally. A testing environment running jasmine in a recent version of Chrome that is running with the flag `--enable-blink-features=TrustedDOMTypes` may send CSP  headers that indicate trust in the "jasmine" policy.

This code should only be necessary for a limited time, because the Trusted Types spec has recently been updated to handle anchor URLs more transparently. However I think this change will still be useful to land now, as it will enable libraries and frameworks to test with Jasmine and the current implementation that's available in Chrome today behind a flag.

More info about the proposed Trusted Types standard at https://github.com/WICG/trusted-type

## How Has This Been Tested?

I've tested this end to end in Chrome 76.0.3809.87 and 77.0.3865.19 with `--enable-blink-features=TrustedDOMTypes`, as well as with other browsers in which this change is a no-op.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

To test this change on CI we'd need a way to send down CSP headers, and to add a Chrome with `--enable-blink-features=TrustedDOMTypes` to the browser matrix. I'm not familiar with configuring sauce or the rest of the jasmine CI infrastructure, but I'm happy to take direction!

Related change in Karma: https://github.com/karma-runner/karma/pull/3360