### PR TITLE
Fix: Jasmine reports toEqual(0, Number.MIN_VALUE) to be true

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -4321,7 +4321,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       case '[object Number]':
         // `NaN`s are equivalent, but non-reflexive. An `egal` comparison is performed for
         // other numeric values.
-        result = a != +a ? b != +b : (a === 0 ? 1 / a == 1 / b : a == +b);
+        result = a != +a ? b != +b : (a === 0 && b === 0 ? 1 / a == 1 / b : a == +b);
         if (!result) {
           diffBuilder.record(a, b);
         }

--- a/spec/core/matchers/toEqualSpec.js
+++ b/spec/core/matchers/toEqualSpec.js
@@ -334,6 +334,14 @@ describe("toEqual", function() {
     expect(compareEquals(actual, expected).message).toEqual(message);
   });
 
+  it("reports mismatches between 0 and Number.MIN_VALUE", function() {
+    var actual = {x: 0},
+      expected = {x: Number.MIN_VALUE},
+      message = "Expected $.x = 0 to equal 5e-324.";
+
+    expect(compareEquals(actual, expected).message).toEqual(message);
+  });
+
   it("reports mismatches between Errors", function() {
     var actual = {x: new Error("the error you got")},
       expected = {x: new Error("the error you want")},

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -162,7 +162,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       case '[object Number]':
         // `NaN`s are equivalent, but non-reflexive. An `egal` comparison is performed for
         // other numeric values.
-        result = a != +a ? b != +b : (a === 0 ? 1 / a == 1 / b : a == +b);
+        result = a != +a ? b != +b : (a === 0 && b === 0 ? 1 / a == 1 / b : a == +b);
         if (!result) {
           diffBuilder.record(a, b);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The current implementation of toEqual returns an invalid answer for:

```js
toEqual(0, Number.MIN_VALUE)
// expected to be false but was true before the fix
```

Similar to a bug found in Jest https://github.com/facebook/jest/issues/7941

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This bug has been discovered when running property based testing test against Jest. Then I discovered the very same code was part of many other libs including Jasmine.

Please note that following this bug report on Jest, property based tests are now used [within Jest](https://github.com/facebook/jest/blob/86e73f5b22e8a02b5233af78c68ef7318c59e1b3/packages/expect/src/__tests__/matchers-toEqual.property.test.ts#L26) to avoid future issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

