### PR TITLE
Implement jasmine.clock().asyncTick()

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -933,7 +933,10 @@ getJasmineRequireObj().Env = function(j$) {
     this.clock = new j$.Clock(
       global,
       function() {
-        return new j$.DelayedFunctionScheduler();
+        return new j$.DelayedFunctionScheduler(
+          customPromise || global.Promise,
+          clearStack
+        );
       },
       new j$.MockDate(global)
     );
@@ -2956,6 +2959,27 @@ getJasmineRequireObj().Clock = function() {
       }
     };
 
+    /**
+     * Tick the Clock forward, running any pending microtasks and enqueued
+     * timeouts.
+     * @name Clock#asyncTick
+     * @since 3.5.1
+     * @function
+     * @param {int} millis The number of milliseconds to tick.
+     * @return {Promise}
+     */
+    self.asyncTick = function(millis) {
+      if (installed) {
+        return delayedFunctionScheduler.asyncTick(millis, function(millis) {
+          mockDate.tick(millis);
+        });
+      } else {
+        throw new Error(
+          'Mock clock is not installed, use jasmine.clock().install()'
+        );
+      }
+    };
+
     return self;
 
     function originalTimingFunctionsIntact() {
@@ -3048,7 +3072,7 @@ getJasmineRequireObj().Clock = function() {
 };
 
 getJasmineRequireObj().DelayedFunctionScheduler = function(j$) {
-  function DelayedFunctionScheduler() {
+  function DelayedFunctionScheduler(Promise, clearStack) {
     var self = this;
     var scheduledLookup = [];
     var scheduledFunctions = {};
@@ -3057,11 +3081,13 @@ getJasmineRequireObj().DelayedFunctionScheduler = function(j$) {
     var deletedKeys = [];
 
     self.tick = function(millis, tickDate) {
-      millis = millis || 0;
-      var endTime = currentTime + millis;
+      runScheduledFunctions(millis, tickDate);
+    };
 
-      runScheduledFunctions(endTime, tickDate);
-      currentTime = endTime;
+    self.asyncTick = function(millis, tickDate) {
+      return new Promise(function(resolve) {
+        runScheduledFunctions(millis, tickDate, clearStack, resolve);
+      });
     };
 
     self.scheduleFunction = function(
@@ -3170,55 +3196,136 @@ getJasmineRequireObj().DelayedFunctionScheduler = function(j$) {
       );
     }
 
-    function forEachFunction(funcsToRun, callback) {
-      for (var i = 0; i < funcsToRun.length; ++i) {
-        callback(funcsToRun[i]);
-      }
-    }
-
-    function runScheduledFunctions(endTime, tickDate) {
+    /**
+     * Runs scheduled functions, possibly asynchronously.
+     *
+     * @param {number} millis
+     * @param {function} tickDate A function that advances the date.
+     * @param {function} runMicrotasks For .asyncTick() this function
+     *     should empty the microtask queue, and then call its callback.
+     *     For .tick() no microtasks are run, so this function should simply
+     *     call its callback immediately.
+     * @param {function} onFinish Function to call when we are finished running
+     *     scheduled functions.
+     */
+    function runScheduledFunctions(millis, tickDate, runMicrotasks, onFinish) {
+      millis = millis || 0;
       tickDate = tickDate || function() {};
-      if (scheduledLookup.length === 0 || scheduledLookup[0] > endTime) {
-        tickDate(endTime - currentTime);
-        return;
-      }
+      onFinish = onFinish || function() {};
+      var endTime = currentTime + millis;
 
-      do {
-        deletedKeys = [];
-        var newCurrentTime = scheduledLookup.shift();
-        tickDate(newCurrentTime - currentTime);
+      // Conceptually, this is a do-while loop, with a for loop inside. The
+      // problem is that it needs to execute asynchronously. If this were ES6,
+      // we would do this with async-await. But it's not. Instead this is
+      // manually transpiled as a while loop with a switch statement. This gives
+      // us something like goto in JS.
 
-        currentTime = newCurrentTime;
+      // Variables in the for loop.
+      var i;
+      var funcsToRun;
 
-        var funcsToRun = scheduledFunctions[currentTime];
+      // Start the asynchronous loop.
+      var nextLabel = 'start';
+      return loop();
 
-        delete scheduledFunctions[currentTime];
+      function loop() {
+        while (true) {
+          switch (nextLabel) {
+            case 'start':
+              if (runMicrotasks) {
+                nextLabel = 'after-microtasks-1';
+                return runMicrotasks(loop);
+              }
 
-        forEachFunction(funcsToRun, function(funcToRun) {
-          if (funcToRun.recurring) {
-            reschedule(funcToRun);
+            case 'after-microtasks-1':
+              if (
+                scheduledLookup.length === 0 ||
+                scheduledLookup[0] > endTime
+              ) {
+                tickDate(endTime - currentTime);
+                currentTime = endTime;
+                return onFinish();
+              }
+
+            // DO
+            case 'do-body':
+              deletedKeys = [];
+              var newCurrentTime = scheduledLookup.shift();
+              tickDate(newCurrentTime - currentTime);
+              currentTime = newCurrentTime;
+
+              funcsToRun = scheduledFunctions[currentTime];
+
+              delete scheduledFunctions[currentTime];
+
+              for (i = 0; i < funcsToRun.length; i++) {
+                if (funcsToRun[i].recurring) {
+                  reschedule(funcsToRun[i]);
+                }
+              }
+
+              // FOR INITIALIZATION
+              i = 0;
+            case 'for-body':
+              // FOR CONDITION
+              if (!(i < funcsToRun.length)) {
+                nextLabel = 'for-end';
+                break;
+              }
+
+              var funcToRun = funcsToRun[i];
+              if (j$.util.arrayContains(deletedKeys, funcToRun.timeoutKey)) {
+                // skip a timeoutKey deleted whilst we were running
+                // CONTINUE FOR
+                nextLabel = 'for-increment';
+                break;
+              }
+
+              funcToRun.funcToCall.apply(null, funcToRun.params || []);
+              if (runMicrotasks) {
+                nextLabel = 'after-microtasks-2';
+                return runMicrotasks(loop);
+              }
+
+            case 'after-microtasks-2':
+
+            case 'for-increment':
+              // FOR INCREMENT
+              i++;
+              // END FOR
+              nextLabel = 'for-body';
+              break;
+
+            case 'for-end':
+              deletedKeys = [];
+
+            case 'do-condition':
+              // DO CONDITION
+              if (
+                scheduledLookup.length > 0 &&
+                // checking first if we're out of time prevents setTimeout(0)
+                // scheduled in a funcToRun from forcing an extra iteration
+                currentTime !== endTime &&
+                scheduledLookup[0] <= endTime
+              ) {
+                nextLabel = 'do-body';
+                break;
+              }
+
+            case 'do-end':
+              // END DO
+
+              // ran out of functions to call, but still time left on the clock
+              if (currentTime !== endTime) {
+                tickDate(endTime - currentTime);
+                currentTime = endTime;
+              }
+              return onFinish();
+
+            default:
+              throw new Error('IMPOSSIBLE');
           }
-        });
-
-        forEachFunction(funcsToRun, function(funcToRun) {
-          if (j$.util.arrayContains(deletedKeys, funcToRun.timeoutKey)) {
-            // skip a timeoutKey deleted whilst we were running
-            return;
-          }
-          funcToRun.funcToCall.apply(null, funcToRun.params || []);
-        });
-        deletedKeys = [];
-      } while (
-        scheduledLookup.length > 0 &&
-        // checking first if we're out of time prevents setTimeout(0)
-        // scheduled in a funcToRun from forcing an extra iteration
-        currentTime !== endTime &&
-        scheduledLookup[0] <= endTime
-      );
-
-      // ran out of functions to call, but still time left on the clock
-      if (currentTime !== endTime) {
-        tickDate(endTime - currentTime);
+        }
       }
     }
   }

--- a/spec/core/ClockSpec.js
+++ b/spec/core/ClockSpec.js
@@ -633,7 +633,7 @@ describe('Clock', function() {
 
 describe('Clock (acceptance)', function() {
   function createDelayedFunctionScheduler() {
-    return new jasmineUnderTest.DelayedFunctionScheduler(Promise, setImmediate);
+    return new jasmineUnderTest.DelayedFunctionScheduler(Promise, setTimeout);
   }
 
   it('can run setTimeouts/setIntervals synchronously', function() {

--- a/spec/core/DelayedFunctionSchedulerSpec.js
+++ b/spec/core/DelayedFunctionSchedulerSpec.js
@@ -1,6 +1,10 @@
 describe('DelayedFunctionScheduler', function() {
+  function createDelayedFunctionScheduler() {
+    return new jasmineUnderTest.DelayedFunctionScheduler(Promise, setImmediate);
+  }
+
   it('schedules a function for later execution', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn');
 
     scheduler.scheduleFunction(fn, 0);
@@ -13,7 +17,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('schedules a string for later execution', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       strfn = 'horrible = true;';
 
     scheduler.scheduleFunction(strfn, 0);
@@ -24,7 +28,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('#tick defaults to 0', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn');
 
     scheduler.scheduleFunction(fn, 0);
@@ -37,7 +41,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('defaults delay to 0', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn');
 
     scheduler.scheduleFunction(fn);
@@ -50,7 +54,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('optionally passes params to scheduled functions', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn');
 
     scheduler.scheduleFunction(fn, 0, ['foo', 'bar']);
@@ -63,7 +67,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('scheduled fns can optionally reoccur', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn');
 
     scheduler.scheduleFunction(fn, 20, [], true);
@@ -95,7 +99,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('#removeFunctionWithId removes a previously scheduled function with a given id', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn'),
       timeoutKey;
 
@@ -111,7 +115,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('executes recurring functions interleaved with regular functions in the correct order', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn'),
       recurringCallCount = 0,
       recurring = jasmine.createSpy('recurring').and.callFake(function() {
@@ -132,7 +136,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('schedules a function for later execution during a tick', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn'),
       fnDelay = 10;
 
@@ -148,7 +152,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('#removeFunctionWithId removes a previously scheduled function with a given id during a tick', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn'),
       fnDelay = 10,
       timeoutKey;
@@ -166,7 +170,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('executes recurring functions interleaved with regular functions and functions scheduled during a tick in the correct order', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn'),
       recurringCallCount = 0,
       recurring = jasmine.createSpy('recurring').and.callFake(function() {
@@ -199,7 +203,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('executes recurring functions after rescheduling them', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       recurring = function() {
         expect(scheduler.scheduleFunction).toHaveBeenCalled();
       };
@@ -212,7 +216,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('removes functions during a tick that runs the function', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       spy = jasmine.createSpy('fn'),
       spyAndRemove = jasmine.createSpy('fn'),
       fnDelay = 10,
@@ -233,7 +237,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('removes functions during the first tick that runs the function', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn'),
       fnDelay = 10,
       timeoutKey;
@@ -252,7 +256,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it("does not remove a function that hasn't been added yet", function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       fn = jasmine.createSpy('fn'),
       fnDelay = 10;
 
@@ -267,7 +271,7 @@ describe('DelayedFunctionScheduler', function() {
   });
 
   it('updates the mockDate per scheduled time', function() {
-    var scheduler = new jasmineUnderTest.DelayedFunctionScheduler(),
+    var scheduler = createDelayedFunctionScheduler(),
       tickDate = jasmine.createSpy('tickDate');
 
     scheduler.scheduleFunction(function() {});
@@ -277,5 +281,38 @@ describe('DelayedFunctionScheduler', function() {
 
     expect(tickDate).toHaveBeenCalledWith(0);
     expect(tickDate).toHaveBeenCalledWith(1);
+  });
+
+  it('runs pending microtasks before scheduled functions', async function() {
+    var scheduler = createDelayedFunctionScheduler(),
+      microtask = jasmine.createSpy('microtask'),
+      fn = jasmine.createSpy('fn').and.callThrough(function() {
+        // Verify microtask was called *before* scheduled function.
+        expect(microtask).toHaveBeenCalled();
+      });
+
+    Promise.resolve().then(microtask);
+    scheduler.scheduleFunction(fn);
+
+    expect(microtask).not.toHaveBeenCalled();
+
+    await scheduler.asyncTick();
+
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('runs microtasks enqueued by scheduled functions', async function() {
+    var scheduler = createDelayedFunctionScheduler(),
+      microtask = jasmine.createSpy('microtask');
+
+    scheduler.scheduleFunction(function() {
+      Promise.resolve().then(microtask);
+    });
+
+    expect(microtask).not.toHaveBeenCalled();
+
+    await scheduler.asyncTick();
+
+    expect(microtask).toHaveBeenCalled();
   });
 });

--- a/spec/core/DelayedFunctionSchedulerSpec.js
+++ b/spec/core/DelayedFunctionSchedulerSpec.js
@@ -1,6 +1,6 @@
 describe('DelayedFunctionScheduler', function() {
   function createDelayedFunctionScheduler() {
-    return new jasmineUnderTest.DelayedFunctionScheduler(Promise, setImmediate);
+    return new jasmineUnderTest.DelayedFunctionScheduler(Promise, setTimeout);
   }
 
   it('schedules a function for later execution', function() {

--- a/spec/core/DelayedFunctionSchedulerSpec.js
+++ b/spec/core/DelayedFunctionSchedulerSpec.js
@@ -283,7 +283,7 @@ describe('DelayedFunctionScheduler', function() {
     expect(tickDate).toHaveBeenCalledWith(1);
   });
 
-  it('runs pending microtasks before scheduled functions', async function() {
+  it('runs pending microtasks before scheduled functions', function() {
     var scheduler = createDelayedFunctionScheduler(),
       microtask = jasmine.createSpy('microtask'),
       fn = jasmine.createSpy('fn').and.callThrough(function() {
@@ -296,12 +296,12 @@ describe('DelayedFunctionScheduler', function() {
 
     expect(microtask).not.toHaveBeenCalled();
 
-    await scheduler.asyncTick();
-
-    expect(fn).toHaveBeenCalled();
+    return scheduler.asyncTick().then(function() {
+      expect(fn).toHaveBeenCalled();
+    });
   });
 
-  it('runs microtasks enqueued by scheduled functions', async function() {
+  it('runs microtasks enqueued by scheduled functions', function() {
     var scheduler = createDelayedFunctionScheduler(),
       microtask = jasmine.createSpy('microtask');
 
@@ -311,8 +311,8 @@ describe('DelayedFunctionScheduler', function() {
 
     expect(microtask).not.toHaveBeenCalled();
 
-    await scheduler.asyncTick();
-
-    expect(microtask).toHaveBeenCalled();
+    return scheduler.asyncTick().then(function() {
+      expect(microtask).toHaveBeenCalled();
+    });
   });
 });

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -136,6 +136,27 @@ getJasmineRequireObj().Clock = function() {
       }
     };
 
+    /**
+     * Tick the Clock forward, running any pending microtasks and enqueued
+     * timeouts.
+     * @name Clock#asyncTick
+     * @since 3.5.1
+     * @function
+     * @param {int} millis The number of milliseconds to tick.
+     * @return {Promise}
+     */
+    self.asyncTick = function(millis) {
+      if (installed) {
+        return delayedFunctionScheduler.asyncTick(millis, function(millis) {
+          mockDate.tick(millis);
+        });
+      } else {
+        throw new Error(
+          'Mock clock is not installed, use jasmine.clock().install()'
+        );
+      }
+    };
+
     return self;
 
     function originalTimingFunctionsIntact() {

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -21,7 +21,10 @@ getJasmineRequireObj().Env = function(j$) {
     this.clock = new j$.Clock(
       global,
       function() {
-        return new j$.DelayedFunctionScheduler();
+        return new j$.DelayedFunctionScheduler(
+          customPromise || global.Promise,
+          clearStack
+        );
       },
       new j$.MockDate(global)
     );


### PR DESCRIPTION
## Description

Adds an `.asyncTick()` method to `jasmine.Clock`, and to the internal `DelayedFunctionScheduler`. These are just a slight variation on the existing `.tick()` methods, but they allow microtasks to run.

There is an existing loop in `DelayedFunctionScheduler` for running the scheduled timeouts/intervals.
I just want to make that an async loop, and call clearStack() to run any pending microtasks.
Simple.

Unfortunately, it requires transforming the code.
I changed the existing loop into an async loop, using a state machine with a switch statement. (This is how babel transpiles async-await, although I did this manually.)

## Motivation and Context
Closes #1725 

This makes it possible to test code that uses timeouts in combination with Promises or async-await.

## How Has This Been Tested?

I'm fairly confident that the existing tests verify the transformed loop with the switch statement.
Thus, I've only added a handful of tests that verify microtasks get run.
* one for the initial queue pumping.
* one for the subsequent queue pumping.
* one to verify that setTimeout and asyncTick interact as expected.

Problems:
* At the moment the tests use async-await, but once the review is close to the end, I'll manually convert them from async-await to ES5.
* I have only run this on node.js. I will have to do something different in the browser, and I'm not sure how to handle IE which doesn't even have Promises.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
