### PR TITLE
Fix #1771 : Method messagePrefixLength now considers other error messages like ReferenceError or TypeError, too

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2019 Pivotal Labs
+Copyright (c) 2008-2020 Pivotal Labs
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -2236,12 +2236,11 @@ getJasmineRequireObj().JsApiReporter = function(j$) {
 };
 
 getJasmineRequireObj().Any = function(j$) {
-
   function Any(expectedObject) {
     if (typeof expectedObject === 'undefined') {
       throw new TypeError(
         'jasmine.any() expects to be passed a constructor function. ' +
-        'Please pass one or use jasmine.anything() to match any object.'
+          'Please pass one or use jasmine.anything() to match any object.'
       );
     }
     this.expectedObject = expectedObject;
@@ -2286,7 +2285,6 @@ getJasmineRequireObj().Any = function(j$) {
 };
 
 getJasmineRequireObj().Anything = function(j$) {
-
   function Anything() {}
 
   Anything.prototype.asymmetricMatch = function(other) {
@@ -2307,7 +2305,11 @@ getJasmineRequireObj().ArrayContaining = function(j$) {
 
   ArrayContaining.prototype.asymmetricMatch = function(other, customTesters) {
     if (!j$.isArray_(this.sample)) {
-      throw new Error('You must provide an array to arrayContaining, not ' + j$.pp(this.sample) + '.');
+      throw new Error(
+        'You must provide an array to arrayContaining, not ' +
+          j$.pp(this.sample) +
+          '.'
+      );
     }
 
     // If the actual parameter is not an array, we can fail immediately, since it couldn't
@@ -2327,22 +2329,28 @@ getJasmineRequireObj().ArrayContaining = function(j$) {
     return true;
   };
 
-  ArrayContaining.prototype.jasmineToString = function () {
-    return '<jasmine.arrayContaining(' + j$.pp(this.sample) +')>';
+  ArrayContaining.prototype.jasmineToString = function() {
+    return '<jasmine.arrayContaining(' + j$.pp(this.sample) + ')>';
   };
 
   return ArrayContaining;
 };
 
 getJasmineRequireObj().ArrayWithExactContents = function(j$) {
-
   function ArrayWithExactContents(sample) {
     this.sample = sample;
   }
 
-  ArrayWithExactContents.prototype.asymmetricMatch = function(other, customTesters) {
+  ArrayWithExactContents.prototype.asymmetricMatch = function(
+    other,
+    customTesters
+  ) {
     if (!j$.isArray_(this.sample)) {
-      throw new Error('You must provide an array to arrayWithExactContents, not ' + j$.pp(this.sample) + '.');
+      throw new Error(
+        'You must provide an array to arrayWithExactContents, not ' +
+          j$.pp(this.sample) +
+          '.'
+      );
     }
 
     if (this.sample.length !== other.length) {
@@ -2366,11 +2374,10 @@ getJasmineRequireObj().ArrayWithExactContents = function(j$) {
   return ArrayWithExactContents;
 };
 
-getJasmineRequireObj().Empty = function (j$) {
-
+getJasmineRequireObj().Empty = function(j$) {
   function Empty() {}
 
-  Empty.prototype.asymmetricMatch = function (other) {
+  Empty.prototype.asymmetricMatch = function(other) {
     if (j$.isString_(other) || j$.isArray_(other) || j$.isTypedArray_(other)) {
       return other.length === 0;
     }
@@ -2385,7 +2392,7 @@ getJasmineRequireObj().Empty = function (j$) {
     return false;
   };
 
-  Empty.prototype.jasmineToString = function () {
+  Empty.prototype.jasmineToString = function() {
     return '<jasmine.empty>';
   };
 
@@ -2393,7 +2400,6 @@ getJasmineRequireObj().Empty = function (j$) {
 };
 
 getJasmineRequireObj().Falsy = function(j$) {
-
   function Falsy() {}
 
   Falsy.prototype.asymmetricMatch = function(other) {
@@ -2410,7 +2416,9 @@ getJasmineRequireObj().Falsy = function(j$) {
 getJasmineRequireObj().MapContaining = function(j$) {
   function MapContaining(sample) {
     if (!j$.isMap(sample)) {
-      throw new Error('You must provide a map to `mapContaining`, not ' + j$.pp(sample));
+      throw new Error(
+        'You must provide a map to `mapContaining`, not ' + j$.pp(sample)
+      );
     }
 
     this.sample = sample;
@@ -2426,8 +2434,8 @@ getJasmineRequireObj().MapContaining = function(j$) {
       var hasMatch = false;
       j$.util.forEachBreakable(other, function(oBreakLoop, oValue, oKey) {
         if (
-          j$.matchersUtil.equals(oKey, key, customTesters)
-          && j$.matchersUtil.equals(oValue, value, customTesters)
+          j$.matchersUtil.equals(oKey, key, customTesters) &&
+          j$.matchersUtil.equals(oValue, value, customTesters)
         ) {
           hasMatch = true;
           oBreakLoop();
@@ -2449,11 +2457,10 @@ getJasmineRequireObj().MapContaining = function(j$) {
   return MapContaining;
 };
 
-getJasmineRequireObj().NotEmpty = function (j$) {
-
+getJasmineRequireObj().NotEmpty = function(j$) {
   function NotEmpty() {}
 
-  NotEmpty.prototype.asymmetricMatch = function (other) {
+  NotEmpty.prototype.asymmetricMatch = function(other) {
     if (j$.isString_(other) || j$.isArray_(other) || j$.isTypedArray_(other)) {
       return other.length !== 0;
     }
@@ -2469,7 +2476,7 @@ getJasmineRequireObj().NotEmpty = function (j$) {
     return false;
   };
 
-  NotEmpty.prototype.jasmineToString = function () {
+  NotEmpty.prototype.jasmineToString = function() {
     return '<jasmine.notEmpty>';
   };
 
@@ -2477,7 +2484,6 @@ getJasmineRequireObj().NotEmpty = function (j$) {
 };
 
 getJasmineRequireObj().ObjectContaining = function(j$) {
-
   function ObjectContaining(sample) {
     this.sample = sample;
   }
@@ -2495,7 +2501,7 @@ getJasmineRequireObj().ObjectContaining = function(j$) {
   }
 
   function hasProperty(obj, property) {
-    if (!obj || typeof(obj) !== 'object') {
+    if (!obj || typeof obj !== 'object') {
       return false;
     }
 
@@ -2507,12 +2513,26 @@ getJasmineRequireObj().ObjectContaining = function(j$) {
   }
 
   ObjectContaining.prototype.asymmetricMatch = function(other, customTesters) {
-    if (typeof(this.sample) !== 'object') { throw new Error('You must provide an object to objectContaining, not \''+this.sample+'\'.'); }
-    if (typeof(other) !== 'object') { return false; }
+    if (typeof this.sample !== 'object') {
+      throw new Error(
+        "You must provide an object to objectContaining, not '" +
+          this.sample +
+          "'."
+      );
+    }
+    if (typeof other !== 'object') {
+      return false;
+    }
 
     for (var property in this.sample) {
-      if (!hasProperty(other, property) ||
-          !j$.matchersUtil.equals(this.sample[property], other[property], customTesters)) {
+      if (
+        !hasProperty(other, property) ||
+        !j$.matchersUtil.equals(
+          this.sample[property],
+          other[property],
+          customTesters
+        )
+      ) {
         return false;
       }
     }
@@ -2529,7 +2549,7 @@ getJasmineRequireObj().ObjectContaining = function(j$) {
     }
 
     var filteredOther = {};
-    Object.keys(this.sample).forEach(function (k) {
+    Object.keys(this.sample).forEach(function(k) {
       // eq short-circuits comparison of objects that have different key sets,
       // so include all keys even if undefined.
       filteredOther[k] = other[k];
@@ -2551,7 +2571,9 @@ getJasmineRequireObj().ObjectContaining = function(j$) {
 getJasmineRequireObj().SetContaining = function(j$) {
   function SetContaining(sample) {
     if (!j$.isSet(sample)) {
-      throw new Error('You must provide a set to `setContaining`, not ' + j$.pp(sample));
+      throw new Error(
+        'You must provide a set to `setContaining`, not ' + j$.pp(sample)
+      );
     }
 
     this.sample = sample;
@@ -2589,7 +2611,6 @@ getJasmineRequireObj().SetContaining = function(j$) {
 };
 
 getJasmineRequireObj().StringMatching = function(j$) {
-
   function StringMatching(expected) {
     if (!j$.isString_(expected) && !j$.isA_('RegExp', expected)) {
       throw new Error('Expected is not a String or a RegExp');
@@ -2610,7 +2631,6 @@ getJasmineRequireObj().StringMatching = function(j$) {
 };
 
 getJasmineRequireObj().Truthy = function(j$) {
-
   function Truthy() {}
 
   Truthy.prototype.asymmetricMatch = function(other) {
@@ -3885,8 +3905,12 @@ getJasmineRequireObj().toBeRejected = function(j$) {
           throw new Error('Expected toBeRejected to be called on a promise.');
         }
         return actual.then(
-          function() { return {pass: false}; },
-          function() { return {pass: true}; }
+          function() {
+            return { pass: false };
+          },
+          function() {
+            return { pass: true };
+          }
         );
       }
     };
@@ -3910,35 +3934,46 @@ getJasmineRequireObj().toBeRejectedWith = function(j$) {
     return {
       compare: function(actualPromise, expectedValue) {
         if (!j$.isPromiseLike(actualPromise)) {
-          throw new Error('Expected toBeRejectedWith to be called on a promise.');
+          throw new Error(
+            'Expected toBeRejectedWith to be called on a promise.'
+          );
         }
 
         function prefix(passed) {
-          return 'Expected a promise ' +
+          return (
+            'Expected a promise ' +
             (passed ? 'not ' : '') +
-            'to be rejected with ' + j$.pp(expectedValue);
+            'to be rejected with ' +
+            j$.pp(expectedValue)
+          );
         }
 
         return actualPromise.then(
           function() {
-          return {
-            pass: false,
-            message: prefix(false) + ' but it was resolved.'
-          };
-        },
-        function(actualValue) {
-          if (util.equals(actualValue, expectedValue, customEqualityTesters)) {
-            return {
-              pass: true,
-              message: prefix(true) + '.'
-            };
-          } else {
             return {
               pass: false,
-              message: prefix(false) + ' but it was rejected with ' + j$.pp(actualValue) + '.'
+              message: prefix(false) + ' but it was resolved.'
             };
+          },
+          function(actualValue) {
+            if (
+              util.equals(actualValue, expectedValue, customEqualityTesters)
+            ) {
+              return {
+                pass: true,
+                message: prefix(true) + '.'
+              };
+            } else {
+              return {
+                pass: false,
+                message:
+                  prefix(false) +
+                  ' but it was rejected with ' +
+                  j$.pp(actualValue) +
+                  '.'
+              };
+            }
           }
-        }
         );
       }
     };
@@ -3965,7 +4000,9 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
     return {
       compare: function(actualPromise, arg1, arg2) {
         if (!j$.isPromiseLike(actualPromise)) {
-          throw new Error('Expected toBeRejectedWithError to be called on a promise.');
+          throw new Error(
+            'Expected toBeRejectedWithError to be called on a promise.'
+          );
         }
 
         var expected = getExpectedFromArgs(arg1, arg2);
@@ -3977,7 +4014,9 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
               message: 'Expected a promise to be rejected but it was resolved.'
             };
           },
-          function(actualValue) { return matchError(actualValue, expected); }
+          function(actualValue) {
+            return matchError(actualValue, expected);
+          }
         );
       }
     };
@@ -3989,16 +4028,25 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
     }
 
     if (!(actual instanceof expected.error)) {
-      return fail(expected, 'rejected with type ' + j$.fnNameFor(actual.constructor));
+      return fail(
+        expected,
+        'rejected with type ' + j$.fnNameFor(actual.constructor)
+      );
     }
 
     var actualMessage = actual.message;
 
-    if (actualMessage === expected.message || typeof expected.message === 'undefined') {
+    if (
+      actualMessage === expected.message ||
+      typeof expected.message === 'undefined'
+    ) {
       return pass(expected);
     }
 
-    if (expected.message instanceof RegExp && expected.message.test(actualMessage)) {
+    if (
+      expected.message instanceof RegExp &&
+      expected.message.test(actualMessage)
+    ) {
       return pass(expected);
     }
 
@@ -4008,17 +4056,24 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
   function pass(expected) {
     return {
       pass: true,
-      message: 'Expected a promise not to be rejected with ' + expected.printValue + ', but it was.'
+      message:
+        'Expected a promise not to be rejected with ' +
+        expected.printValue +
+        ', but it was.'
     };
   }
 
   function fail(expected, message) {
     return {
       pass: false,
-      message: 'Expected a promise to be rejected with ' + expected.printValue + ' but it was ' + message + '.'
+      message:
+        'Expected a promise to be rejected with ' +
+        expected.printValue +
+        ' but it was ' +
+        message +
+        '.'
     };
   }
-
 
   function getExpectedFromArgs(arg1, arg2) {
     var error, message;
@@ -4034,12 +4089,17 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
     return {
       error: error,
       message: message,
-      printValue: j$.fnNameFor(error) + (typeof message === 'undefined' ? '' : ': ' + j$.pp(message))
+      printValue:
+        j$.fnNameFor(error) +
+        (typeof message === 'undefined' ? '' : ': ' + j$.pp(message))
     };
   }
 
   function isErrorConstructor(value) {
-    return typeof value === 'function' && (value === Error || j$.isError_(value.prototype));
+    return (
+      typeof value === 'function' &&
+      (value === Error || j$.isError_(value.prototype))
+    );
   }
 };
 
@@ -4063,8 +4123,12 @@ getJasmineRequireObj().toBeResolved = function(j$) {
         }
 
         return actual.then(
-          function() { return {pass: true}; },
-          function() { return {pass: false}; }
+          function() {
+            return { pass: true };
+          },
+          function() {
+            return { pass: false };
+          }
         );
       }
     };
@@ -4092,14 +4156,19 @@ getJasmineRequireObj().toBeResolvedTo = function(j$) {
         }
 
         function prefix(passed) {
-          return 'Expected a promise ' +
+          return (
+            'Expected a promise ' +
             (passed ? 'not ' : '') +
-            'to be resolved to ' + j$.pp(expectedValue);
+            'to be resolved to ' +
+            j$.pp(expectedValue)
+          );
         }
 
         return actualPromise.then(
           function(actualValue) {
-            if (util.equals(actualValue, expectedValue, customEqualityTesters)) {
+            if (
+              util.equals(actualValue, expectedValue, customEqualityTesters)
+            ) {
               return {
                 pass: true,
                 message: prefix(true) + '.'
@@ -4107,7 +4176,11 @@ getJasmineRequireObj().toBeResolvedTo = function(j$) {
             } else {
               return {
                 pass: false,
-                message: prefix(false) + ' but it was resolved to ' + j$.pp(actualValue) + '.'
+                message:
+                  prefix(false) +
+                  ' but it was resolved to ' +
+                  j$.pp(actualValue) +
+                  '.'
               };
             }
           },
@@ -4126,19 +4199,19 @@ getJasmineRequireObj().toBeResolvedTo = function(j$) {
 getJasmineRequireObj().DiffBuilder = function(j$) {
   return function DiffBuilder() {
     var path = new j$.ObjectPath(),
-        mismatches = [];
+      mismatches = [];
 
     return {
-      record: function (actual, expected, formatter) {
+      record: function(actual, expected, formatter) {
         formatter = formatter || defaultFormatter;
         mismatches.push(formatter(actual, expected, path));
       },
 
-      getMessage: function () {
+      getMessage: function() {
         return mismatches.join('\n');
       },
 
-      withPath: function (pathComponent, block) {
+      withPath: function(pathComponent, block) {
         var oldPath = path;
         path = path.add(pathComponent);
         block();
@@ -4146,13 +4219,16 @@ getJasmineRequireObj().DiffBuilder = function(j$) {
       }
     };
 
-    function defaultFormatter (actual, expected, path) {
-      return 'Expected ' +
-        path + (path.depth() ? ' = ' : '') +
+    function defaultFormatter(actual, expected, path) {
+      return (
+        'Expected ' +
+        path +
+        (path.depth() ? ' = ' : '') +
         j$.pp(actual) +
         ' to equal ' +
         j$.pp(expected) +
-        '.';
+        '.'
+      );
     }
   };
 };
@@ -4170,9 +4246,10 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         return haystack.has(needle);
       }
 
-      if ((Object.prototype.toString.apply(haystack) === '[object Array]') ||
-        (!!haystack && !haystack.indexOf))
-      {
+      if (
+        Object.prototype.toString.apply(haystack) === '[object Array]' ||
+        (!!haystack && !haystack.indexOf)
+      ) {
         for (var i = 0; i < haystack.length; i++) {
           if (equals(haystack[i], needle, customTesters)) {
             return true;
@@ -4190,9 +4267,12 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         isNot = args[1],
         actual = args[2],
         expected = args.slice(3),
-        englishyPredicate = matcherName.replace(/[A-Z]/g, function(s) { return ' ' + s.toLowerCase(); });
+        englishyPredicate = matcherName.replace(/[A-Z]/g, function(s) {
+          return ' ' + s.toLowerCase();
+        });
 
-      var message = 'Expected ' +
+      var message =
+        'Expected ' +
         j$.pp(actual) +
         (isNot ? ' not ' : ' ') +
         englishyPredicate;
@@ -4225,8 +4305,8 @@ getJasmineRequireObj().matchersUtil = function(j$) {
 
   function asymmetricMatch(a, b, aStack, bStack, customTesters, diffBuilder) {
     var asymmetricA = isAsymmetric(a),
-        asymmetricB = isAsymmetric(b),
-        result;
+      asymmetricB = isAsymmetric(b),
+      result;
 
     if (asymmetricA && asymmetricB) {
       return undefined;
@@ -4261,9 +4341,17 @@ getJasmineRequireObj().matchersUtil = function(j$) {
   // Equality function lovingly adapted from isEqual in
   //   [Underscore](http://underscorejs.org)
   function eq(a, b, aStack, bStack, customTesters, diffBuilder) {
-    var result = true, i;
+    var result = true,
+      i;
 
-    var asymmetricResult = asymmetricMatch(a, b, aStack, bStack, customTesters, diffBuilder);
+    var asymmetricResult = asymmetricMatch(
+      a,
+      b,
+      aStack,
+      bStack,
+      customTesters,
+      diffBuilder
+    );
     if (!j$.util.isUndefined(asymmetricResult)) {
       return asymmetricResult;
     }
@@ -4321,7 +4409,8 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       case '[object Number]':
         // `NaN`s are equivalent, but non-reflexive. An `egal` comparison is performed for
         // other numeric values.
-        result = a != +a ? b != +b : (a === 0 && b === 0 ? 1 / a == 1 / b : a == +b);
+        result =
+          a != +a ? b != +b : a === 0 && b === 0 ? 1 / a == 1 / b : a == +b;
         if (!result) {
           diffBuilder.record(a, b);
         }
@@ -4338,10 +4427,12 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         return result;
       // RegExps are compared by their source patterns and flags.
       case '[object RegExp]':
-        return a.source == b.source &&
+        return (
+          a.source == b.source &&
           a.global == b.global &&
           a.multiline == b.multiline &&
-          a.ignoreCase == b.ignoreCase;
+          a.ignoreCase == b.ignoreCase
+        );
     }
     if (typeof a != 'object' || typeof b != 'object') {
       diffBuilder.record(a, b);
@@ -4375,7 +4466,9 @@ getJasmineRequireObj().matchersUtil = function(j$) {
     while (length--) {
       // Linear search. Performance is inversely proportional to the number of
       // unique nested structures.
-      if (aStack[length] == a) { return bStack[length] == b; }
+      if (aStack[length] == a) {
+        return bStack[length] == b;
+      }
     }
     // Add the first object to the stack of traversed objects.
     aStack.push(a);
@@ -4400,7 +4493,15 @@ getJasmineRequireObj().matchersUtil = function(j$) {
             diffBuilder.record(a[i], void 0, actualArrayIsLongerFormatter);
             result = false;
           } else {
-            result = eq(i < aLength ? a[i] : void 0, i < bLength ? b[i] : void 0, aStack, bStack, customTesters, diffBuilder) && result;
+            result =
+              eq(
+                i < aLength ? a[i] : void 0,
+                i < bLength ? b[i] : void 0,
+                aStack,
+                bStack,
+                customTesters,
+                diffBuilder
+              ) && result;
           }
         });
       }
@@ -4415,11 +4516,11 @@ getJasmineRequireObj().matchersUtil = function(j$) {
 
       var keysA = [];
       var keysB = [];
-      a.forEach( function( valueA, keyA ) {
-        keysA.push( keyA );
+      a.forEach(function(valueA, keyA) {
+        keysA.push(keyA);
       });
-      b.forEach( function( valueB, keyB ) {
-        keysB.push( keyB );
+      b.forEach(function(valueB, keyB) {
+        keysB.push(keyB);
       });
 
       // For both sets of keys, check they map to equal values in both maps.
@@ -4440,13 +4541,30 @@ getJasmineRequireObj().matchersUtil = function(j$) {
           // Only use the cmpKey when one of the keys is asymmetric and the corresponding key matches,
           // otherwise explicitly look up the mapKey in the other Map since we want keys with unique
           // obj identity (that are otherwise equal) to not match.
-          if (isAsymmetric(mapKey) || isAsymmetric(cmpKey) &&
-              eq(mapKey, cmpKey, aStack, bStack, customTesters, j$.NullDiffBuilder())) {
+          if (
+            isAsymmetric(mapKey) ||
+            (isAsymmetric(cmpKey) &&
+              eq(
+                mapKey,
+                cmpKey,
+                aStack,
+                bStack,
+                customTesters,
+                j$.NullDiffBuilder()
+              ))
+          ) {
             mapValueB = b.get(cmpKey);
           } else {
             mapValueB = b.get(mapKey);
           }
-          result = eq(mapValueA, mapValueB, aStack, bStack, customTesters, j$.NullDiffBuilder());
+          result = eq(
+            mapValueA,
+            mapValueB,
+            aStack,
+            bStack,
+            customTesters,
+            j$.NullDiffBuilder()
+          );
         }
       }
 
@@ -4461,12 +4579,12 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       }
 
       var valuesA = [];
-      a.forEach( function( valueA ) {
-        valuesA.push( valueA );
+      a.forEach(function(valueA) {
+        valuesA.push(valueA);
       });
       var valuesB = [];
-      b.forEach( function( valueB ) {
-        valuesB.push( valueB );
+      b.forEach(function(valueB) {
+        valuesB.push(valueB);
       });
 
       // For both sets, check they are all contained in the other set
@@ -4490,7 +4608,14 @@ getJasmineRequireObj().matchersUtil = function(j$) {
             otherValue = otherValues[l];
             prevStackSize = baseStack.length;
             // compare by value equality
-            found = eq(baseValue, otherValue, baseStack, otherStack, customTesters, j$.NullDiffBuilder());
+            found = eq(
+              baseValue,
+              otherValue,
+              baseStack,
+              otherStack,
+              customTesters,
+              j$.NullDiffBuilder()
+            );
             if (!found && prevStackSize !== baseStack.length) {
               baseStack.splice(prevStackSize);
               otherStack.splice(prevStackSize);
@@ -4505,22 +4630,26 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         return false;
       }
     } else {
-
       // Objects with different constructors are not equivalent, but `Object`s
       // or `Array`s from different frames are.
-      var aCtor = a.constructor, bCtor = b.constructor;
-      if (aCtor !== bCtor &&
-          isFunction(aCtor) && isFunction(bCtor) &&
-          a instanceof aCtor && b instanceof bCtor &&
-          !(aCtor instanceof aCtor && bCtor instanceof bCtor)) {
-
+      var aCtor = a.constructor,
+        bCtor = b.constructor;
+      if (
+        aCtor !== bCtor &&
+        isFunction(aCtor) &&
+        isFunction(bCtor) &&
+        a instanceof aCtor &&
+        b instanceof bCtor &&
+        !(aCtor instanceof aCtor && bCtor instanceof bCtor)
+      ) {
         diffBuilder.record(a, b, constructorsAreDifferentFormatter);
         return false;
       }
     }
 
     // Deep compare objects.
-    var aKeys = keys(a, className == '[object Array]'), key;
+    var aKeys = keys(a, className == '[object Array]'),
+      key;
     size = aKeys.length;
 
     // Ensure that both objects contain the same number of properties before comparing deep equality.
@@ -4539,7 +4668,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       }
 
       diffBuilder.withPath(key, function() {
-        if(!eq(a[key], b[key], aStack, bStack, customTesters, diffBuilder)) {
+        if (!eq(a[key], b[key], aStack, bStack, customTesters, diffBuilder)) {
           result = false;
         }
       });
@@ -4557,23 +4686,24 @@ getJasmineRequireObj().matchersUtil = function(j$) {
   }
 
   function keys(obj, isArray) {
-    var allKeys = Object.keys ? Object.keys(obj) :
-      (function(o) {
+    var allKeys = Object.keys
+      ? Object.keys(obj)
+      : (function(o) {
           var keys = [];
           for (var key in o) {
-              if (j$.util.has(o, key)) {
-                  keys.push(key);
-              }
+            if (j$.util.has(o, key)) {
+              keys.push(key);
+            }
           }
           return keys;
-      })(obj);
+        })(obj);
 
     if (!isArray) {
       return allKeys;
     }
 
     if (allKeys.length === 0) {
-        return allKeys;
+      return allKeys;
     }
 
     var extraKeys = [];
@@ -4592,21 +4722,25 @@ getJasmineRequireObj().matchersUtil = function(j$) {
 
   function objectKeysAreDifferentFormatter(actual, expected, path) {
     var missingProperties = j$.util.objectDifference(expected, actual),
-        extraProperties = j$.util.objectDifference(actual, expected),
-        missingPropertiesMessage = formatKeyValuePairs(missingProperties),
-        extraPropertiesMessage = formatKeyValuePairs(extraProperties),
-        messages = [];
+      extraProperties = j$.util.objectDifference(actual, expected),
+      missingPropertiesMessage = formatKeyValuePairs(missingProperties),
+      extraPropertiesMessage = formatKeyValuePairs(extraProperties),
+      messages = [];
 
     if (!path.depth()) {
       path = 'object';
     }
 
     if (missingPropertiesMessage.length) {
-      messages.push('Expected ' + path + ' to have properties' + missingPropertiesMessage);
+      messages.push(
+        'Expected ' + path + ' to have properties' + missingPropertiesMessage
+      );
     }
 
     if (extraPropertiesMessage.length) {
-      messages.push('Expected ' + path + ' not to have properties' + extraPropertiesMessage);
+      messages.push(
+        'Expected ' + path + ' not to have properties' + extraPropertiesMessage
+      );
     }
 
     return messages.join('\n');
@@ -4617,17 +4751,25 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       path = 'object';
     }
 
-    return 'Expected ' +
-      path + ' to be a kind of ' +
+    return (
+      'Expected ' +
+      path +
+      ' to be a kind of ' +
       j$.fnNameFor(expected.constructor) +
-      ', but was ' + j$.pp(actual) + '.';
+      ', but was ' +
+      j$.pp(actual) +
+      '.'
+    );
   }
 
   function actualArrayIsLongerFormatter(actual, expected, path) {
-    return 'Unexpected ' +
-      path + (path.depth() ? ' = ' : '') +
+    return (
+      'Unexpected ' +
+      path +
+      (path.depth() ? ' = ' : '') +
       j$.pp(actual) +
-      ' in array.';
+      ' in array.'
+    );
   }
 
   function formatKeyValuePairs(obj) {
@@ -4702,7 +4844,7 @@ getJasmineRequireObj().ObjectPath = function(j$) {
       return '.' + prop;
     }
 
-    return '[\'' + prop + '\']';
+    return "['" + prop + "']";
   }
 
   function map(array, fn) {
@@ -4749,7 +4891,8 @@ getJasmineRequireObj().toBe = function(j$) {
    * expect(thing).toBe(realThing);
    */
   function toBe(util) {
-    var tip = ' Tip: To check for deep equality, use .toEqual() instead of .toBe().';
+    var tip =
+      ' Tip: To check for deep equality, use .toEqual() instead of .toBe().';
 
     return {
       compare: function(actual, expected) {
@@ -4758,7 +4901,9 @@ getJasmineRequireObj().toBe = function(j$) {
         };
 
         if (typeof expected === 'object') {
-          result.message = util.buildFailureMessage('toBe', result.pass, actual, expected) + tip;
+          result.message =
+            util.buildFailureMessage('toBe', result.pass, actual, expected) +
+            tip;
         }
 
         return result;
@@ -4788,8 +4933,13 @@ getJasmineRequireObj().toBeCloseTo = function() {
         }
 
         if (expected === null || actual === null) {
-          throw new Error('Cannot use toBeCloseTo with null. Arguments evaluated to: ' +
-            'expect(' + actual + ').toBeCloseTo(' + expected + ').'
+          throw new Error(
+            'Cannot use toBeCloseTo with null. Arguments evaluated to: ' +
+              'expect(' +
+              actual +
+              ').toBeCloseTo(' +
+              expected +
+              ').'
           );
         }
 
@@ -4820,7 +4970,7 @@ getJasmineRequireObj().toBeDefined = function() {
     return {
       compare: function(actual) {
         return {
-          pass: (void 0 !== actual)
+          pass: void 0 !== actual
         };
       }
     };
@@ -4896,7 +5046,6 @@ getJasmineRequireObj().toBeGreaterThan = function() {
   return toBeGreaterThan;
 };
 
-
 getJasmineRequireObj().toBeGreaterThanOrEqual = function() {
   /**
    * {@link expect} the actual value to be greater than or equal to the expected value.
@@ -4921,7 +5070,10 @@ getJasmineRequireObj().toBeGreaterThanOrEqual = function() {
 };
 
 getJasmineRequireObj().toBeInstanceOf = function(j$) {
-  var usageError =  j$.formatErrorMsg('<toBeInstanceOf>', 'expect(value).toBeInstanceOf(<ConstructorFunction>)');
+  var usageError = j$.formatErrorMsg(
+    '<toBeInstanceOf>',
+    'expect(value).toBeInstanceOf(<ConstructorFunction>)'
+  );
 
   /**
    * {@link expect} the actual to be an instance of the expected class
@@ -4937,27 +5089,40 @@ getJasmineRequireObj().toBeInstanceOf = function(j$) {
   function toBeInstanceOf(util, customEqualityTesters) {
     return {
       compare: function(actual, expected) {
-        var actualType = actual && actual.constructor ? j$.fnNameFor(actual.constructor) : j$.pp(actual),
-            expectedType = expected ? j$.fnNameFor(expected) : j$.pp(expected),
-            expectedMatcher,
-            pass;
+        var actualType =
+            actual && actual.constructor
+              ? j$.fnNameFor(actual.constructor)
+              : j$.pp(actual),
+          expectedType = expected ? j$.fnNameFor(expected) : j$.pp(expected),
+          expectedMatcher,
+          pass;
 
         try {
-            expectedMatcher = new j$.Any(expected);
-            pass = expectedMatcher.asymmetricMatch(actual);
+          expectedMatcher = new j$.Any(expected);
+          pass = expectedMatcher.asymmetricMatch(actual);
         } catch (error) {
-            throw new Error(usageError('Expected value is not a constructor function'));
+          throw new Error(
+            usageError('Expected value is not a constructor function')
+          );
         }
 
         if (pass) {
           return {
             pass: true,
-            message: 'Expected instance of ' + actualType + ' not to be an instance of ' + expectedType
+            message:
+              'Expected instance of ' +
+              actualType +
+              ' not to be an instance of ' +
+              expectedType
           };
         } else {
           return {
             pass: false,
-            message: 'Expected instance of ' + actualType + ' to be an instance of ' + expectedType
+            message:
+              'Expected instance of ' +
+              actualType +
+              ' to be an instance of ' +
+              expectedType
           };
         }
       }
@@ -4979,7 +5144,6 @@ getJasmineRequireObj().toBeLessThan = function() {
    */
   function toBeLessThan() {
     return {
-
       compare: function(actual, expected) {
         return {
           pass: actual < expected
@@ -5003,7 +5167,6 @@ getJasmineRequireObj().toBeLessThanOrEqual = function() {
    */
   function toBeLessThanOrEqual() {
     return {
-
       compare: function(actual, expected) {
         return {
           pass: actual <= expected
@@ -5028,13 +5191,15 @@ getJasmineRequireObj().toBeNaN = function(j$) {
     return {
       compare: function(actual) {
         var result = {
-          pass: (actual !== actual)
+          pass: actual !== actual
         };
 
         if (result.pass) {
           result.message = 'Expected actual not to be NaN.';
         } else {
-          result.message = function() { return 'Expected ' + j$.pp(actual) + ' to be NaN.'; };
+          result.message = function() {
+            return 'Expected ' + j$.pp(actual) + ' to be NaN.';
+          };
         }
 
         return result;
@@ -5058,13 +5223,15 @@ getJasmineRequireObj().toBeNegativeInfinity = function(j$) {
     return {
       compare: function(actual) {
         var result = {
-          pass: (actual === Number.NEGATIVE_INFINITY)
+          pass: actual === Number.NEGATIVE_INFINITY
         };
 
         if (result.pass) {
           result.message = 'Expected actual not to be -Infinity.';
         } else {
-          result.message = function() { return 'Expected ' + j$.pp(actual) + ' to be -Infinity.'; };
+          result.message = function() {
+            return 'Expected ' + j$.pp(actual) + ' to be -Infinity.';
+          };
         }
 
         return result;
@@ -5110,13 +5277,15 @@ getJasmineRequireObj().toBePositiveInfinity = function(j$) {
     return {
       compare: function(actual) {
         var result = {
-          pass: (actual === Number.POSITIVE_INFINITY)
+          pass: actual === Number.POSITIVE_INFINITY
         };
 
         if (result.pass) {
           result.message = 'Expected actual not to be Infinity.';
         } else {
-          result.message = function() { return 'Expected ' + j$.pp(actual) + ' to be Infinity.'; };
+          result.message = function() {
+            return 'Expected ' + j$.pp(actual) + ' to be Infinity.';
+          };
         }
 
         return result;
@@ -5209,7 +5378,6 @@ getJasmineRequireObj().toContain = function() {
 
     return {
       compare: function(actual, expected) {
-
         return {
           pass: util.contains(actual, expected, customEqualityTesters)
         };
@@ -5240,7 +5408,12 @@ getJasmineRequireObj().toEqual = function(j$) {
           },
           diffBuilder = j$.DiffBuilder();
 
-        result.pass = util.equals(actual, expected, customEqualityTesters, diffBuilder);
+        result.pass = util.equals(
+          actual,
+          expected,
+          customEqualityTesters,
+          diffBuilder
+        );
 
         // TODO: only set error message if test fails
         result.message = diffBuilder.getMessage();
@@ -5254,8 +5427,10 @@ getJasmineRequireObj().toEqual = function(j$) {
 };
 
 getJasmineRequireObj().toHaveBeenCalled = function(j$) {
-
-  var getErrorMsg = j$.formatErrorMsg('<toHaveBeenCalled>', 'expect(<spyObj>).toHaveBeenCalled()');
+  var getErrorMsg = j$.formatErrorMsg(
+    '<toHaveBeenCalled>',
+    'expect(<spyObj>).toHaveBeenCalled()'
+  );
 
   /**
    * {@link expect} the actual (a {@link Spy}) to have been called.
@@ -5272,18 +5447,22 @@ getJasmineRequireObj().toHaveBeenCalled = function(j$) {
         var result = {};
 
         if (!j$.isSpy(actual)) {
-          throw new Error(getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.'));
+          throw new Error(
+            getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.')
+          );
         }
 
         if (arguments.length > 1) {
-          throw new Error(getErrorMsg('Does not take arguments, use toHaveBeenCalledWith'));
+          throw new Error(
+            getErrorMsg('Does not take arguments, use toHaveBeenCalledWith')
+          );
         }
 
         result.pass = actual.calls.any();
 
-        result.message = result.pass ?
-          'Expected spy ' + actual.and.identity + ' not to have been called.' :
-          'Expected spy ' + actual.and.identity + ' to have been called.';
+        result.message = result.pass
+          ? 'Expected spy ' + actual.and.identity + ' not to have been called.'
+          : 'Expected spy ' + actual.and.identity + ' to have been called.';
 
         return result;
       }
@@ -5294,8 +5473,10 @@ getJasmineRequireObj().toHaveBeenCalled = function(j$) {
 };
 
 getJasmineRequireObj().toHaveBeenCalledBefore = function(j$) {
-
-  var getErrorMsg = j$.formatErrorMsg('<toHaveBeenCalledBefore>', 'expect(<spyObj>).toHaveBeenCalledBefore(<spyObj>)');
+  var getErrorMsg = j$.formatErrorMsg(
+    '<toHaveBeenCalledBefore>',
+    'expect(<spyObj>).toHaveBeenCalledBefore(<spyObj>)'
+  );
 
   /**
    * {@link expect} the actual value (a {@link Spy}) to have been called before another {@link Spy}.
@@ -5310,20 +5491,26 @@ getJasmineRequireObj().toHaveBeenCalledBefore = function(j$) {
     return {
       compare: function(firstSpy, latterSpy) {
         if (!j$.isSpy(firstSpy)) {
-          throw new Error(getErrorMsg('Expected a spy, but got ' + j$.pp(firstSpy) + '.'));
+          throw new Error(
+            getErrorMsg('Expected a spy, but got ' + j$.pp(firstSpy) + '.')
+          );
         }
         if (!j$.isSpy(latterSpy)) {
-          throw new Error(getErrorMsg('Expected a spy, but got ' + j$.pp(latterSpy) + '.'));
+          throw new Error(
+            getErrorMsg('Expected a spy, but got ' + j$.pp(latterSpy) + '.')
+          );
         }
 
         var result = { pass: false };
 
         if (!firstSpy.calls.count()) {
-          result.message = 'Expected spy ' +  firstSpy.and.identity + ' to have been called.';
+          result.message =
+            'Expected spy ' + firstSpy.and.identity + ' to have been called.';
           return result;
         }
         if (!latterSpy.calls.count()) {
-          result.message = 'Expected spy ' +  latterSpy.and.identity + ' to have been called.';
+          result.message =
+            'Expected spy ' + latterSpy.and.identity + ' to have been called.';
           return result;
         }
 
@@ -5333,17 +5520,36 @@ getJasmineRequireObj().toHaveBeenCalledBefore = function(j$) {
         result.pass = latest1stSpyCall < first2ndSpyCall;
 
         if (result.pass) {
-          result.message = 'Expected spy ' + firstSpy.and.identity + ' to not have been called before spy ' + latterSpy.and.identity + ', but it was';
+          result.message =
+            'Expected spy ' +
+            firstSpy.and.identity +
+            ' to not have been called before spy ' +
+            latterSpy.and.identity +
+            ', but it was';
         } else {
           var first1stSpyCall = firstSpy.calls.first().invocationOrder;
           var latest2ndSpyCall = latterSpy.calls.mostRecent().invocationOrder;
 
-          if(first1stSpyCall < first2ndSpyCall) {
-            result.message = 'Expected latest call to spy ' + firstSpy.and.identity + ' to have been called before first call to spy ' + latterSpy.and.identity + ' (no interleaved calls)';
+          if (first1stSpyCall < first2ndSpyCall) {
+            result.message =
+              'Expected latest call to spy ' +
+              firstSpy.and.identity +
+              ' to have been called before first call to spy ' +
+              latterSpy.and.identity +
+              ' (no interleaved calls)';
           } else if (latest2ndSpyCall > latest1stSpyCall) {
-            result.message = 'Expected first call to spy ' + latterSpy.and.identity + ' to have been called after latest call to spy ' + firstSpy.and.identity + ' (no interleaved calls)';
+            result.message =
+              'Expected first call to spy ' +
+              latterSpy.and.identity +
+              ' to have been called after latest call to spy ' +
+              firstSpy.and.identity +
+              ' (no interleaved calls)';
           } else {
-            result.message = 'Expected spy ' + firstSpy.and.identity + ' to have been called before spy ' + latterSpy.and.identity;
+            result.message =
+              'Expected spy ' +
+              firstSpy.and.identity +
+              ' to have been called before spy ' +
+              latterSpy.and.identity;
           }
         }
 
@@ -5356,8 +5562,10 @@ getJasmineRequireObj().toHaveBeenCalledBefore = function(j$) {
 };
 
 getJasmineRequireObj().toHaveBeenCalledTimes = function(j$) {
-
-  var getErrorMsg = j$.formatErrorMsg('<toHaveBeenCalledTimes>', 'expect(<spyObj>).toHaveBeenCalledTimes(<Number>)');
+  var getErrorMsg = j$.formatErrorMsg(
+    '<toHaveBeenCalledTimes>',
+    'expect(<spyObj>).toHaveBeenCalledTimes(<Number>)'
+  );
 
   /**
    * {@link expect} the actual (a {@link Spy}) to have been called the specified number of times.
@@ -5372,23 +5580,41 @@ getJasmineRequireObj().toHaveBeenCalledTimes = function(j$) {
     return {
       compare: function(actual, expected) {
         if (!j$.isSpy(actual)) {
-          throw new Error(getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.'));
+          throw new Error(
+            getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.')
+          );
         }
 
         var args = Array.prototype.slice.call(arguments, 0),
           result = { pass: false };
 
         if (!j$.isNumber_(expected)) {
-          throw new Error(getErrorMsg('The expected times failed is a required argument and must be a number.'));
+          throw new Error(
+            getErrorMsg(
+              'The expected times failed is a required argument and must be a number.'
+            )
+          );
         }
 
         actual = args[0];
         var calls = actual.calls.count();
         var timesMessage = expected === 1 ? 'once' : expected + ' times';
         result.pass = calls === expected;
-        result.message = result.pass ?
-          'Expected spy ' + actual.and.identity + ' not to have been called ' + timesMessage + '. It was called ' +  calls + ' times.' :
-          'Expected spy ' + actual.and.identity + ' to have been called ' + timesMessage + '. It was called ' +  calls + ' times.';
+        result.message = result.pass
+          ? 'Expected spy ' +
+            actual.and.identity +
+            ' not to have been called ' +
+            timesMessage +
+            '. It was called ' +
+            calls +
+            ' times.'
+          : 'Expected spy ' +
+            actual.and.identity +
+            ' to have been called ' +
+            timesMessage +
+            '. It was called ' +
+            calls +
+            ' times.';
         return result;
       }
     };
@@ -5398,8 +5624,10 @@ getJasmineRequireObj().toHaveBeenCalledTimes = function(j$) {
 };
 
 getJasmineRequireObj().toHaveBeenCalledWith = function(j$) {
-
-  var getErrorMsg = j$.formatErrorMsg('<toHaveBeenCalledWith>', 'expect(<spyObj>).toHaveBeenCalledWith(...arguments)');
+  var getErrorMsg = j$.formatErrorMsg(
+    '<toHaveBeenCalledWith>',
+    'expect(<spyObj>).toHaveBeenCalledWith(...arguments)'
+  );
 
   /**
    * {@link expect} the actual (a {@link Spy}) to have been called with particular arguments at least once.
@@ -5419,43 +5647,82 @@ getJasmineRequireObj().toHaveBeenCalledWith = function(j$) {
           result = { pass: false };
 
         if (!j$.isSpy(actual)) {
-          throw new Error(getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.'));
+          throw new Error(
+            getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.')
+          );
         }
 
         if (!actual.calls.any()) {
           result.message = function() {
-            return 'Expected spy ' + actual.and.identity + ' to have been called with:\n' +
-              '  ' + j$.pp(expectedArgs) +
-              '\nbut it was never called.';
+            return (
+              'Expected spy ' +
+              actual.and.identity +
+              ' to have been called with:\n' +
+              '  ' +
+              j$.pp(expectedArgs) +
+              '\nbut it was never called.'
+            );
           };
           return result;
         }
 
-        if (util.contains(actual.calls.allArgs(), expectedArgs, customEqualityTesters)) {
+        if (
+          util.contains(
+            actual.calls.allArgs(),
+            expectedArgs,
+            customEqualityTesters
+          )
+        ) {
           result.pass = true;
           result.message = function() {
-            return 'Expected spy ' + actual.and.identity + ' not to have been called with:\n' +
-              '  ' + j$.pp(expectedArgs) +
-              '\nbut it was.';
+            return (
+              'Expected spy ' +
+              actual.and.identity +
+              ' not to have been called with:\n' +
+              '  ' +
+              j$.pp(expectedArgs) +
+              '\nbut it was.'
+            );
           };
         } else {
           result.message = function() {
-            var prettyPrintedCalls = actual.calls.allArgs().map(function(argsForCall) {
-              return '  ' + j$.pp(argsForCall);
-            });
+            var prettyPrintedCalls = actual.calls
+              .allArgs()
+              .map(function(argsForCall) {
+                return '  ' + j$.pp(argsForCall);
+              });
 
-            var diffs = actual.calls.allArgs().map(function(argsForCall, callIx) {
-            var diffBuilder = new j$.DiffBuilder();
-              util.equals(argsForCall, expectedArgs, customEqualityTesters, diffBuilder);
-              return 'Call ' + callIx + ':\n' +
-                diffBuilder.getMessage().replace(/^/mg, '  ');
-            });
+            var diffs = actual.calls
+              .allArgs()
+              .map(function(argsForCall, callIx) {
+                var diffBuilder = new j$.DiffBuilder();
+                util.equals(
+                  argsForCall,
+                  expectedArgs,
+                  customEqualityTesters,
+                  diffBuilder
+                );
+                return (
+                  'Call ' +
+                  callIx +
+                  ':\n' +
+                  diffBuilder.getMessage().replace(/^/gm, '  ')
+                );
+              });
 
-            return 'Expected spy ' + actual.and.identity + ' to have been called with:\n' +
-              '  ' + j$.pp(expectedArgs) + '\n' + '' +
+            return (
+              'Expected spy ' +
+              actual.and.identity +
+              ' to have been called with:\n' +
+              '  ' +
+              j$.pp(expectedArgs) +
+              '\n' +
+              '' +
               'but actual calls were:\n' +
-              prettyPrintedCalls.join(',\n') + '.\n\n' +
-              diffs.join('\n');
+              prettyPrintedCalls.join(',\n') +
+              '.\n\n' +
+              diffs.join('\n')
+            );
           };
         }
 
@@ -5494,17 +5761,19 @@ getJasmineRequireObj().toHaveClass = function(j$) {
   }
 
   function isElement(maybeEl) {
-    return maybeEl &&
-      maybeEl.classList &&
-      j$.isFunction_(maybeEl.classList.contains);
+    return (
+      maybeEl && maybeEl.classList && j$.isFunction_(maybeEl.classList.contains)
+    );
   }
 
   return toHaveClass;
 };
 
 getJasmineRequireObj().toMatch = function(j$) {
-
-  var getErrorMsg = j$.formatErrorMsg('<toMatch>', 'expect(<expectation>).toMatch(<string> || <regexp>)');
+  var getErrorMsg = j$.formatErrorMsg(
+    '<toMatch>',
+    'expect(<expectation>).toMatch(<string> || <regexp>)'
+  );
 
   /**
    * {@link expect} the actual value to match a regular expression
@@ -5536,8 +5805,10 @@ getJasmineRequireObj().toMatch = function(j$) {
 };
 
 getJasmineRequireObj().toThrow = function(j$) {
-
-  var getErrorMsg = j$.formatErrorMsg('<toThrow>', 'expect(function() {<expectation>}).toThrow()');
+  var getErrorMsg = j$.formatErrorMsg(
+    '<toThrow>',
+    'expect(function() {<expectation>}).toThrow()'
+  );
 
   /**
    * {@link expect} a function to `throw` something.
@@ -5574,16 +5845,32 @@ getJasmineRequireObj().toThrow = function(j$) {
 
         if (arguments.length == 1) {
           result.pass = true;
-          result.message = function() { return 'Expected function not to throw, but it threw ' + j$.pp(thrown) + '.'; };
+          result.message = function() {
+            return (
+              'Expected function not to throw, but it threw ' +
+              j$.pp(thrown) +
+              '.'
+            );
+          };
 
           return result;
         }
 
         if (util.equals(thrown, expected)) {
           result.pass = true;
-          result.message = function() { return 'Expected function not to throw ' + j$.pp(expected) + '.'; };
+          result.message = function() {
+            return 'Expected function not to throw ' + j$.pp(expected) + '.';
+          };
         } else {
-          result.message = function() { return 'Expected function to throw ' + j$.pp(expected) + ', but it threw ' +  j$.pp(thrown) + '.'; };
+          result.message = function() {
+            return (
+              'Expected function to throw ' +
+              j$.pp(expected) +
+              ', but it threw ' +
+              j$.pp(thrown) +
+              '.'
+            );
+          };
         }
 
         return result;
@@ -5595,8 +5882,10 @@ getJasmineRequireObj().toThrow = function(j$) {
 };
 
 getJasmineRequireObj().toThrowError = function(j$) {
-
-  var getErrorMsg =  j$.formatErrorMsg('<toThrowError>', 'expect(function() {<expectation>}).toThrowError(<ErrorConstructor>, <message>)');
+  var getErrorMsg = j$.formatErrorMsg(
+    '<toThrowError>',
+    'expect(function() {<expectation>}).toThrowError(<ErrorConstructor>, <message>)'
+  );
 
   /**
    * {@link expect} a function to `throw` an `Error`.
@@ -5612,7 +5901,7 @@ getJasmineRequireObj().toThrowError = function(j$) {
    * expect(function() { return 'other'; }).toThrowError(/foo/);
    * expect(function() { return 'other'; }).toThrowError();
    */
-  function toThrowError () {
+  function toThrowError() {
     return {
       compare: function(actual) {
         var errorMatcher = getMatcher.apply(null, arguments),
@@ -5630,7 +5919,13 @@ getJasmineRequireObj().toThrowError = function(j$) {
         }
 
         if (!j$.isError_(thrown)) {
-          return fail(function() { return 'Expected function to throw an Error, but it threw ' + j$.pp(thrown) + '.'; });
+          return fail(function() {
+            return (
+              'Expected function to throw an Error, but it threw ' +
+              j$.pp(thrown) +
+              '.'
+            );
+          });
         }
 
         return errorMatcher.match(thrown);
@@ -5664,7 +5959,11 @@ getJasmineRequireObj().toThrowError = function(j$) {
     function anyMatcher() {
       return {
         match: function(error) {
-          return pass('Expected function not to throw an Error, but it threw ' + j$.fnNameFor(error) + '.');
+          return pass(
+            'Expected function not to throw an Error, but it threw ' +
+              j$.fnNameFor(error) +
+              '.'
+          );
         }
       };
     }
@@ -5672,9 +5971,13 @@ getJasmineRequireObj().toThrowError = function(j$) {
     function exactMatcher(expected, errorType) {
       if (expected && !isStringOrRegExp(expected)) {
         if (errorType) {
-          throw new Error(getErrorMsg('Expected error message is not a string or RegExp.'));
+          throw new Error(
+            getErrorMsg('Expected error message is not a string or RegExp.')
+          );
         } else {
-          throw new Error(getErrorMsg('Expected is not an Error, string, or RegExp.'));
+          throw new Error(
+            getErrorMsg('Expected is not an Error, string, or RegExp.')
+          );
         }
       }
 
@@ -5686,11 +5989,15 @@ getJasmineRequireObj().toThrowError = function(j$) {
         }
       }
 
-      var errorTypeDescription = errorType ? j$.fnNameFor(errorType) : 'an exception';
+      var errorTypeDescription = errorType
+        ? j$.fnNameFor(errorType)
+        : 'an exception';
 
       function thrownDescription(thrown) {
-        var thrownName = errorType ? j$.fnNameFor(thrown.constructor) : 'an exception',
-            thrownMessage = '';
+        var thrownName = errorType
+            ? j$.fnNameFor(thrown.constructor)
+            : 'an exception',
+          thrownMessage = '';
 
         if (expected) {
           thrownMessage = ' with message ' + j$.pp(thrown.message);
@@ -5710,20 +6017,33 @@ getJasmineRequireObj().toThrowError = function(j$) {
       }
 
       function matches(error) {
-        return (errorType === null || error instanceof errorType) &&
-          (expected === null || messageMatch(error.message));
+        return (
+          (errorType === null || error instanceof errorType) &&
+          (expected === null || messageMatch(error.message))
+        );
       }
 
       return {
         match: function(thrown) {
           if (matches(thrown)) {
             return pass(function() {
-              return 'Expected function not to throw ' + errorTypeDescription + messageDescription() + '.';
+              return (
+                'Expected function not to throw ' +
+                errorTypeDescription +
+                messageDescription() +
+                '.'
+              );
             });
           } else {
             return fail(function() {
-              return 'Expected function to throw ' + errorTypeDescription + messageDescription() +
-                ', but it threw ' + thrownDescription(thrown) + '.';
+              return (
+                'Expected function to throw ' +
+                errorTypeDescription +
+                messageDescription() +
+                ', but it threw ' +
+                thrownDescription(thrown) +
+                '.'
+              );
             });
           }
         }
@@ -5731,7 +6051,7 @@ getJasmineRequireObj().toThrowError = function(j$) {
     }
 
     function isStringOrRegExp(potential) {
-      return potential instanceof RegExp || (typeof potential == 'string');
+      return potential instanceof RegExp || typeof potential == 'string';
     }
 
     function isAnErrorType(type) {
@@ -5763,7 +6083,10 @@ getJasmineRequireObj().toThrowError = function(j$) {
 };
 
 getJasmineRequireObj().toThrowMatching = function(j$) {
-  var usageError =  j$.formatErrorMsg('<toThrowMatching>', 'expect(function() {<expectation>}).toThrowMatching(<Predicate>)');
+  var usageError = j$.formatErrorMsg(
+    '<toThrowMatching>',
+    'expect(function() {<expectation>}).toThrowMatching(<Predicate>)'
+  );
 
   /**
    * {@link expect} a function to `throw` something matching a predicate.
@@ -5795,12 +6118,18 @@ getJasmineRequireObj().toThrowMatching = function(j$) {
         }
 
         if (predicate(thrown)) {
-          return pass('Expected function not to throw an exception matching a predicate.');
+          return pass(
+            'Expected function not to throw an exception matching a predicate.'
+          );
         } else {
-            return fail(function() {
-              return 'Expected function to throw an exception matching a predicate, ' +
-                'but it threw ' + thrownDescription(thrown) + '.';
-            });
+          return fail(function() {
+            return (
+              'Expected function to throw an exception matching a predicate, ' +
+              'but it threw ' +
+              thrownDescription(thrown) +
+              '.'
+            );
+          });
         }
       }
     };
@@ -5808,8 +6137,11 @@ getJasmineRequireObj().toThrowMatching = function(j$) {
 
   function thrownDescription(thrown) {
     if (thrown && thrown.constructor) {
-      return j$.fnNameFor(thrown.constructor) + ' with message ' +
-        j$.pp(thrown.message);
+      return (
+        j$.fnNameFor(thrown.constructor) +
+        ' with message ' +
+        j$.pp(thrown.message)
+      );
     } else {
       return j$.pp(thrown);
     }
@@ -7787,7 +8119,7 @@ getJasmineRequireObj().StackTrace = function(j$) {
   }
 
   function messagePrefixLength(message, stackLines) {
-    if (!stackLines[0].match(/^Error/)) {
+    if (!stackLines[0].match(/^w*Error/)) {
       return 0;
     }
 

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2008-2020 Pivotal Labs
+Copyright (c) 2008-2019 Pivotal Labs
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -2236,11 +2236,12 @@ getJasmineRequireObj().JsApiReporter = function(j$) {
 };
 
 getJasmineRequireObj().Any = function(j$) {
+
   function Any(expectedObject) {
     if (typeof expectedObject === 'undefined') {
       throw new TypeError(
         'jasmine.any() expects to be passed a constructor function. ' +
-          'Please pass one or use jasmine.anything() to match any object.'
+        'Please pass one or use jasmine.anything() to match any object.'
       );
     }
     this.expectedObject = expectedObject;
@@ -2285,6 +2286,7 @@ getJasmineRequireObj().Any = function(j$) {
 };
 
 getJasmineRequireObj().Anything = function(j$) {
+
   function Anything() {}
 
   Anything.prototype.asymmetricMatch = function(other) {
@@ -2305,11 +2307,7 @@ getJasmineRequireObj().ArrayContaining = function(j$) {
 
   ArrayContaining.prototype.asymmetricMatch = function(other, customTesters) {
     if (!j$.isArray_(this.sample)) {
-      throw new Error(
-        'You must provide an array to arrayContaining, not ' +
-          j$.pp(this.sample) +
-          '.'
-      );
+      throw new Error('You must provide an array to arrayContaining, not ' + j$.pp(this.sample) + '.');
     }
 
     // If the actual parameter is not an array, we can fail immediately, since it couldn't
@@ -2329,28 +2327,22 @@ getJasmineRequireObj().ArrayContaining = function(j$) {
     return true;
   };
 
-  ArrayContaining.prototype.jasmineToString = function() {
-    return '<jasmine.arrayContaining(' + j$.pp(this.sample) + ')>';
+  ArrayContaining.prototype.jasmineToString = function () {
+    return '<jasmine.arrayContaining(' + j$.pp(this.sample) +')>';
   };
 
   return ArrayContaining;
 };
 
 getJasmineRequireObj().ArrayWithExactContents = function(j$) {
+
   function ArrayWithExactContents(sample) {
     this.sample = sample;
   }
 
-  ArrayWithExactContents.prototype.asymmetricMatch = function(
-    other,
-    customTesters
-  ) {
+  ArrayWithExactContents.prototype.asymmetricMatch = function(other, customTesters) {
     if (!j$.isArray_(this.sample)) {
-      throw new Error(
-        'You must provide an array to arrayWithExactContents, not ' +
-          j$.pp(this.sample) +
-          '.'
-      );
+      throw new Error('You must provide an array to arrayWithExactContents, not ' + j$.pp(this.sample) + '.');
     }
 
     if (this.sample.length !== other.length) {
@@ -2374,10 +2366,11 @@ getJasmineRequireObj().ArrayWithExactContents = function(j$) {
   return ArrayWithExactContents;
 };
 
-getJasmineRequireObj().Empty = function(j$) {
+getJasmineRequireObj().Empty = function (j$) {
+
   function Empty() {}
 
-  Empty.prototype.asymmetricMatch = function(other) {
+  Empty.prototype.asymmetricMatch = function (other) {
     if (j$.isString_(other) || j$.isArray_(other) || j$.isTypedArray_(other)) {
       return other.length === 0;
     }
@@ -2392,7 +2385,7 @@ getJasmineRequireObj().Empty = function(j$) {
     return false;
   };
 
-  Empty.prototype.jasmineToString = function() {
+  Empty.prototype.jasmineToString = function () {
     return '<jasmine.empty>';
   };
 
@@ -2400,6 +2393,7 @@ getJasmineRequireObj().Empty = function(j$) {
 };
 
 getJasmineRequireObj().Falsy = function(j$) {
+
   function Falsy() {}
 
   Falsy.prototype.asymmetricMatch = function(other) {
@@ -2416,9 +2410,7 @@ getJasmineRequireObj().Falsy = function(j$) {
 getJasmineRequireObj().MapContaining = function(j$) {
   function MapContaining(sample) {
     if (!j$.isMap(sample)) {
-      throw new Error(
-        'You must provide a map to `mapContaining`, not ' + j$.pp(sample)
-      );
+      throw new Error('You must provide a map to `mapContaining`, not ' + j$.pp(sample));
     }
 
     this.sample = sample;
@@ -2434,8 +2426,8 @@ getJasmineRequireObj().MapContaining = function(j$) {
       var hasMatch = false;
       j$.util.forEachBreakable(other, function(oBreakLoop, oValue, oKey) {
         if (
-          j$.matchersUtil.equals(oKey, key, customTesters) &&
-          j$.matchersUtil.equals(oValue, value, customTesters)
+          j$.matchersUtil.equals(oKey, key, customTesters)
+          && j$.matchersUtil.equals(oValue, value, customTesters)
         ) {
           hasMatch = true;
           oBreakLoop();
@@ -2457,10 +2449,11 @@ getJasmineRequireObj().MapContaining = function(j$) {
   return MapContaining;
 };
 
-getJasmineRequireObj().NotEmpty = function(j$) {
+getJasmineRequireObj().NotEmpty = function (j$) {
+
   function NotEmpty() {}
 
-  NotEmpty.prototype.asymmetricMatch = function(other) {
+  NotEmpty.prototype.asymmetricMatch = function (other) {
     if (j$.isString_(other) || j$.isArray_(other) || j$.isTypedArray_(other)) {
       return other.length !== 0;
     }
@@ -2476,7 +2469,7 @@ getJasmineRequireObj().NotEmpty = function(j$) {
     return false;
   };
 
-  NotEmpty.prototype.jasmineToString = function() {
+  NotEmpty.prototype.jasmineToString = function () {
     return '<jasmine.notEmpty>';
   };
 
@@ -2484,6 +2477,7 @@ getJasmineRequireObj().NotEmpty = function(j$) {
 };
 
 getJasmineRequireObj().ObjectContaining = function(j$) {
+
   function ObjectContaining(sample) {
     this.sample = sample;
   }
@@ -2501,7 +2495,7 @@ getJasmineRequireObj().ObjectContaining = function(j$) {
   }
 
   function hasProperty(obj, property) {
-    if (!obj || typeof obj !== 'object') {
+    if (!obj || typeof(obj) !== 'object') {
       return false;
     }
 
@@ -2513,26 +2507,12 @@ getJasmineRequireObj().ObjectContaining = function(j$) {
   }
 
   ObjectContaining.prototype.asymmetricMatch = function(other, customTesters) {
-    if (typeof this.sample !== 'object') {
-      throw new Error(
-        "You must provide an object to objectContaining, not '" +
-          this.sample +
-          "'."
-      );
-    }
-    if (typeof other !== 'object') {
-      return false;
-    }
+    if (typeof(this.sample) !== 'object') { throw new Error('You must provide an object to objectContaining, not \''+this.sample+'\'.'); }
+    if (typeof(other) !== 'object') { return false; }
 
     for (var property in this.sample) {
-      if (
-        !hasProperty(other, property) ||
-        !j$.matchersUtil.equals(
-          this.sample[property],
-          other[property],
-          customTesters
-        )
-      ) {
+      if (!hasProperty(other, property) ||
+          !j$.matchersUtil.equals(this.sample[property], other[property], customTesters)) {
         return false;
       }
     }
@@ -2549,7 +2529,7 @@ getJasmineRequireObj().ObjectContaining = function(j$) {
     }
 
     var filteredOther = {};
-    Object.keys(this.sample).forEach(function(k) {
+    Object.keys(this.sample).forEach(function (k) {
       // eq short-circuits comparison of objects that have different key sets,
       // so include all keys even if undefined.
       filteredOther[k] = other[k];
@@ -2571,9 +2551,7 @@ getJasmineRequireObj().ObjectContaining = function(j$) {
 getJasmineRequireObj().SetContaining = function(j$) {
   function SetContaining(sample) {
     if (!j$.isSet(sample)) {
-      throw new Error(
-        'You must provide a set to `setContaining`, not ' + j$.pp(sample)
-      );
+      throw new Error('You must provide a set to `setContaining`, not ' + j$.pp(sample));
     }
 
     this.sample = sample;
@@ -2611,6 +2589,7 @@ getJasmineRequireObj().SetContaining = function(j$) {
 };
 
 getJasmineRequireObj().StringMatching = function(j$) {
+
   function StringMatching(expected) {
     if (!j$.isString_(expected) && !j$.isA_('RegExp', expected)) {
       throw new Error('Expected is not a String or a RegExp');
@@ -2631,6 +2610,7 @@ getJasmineRequireObj().StringMatching = function(j$) {
 };
 
 getJasmineRequireObj().Truthy = function(j$) {
+
   function Truthy() {}
 
   Truthy.prototype.asymmetricMatch = function(other) {
@@ -3905,12 +3885,8 @@ getJasmineRequireObj().toBeRejected = function(j$) {
           throw new Error('Expected toBeRejected to be called on a promise.');
         }
         return actual.then(
-          function() {
-            return { pass: false };
-          },
-          function() {
-            return { pass: true };
-          }
+          function() { return {pass: false}; },
+          function() { return {pass: true}; }
         );
       }
     };
@@ -3934,46 +3910,35 @@ getJasmineRequireObj().toBeRejectedWith = function(j$) {
     return {
       compare: function(actualPromise, expectedValue) {
         if (!j$.isPromiseLike(actualPromise)) {
-          throw new Error(
-            'Expected toBeRejectedWith to be called on a promise.'
-          );
+          throw new Error('Expected toBeRejectedWith to be called on a promise.');
         }
 
         function prefix(passed) {
-          return (
-            'Expected a promise ' +
+          return 'Expected a promise ' +
             (passed ? 'not ' : '') +
-            'to be rejected with ' +
-            j$.pp(expectedValue)
-          );
+            'to be rejected with ' + j$.pp(expectedValue);
         }
 
         return actualPromise.then(
           function() {
+          return {
+            pass: false,
+            message: prefix(false) + ' but it was resolved.'
+          };
+        },
+        function(actualValue) {
+          if (util.equals(actualValue, expectedValue, customEqualityTesters)) {
+            return {
+              pass: true,
+              message: prefix(true) + '.'
+            };
+          } else {
             return {
               pass: false,
-              message: prefix(false) + ' but it was resolved.'
+              message: prefix(false) + ' but it was rejected with ' + j$.pp(actualValue) + '.'
             };
-          },
-          function(actualValue) {
-            if (
-              util.equals(actualValue, expectedValue, customEqualityTesters)
-            ) {
-              return {
-                pass: true,
-                message: prefix(true) + '.'
-              };
-            } else {
-              return {
-                pass: false,
-                message:
-                  prefix(false) +
-                  ' but it was rejected with ' +
-                  j$.pp(actualValue) +
-                  '.'
-              };
-            }
           }
+        }
         );
       }
     };
@@ -4000,9 +3965,7 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
     return {
       compare: function(actualPromise, arg1, arg2) {
         if (!j$.isPromiseLike(actualPromise)) {
-          throw new Error(
-            'Expected toBeRejectedWithError to be called on a promise.'
-          );
+          throw new Error('Expected toBeRejectedWithError to be called on a promise.');
         }
 
         var expected = getExpectedFromArgs(arg1, arg2);
@@ -4014,9 +3977,7 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
               message: 'Expected a promise to be rejected but it was resolved.'
             };
           },
-          function(actualValue) {
-            return matchError(actualValue, expected);
-          }
+          function(actualValue) { return matchError(actualValue, expected); }
         );
       }
     };
@@ -4028,25 +3989,16 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
     }
 
     if (!(actual instanceof expected.error)) {
-      return fail(
-        expected,
-        'rejected with type ' + j$.fnNameFor(actual.constructor)
-      );
+      return fail(expected, 'rejected with type ' + j$.fnNameFor(actual.constructor));
     }
 
     var actualMessage = actual.message;
 
-    if (
-      actualMessage === expected.message ||
-      typeof expected.message === 'undefined'
-    ) {
+    if (actualMessage === expected.message || typeof expected.message === 'undefined') {
       return pass(expected);
     }
 
-    if (
-      expected.message instanceof RegExp &&
-      expected.message.test(actualMessage)
-    ) {
+    if (expected.message instanceof RegExp && expected.message.test(actualMessage)) {
       return pass(expected);
     }
 
@@ -4056,24 +4008,17 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
   function pass(expected) {
     return {
       pass: true,
-      message:
-        'Expected a promise not to be rejected with ' +
-        expected.printValue +
-        ', but it was.'
+      message: 'Expected a promise not to be rejected with ' + expected.printValue + ', but it was.'
     };
   }
 
   function fail(expected, message) {
     return {
       pass: false,
-      message:
-        'Expected a promise to be rejected with ' +
-        expected.printValue +
-        ' but it was ' +
-        message +
-        '.'
+      message: 'Expected a promise to be rejected with ' + expected.printValue + ' but it was ' + message + '.'
     };
   }
+
 
   function getExpectedFromArgs(arg1, arg2) {
     var error, message;
@@ -4089,17 +4034,12 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
     return {
       error: error,
       message: message,
-      printValue:
-        j$.fnNameFor(error) +
-        (typeof message === 'undefined' ? '' : ': ' + j$.pp(message))
+      printValue: j$.fnNameFor(error) + (typeof message === 'undefined' ? '' : ': ' + j$.pp(message))
     };
   }
 
   function isErrorConstructor(value) {
-    return (
-      typeof value === 'function' &&
-      (value === Error || j$.isError_(value.prototype))
-    );
+    return typeof value === 'function' && (value === Error || j$.isError_(value.prototype));
   }
 };
 
@@ -4123,12 +4063,8 @@ getJasmineRequireObj().toBeResolved = function(j$) {
         }
 
         return actual.then(
-          function() {
-            return { pass: true };
-          },
-          function() {
-            return { pass: false };
-          }
+          function() { return {pass: true}; },
+          function() { return {pass: false}; }
         );
       }
     };
@@ -4156,19 +4092,14 @@ getJasmineRequireObj().toBeResolvedTo = function(j$) {
         }
 
         function prefix(passed) {
-          return (
-            'Expected a promise ' +
+          return 'Expected a promise ' +
             (passed ? 'not ' : '') +
-            'to be resolved to ' +
-            j$.pp(expectedValue)
-          );
+            'to be resolved to ' + j$.pp(expectedValue);
         }
 
         return actualPromise.then(
           function(actualValue) {
-            if (
-              util.equals(actualValue, expectedValue, customEqualityTesters)
-            ) {
+            if (util.equals(actualValue, expectedValue, customEqualityTesters)) {
               return {
                 pass: true,
                 message: prefix(true) + '.'
@@ -4176,11 +4107,7 @@ getJasmineRequireObj().toBeResolvedTo = function(j$) {
             } else {
               return {
                 pass: false,
-                message:
-                  prefix(false) +
-                  ' but it was resolved to ' +
-                  j$.pp(actualValue) +
-                  '.'
+                message: prefix(false) + ' but it was resolved to ' + j$.pp(actualValue) + '.'
               };
             }
           },
@@ -4199,19 +4126,19 @@ getJasmineRequireObj().toBeResolvedTo = function(j$) {
 getJasmineRequireObj().DiffBuilder = function(j$) {
   return function DiffBuilder() {
     var path = new j$.ObjectPath(),
-      mismatches = [];
+        mismatches = [];
 
     return {
-      record: function(actual, expected, formatter) {
+      record: function (actual, expected, formatter) {
         formatter = formatter || defaultFormatter;
         mismatches.push(formatter(actual, expected, path));
       },
 
-      getMessage: function() {
+      getMessage: function () {
         return mismatches.join('\n');
       },
 
-      withPath: function(pathComponent, block) {
+      withPath: function (pathComponent, block) {
         var oldPath = path;
         path = path.add(pathComponent);
         block();
@@ -4219,16 +4146,13 @@ getJasmineRequireObj().DiffBuilder = function(j$) {
       }
     };
 
-    function defaultFormatter(actual, expected, path) {
-      return (
-        'Expected ' +
-        path +
-        (path.depth() ? ' = ' : '') +
+    function defaultFormatter (actual, expected, path) {
+      return 'Expected ' +
+        path + (path.depth() ? ' = ' : '') +
         j$.pp(actual) +
         ' to equal ' +
         j$.pp(expected) +
-        '.'
-      );
+        '.';
     }
   };
 };
@@ -4246,10 +4170,9 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         return haystack.has(needle);
       }
 
-      if (
-        Object.prototype.toString.apply(haystack) === '[object Array]' ||
-        (!!haystack && !haystack.indexOf)
-      ) {
+      if ((Object.prototype.toString.apply(haystack) === '[object Array]') ||
+        (!!haystack && !haystack.indexOf))
+      {
         for (var i = 0; i < haystack.length; i++) {
           if (equals(haystack[i], needle, customTesters)) {
             return true;
@@ -4267,12 +4190,9 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         isNot = args[1],
         actual = args[2],
         expected = args.slice(3),
-        englishyPredicate = matcherName.replace(/[A-Z]/g, function(s) {
-          return ' ' + s.toLowerCase();
-        });
+        englishyPredicate = matcherName.replace(/[A-Z]/g, function(s) { return ' ' + s.toLowerCase(); });
 
-      var message =
-        'Expected ' +
+      var message = 'Expected ' +
         j$.pp(actual) +
         (isNot ? ' not ' : ' ') +
         englishyPredicate;
@@ -4305,8 +4225,8 @@ getJasmineRequireObj().matchersUtil = function(j$) {
 
   function asymmetricMatch(a, b, aStack, bStack, customTesters, diffBuilder) {
     var asymmetricA = isAsymmetric(a),
-      asymmetricB = isAsymmetric(b),
-      result;
+        asymmetricB = isAsymmetric(b),
+        result;
 
     if (asymmetricA && asymmetricB) {
       return undefined;
@@ -4341,17 +4261,9 @@ getJasmineRequireObj().matchersUtil = function(j$) {
   // Equality function lovingly adapted from isEqual in
   //   [Underscore](http://underscorejs.org)
   function eq(a, b, aStack, bStack, customTesters, diffBuilder) {
-    var result = true,
-      i;
+    var result = true, i;
 
-    var asymmetricResult = asymmetricMatch(
-      a,
-      b,
-      aStack,
-      bStack,
-      customTesters,
-      diffBuilder
-    );
+    var asymmetricResult = asymmetricMatch(a, b, aStack, bStack, customTesters, diffBuilder);
     if (!j$.util.isUndefined(asymmetricResult)) {
       return asymmetricResult;
     }
@@ -4409,8 +4321,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       case '[object Number]':
         // `NaN`s are equivalent, but non-reflexive. An `egal` comparison is performed for
         // other numeric values.
-        result =
-          a != +a ? b != +b : a === 0 && b === 0 ? 1 / a == 1 / b : a == +b;
+        result = a != +a ? b != +b : (a === 0 && b === 0 ? 1 / a == 1 / b : a == +b);
         if (!result) {
           diffBuilder.record(a, b);
         }
@@ -4427,12 +4338,10 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         return result;
       // RegExps are compared by their source patterns and flags.
       case '[object RegExp]':
-        return (
-          a.source == b.source &&
+        return a.source == b.source &&
           a.global == b.global &&
           a.multiline == b.multiline &&
-          a.ignoreCase == b.ignoreCase
-        );
+          a.ignoreCase == b.ignoreCase;
     }
     if (typeof a != 'object' || typeof b != 'object') {
       diffBuilder.record(a, b);
@@ -4466,9 +4375,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
     while (length--) {
       // Linear search. Performance is inversely proportional to the number of
       // unique nested structures.
-      if (aStack[length] == a) {
-        return bStack[length] == b;
-      }
+      if (aStack[length] == a) { return bStack[length] == b; }
     }
     // Add the first object to the stack of traversed objects.
     aStack.push(a);
@@ -4493,15 +4400,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
             diffBuilder.record(a[i], void 0, actualArrayIsLongerFormatter);
             result = false;
           } else {
-            result =
-              eq(
-                i < aLength ? a[i] : void 0,
-                i < bLength ? b[i] : void 0,
-                aStack,
-                bStack,
-                customTesters,
-                diffBuilder
-              ) && result;
+            result = eq(i < aLength ? a[i] : void 0, i < bLength ? b[i] : void 0, aStack, bStack, customTesters, diffBuilder) && result;
           }
         });
       }
@@ -4516,11 +4415,11 @@ getJasmineRequireObj().matchersUtil = function(j$) {
 
       var keysA = [];
       var keysB = [];
-      a.forEach(function(valueA, keyA) {
-        keysA.push(keyA);
+      a.forEach( function( valueA, keyA ) {
+        keysA.push( keyA );
       });
-      b.forEach(function(valueB, keyB) {
-        keysB.push(keyB);
+      b.forEach( function( valueB, keyB ) {
+        keysB.push( keyB );
       });
 
       // For both sets of keys, check they map to equal values in both maps.
@@ -4541,30 +4440,13 @@ getJasmineRequireObj().matchersUtil = function(j$) {
           // Only use the cmpKey when one of the keys is asymmetric and the corresponding key matches,
           // otherwise explicitly look up the mapKey in the other Map since we want keys with unique
           // obj identity (that are otherwise equal) to not match.
-          if (
-            isAsymmetric(mapKey) ||
-            (isAsymmetric(cmpKey) &&
-              eq(
-                mapKey,
-                cmpKey,
-                aStack,
-                bStack,
-                customTesters,
-                j$.NullDiffBuilder()
-              ))
-          ) {
+          if (isAsymmetric(mapKey) || isAsymmetric(cmpKey) &&
+              eq(mapKey, cmpKey, aStack, bStack, customTesters, j$.NullDiffBuilder())) {
             mapValueB = b.get(cmpKey);
           } else {
             mapValueB = b.get(mapKey);
           }
-          result = eq(
-            mapValueA,
-            mapValueB,
-            aStack,
-            bStack,
-            customTesters,
-            j$.NullDiffBuilder()
-          );
+          result = eq(mapValueA, mapValueB, aStack, bStack, customTesters, j$.NullDiffBuilder());
         }
       }
 
@@ -4579,12 +4461,12 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       }
 
       var valuesA = [];
-      a.forEach(function(valueA) {
-        valuesA.push(valueA);
+      a.forEach( function( valueA ) {
+        valuesA.push( valueA );
       });
       var valuesB = [];
-      b.forEach(function(valueB) {
-        valuesB.push(valueB);
+      b.forEach( function( valueB ) {
+        valuesB.push( valueB );
       });
 
       // For both sets, check they are all contained in the other set
@@ -4608,14 +4490,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
             otherValue = otherValues[l];
             prevStackSize = baseStack.length;
             // compare by value equality
-            found = eq(
-              baseValue,
-              otherValue,
-              baseStack,
-              otherStack,
-              customTesters,
-              j$.NullDiffBuilder()
-            );
+            found = eq(baseValue, otherValue, baseStack, otherStack, customTesters, j$.NullDiffBuilder());
             if (!found && prevStackSize !== baseStack.length) {
               baseStack.splice(prevStackSize);
               otherStack.splice(prevStackSize);
@@ -4630,26 +4505,22 @@ getJasmineRequireObj().matchersUtil = function(j$) {
         return false;
       }
     } else {
+
       // Objects with different constructors are not equivalent, but `Object`s
       // or `Array`s from different frames are.
-      var aCtor = a.constructor,
-        bCtor = b.constructor;
-      if (
-        aCtor !== bCtor &&
-        isFunction(aCtor) &&
-        isFunction(bCtor) &&
-        a instanceof aCtor &&
-        b instanceof bCtor &&
-        !(aCtor instanceof aCtor && bCtor instanceof bCtor)
-      ) {
+      var aCtor = a.constructor, bCtor = b.constructor;
+      if (aCtor !== bCtor &&
+          isFunction(aCtor) && isFunction(bCtor) &&
+          a instanceof aCtor && b instanceof bCtor &&
+          !(aCtor instanceof aCtor && bCtor instanceof bCtor)) {
+
         diffBuilder.record(a, b, constructorsAreDifferentFormatter);
         return false;
       }
     }
 
     // Deep compare objects.
-    var aKeys = keys(a, className == '[object Array]'),
-      key;
+    var aKeys = keys(a, className == '[object Array]'), key;
     size = aKeys.length;
 
     // Ensure that both objects contain the same number of properties before comparing deep equality.
@@ -4668,7 +4539,7 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       }
 
       diffBuilder.withPath(key, function() {
-        if (!eq(a[key], b[key], aStack, bStack, customTesters, diffBuilder)) {
+        if(!eq(a[key], b[key], aStack, bStack, customTesters, diffBuilder)) {
           result = false;
         }
       });
@@ -4686,24 +4557,23 @@ getJasmineRequireObj().matchersUtil = function(j$) {
   }
 
   function keys(obj, isArray) {
-    var allKeys = Object.keys
-      ? Object.keys(obj)
-      : (function(o) {
+    var allKeys = Object.keys ? Object.keys(obj) :
+      (function(o) {
           var keys = [];
           for (var key in o) {
-            if (j$.util.has(o, key)) {
-              keys.push(key);
-            }
+              if (j$.util.has(o, key)) {
+                  keys.push(key);
+              }
           }
           return keys;
-        })(obj);
+      })(obj);
 
     if (!isArray) {
       return allKeys;
     }
 
     if (allKeys.length === 0) {
-      return allKeys;
+        return allKeys;
     }
 
     var extraKeys = [];
@@ -4722,25 +4592,21 @@ getJasmineRequireObj().matchersUtil = function(j$) {
 
   function objectKeysAreDifferentFormatter(actual, expected, path) {
     var missingProperties = j$.util.objectDifference(expected, actual),
-      extraProperties = j$.util.objectDifference(actual, expected),
-      missingPropertiesMessage = formatKeyValuePairs(missingProperties),
-      extraPropertiesMessage = formatKeyValuePairs(extraProperties),
-      messages = [];
+        extraProperties = j$.util.objectDifference(actual, expected),
+        missingPropertiesMessage = formatKeyValuePairs(missingProperties),
+        extraPropertiesMessage = formatKeyValuePairs(extraProperties),
+        messages = [];
 
     if (!path.depth()) {
       path = 'object';
     }
 
     if (missingPropertiesMessage.length) {
-      messages.push(
-        'Expected ' + path + ' to have properties' + missingPropertiesMessage
-      );
+      messages.push('Expected ' + path + ' to have properties' + missingPropertiesMessage);
     }
 
     if (extraPropertiesMessage.length) {
-      messages.push(
-        'Expected ' + path + ' not to have properties' + extraPropertiesMessage
-      );
+      messages.push('Expected ' + path + ' not to have properties' + extraPropertiesMessage);
     }
 
     return messages.join('\n');
@@ -4751,25 +4617,17 @@ getJasmineRequireObj().matchersUtil = function(j$) {
       path = 'object';
     }
 
-    return (
-      'Expected ' +
-      path +
-      ' to be a kind of ' +
+    return 'Expected ' +
+      path + ' to be a kind of ' +
       j$.fnNameFor(expected.constructor) +
-      ', but was ' +
-      j$.pp(actual) +
-      '.'
-    );
+      ', but was ' + j$.pp(actual) + '.';
   }
 
   function actualArrayIsLongerFormatter(actual, expected, path) {
-    return (
-      'Unexpected ' +
-      path +
-      (path.depth() ? ' = ' : '') +
+    return 'Unexpected ' +
+      path + (path.depth() ? ' = ' : '') +
       j$.pp(actual) +
-      ' in array.'
-    );
+      ' in array.';
   }
 
   function formatKeyValuePairs(obj) {
@@ -4844,7 +4702,7 @@ getJasmineRequireObj().ObjectPath = function(j$) {
       return '.' + prop;
     }
 
-    return "['" + prop + "']";
+    return '[\'' + prop + '\']';
   }
 
   function map(array, fn) {
@@ -4891,8 +4749,7 @@ getJasmineRequireObj().toBe = function(j$) {
    * expect(thing).toBe(realThing);
    */
   function toBe(util) {
-    var tip =
-      ' Tip: To check for deep equality, use .toEqual() instead of .toBe().';
+    var tip = ' Tip: To check for deep equality, use .toEqual() instead of .toBe().';
 
     return {
       compare: function(actual, expected) {
@@ -4901,9 +4758,7 @@ getJasmineRequireObj().toBe = function(j$) {
         };
 
         if (typeof expected === 'object') {
-          result.message =
-            util.buildFailureMessage('toBe', result.pass, actual, expected) +
-            tip;
+          result.message = util.buildFailureMessage('toBe', result.pass, actual, expected) + tip;
         }
 
         return result;
@@ -4933,13 +4788,8 @@ getJasmineRequireObj().toBeCloseTo = function() {
         }
 
         if (expected === null || actual === null) {
-          throw new Error(
-            'Cannot use toBeCloseTo with null. Arguments evaluated to: ' +
-              'expect(' +
-              actual +
-              ').toBeCloseTo(' +
-              expected +
-              ').'
+          throw new Error('Cannot use toBeCloseTo with null. Arguments evaluated to: ' +
+            'expect(' + actual + ').toBeCloseTo(' + expected + ').'
           );
         }
 
@@ -4970,7 +4820,7 @@ getJasmineRequireObj().toBeDefined = function() {
     return {
       compare: function(actual) {
         return {
-          pass: void 0 !== actual
+          pass: (void 0 !== actual)
         };
       }
     };
@@ -5046,6 +4896,7 @@ getJasmineRequireObj().toBeGreaterThan = function() {
   return toBeGreaterThan;
 };
 
+
 getJasmineRequireObj().toBeGreaterThanOrEqual = function() {
   /**
    * {@link expect} the actual value to be greater than or equal to the expected value.
@@ -5070,10 +4921,7 @@ getJasmineRequireObj().toBeGreaterThanOrEqual = function() {
 };
 
 getJasmineRequireObj().toBeInstanceOf = function(j$) {
-  var usageError = j$.formatErrorMsg(
-    '<toBeInstanceOf>',
-    'expect(value).toBeInstanceOf(<ConstructorFunction>)'
-  );
+  var usageError =  j$.formatErrorMsg('<toBeInstanceOf>', 'expect(value).toBeInstanceOf(<ConstructorFunction>)');
 
   /**
    * {@link expect} the actual to be an instance of the expected class
@@ -5089,40 +4937,27 @@ getJasmineRequireObj().toBeInstanceOf = function(j$) {
   function toBeInstanceOf(util, customEqualityTesters) {
     return {
       compare: function(actual, expected) {
-        var actualType =
-            actual && actual.constructor
-              ? j$.fnNameFor(actual.constructor)
-              : j$.pp(actual),
-          expectedType = expected ? j$.fnNameFor(expected) : j$.pp(expected),
-          expectedMatcher,
-          pass;
+        var actualType = actual && actual.constructor ? j$.fnNameFor(actual.constructor) : j$.pp(actual),
+            expectedType = expected ? j$.fnNameFor(expected) : j$.pp(expected),
+            expectedMatcher,
+            pass;
 
         try {
-          expectedMatcher = new j$.Any(expected);
-          pass = expectedMatcher.asymmetricMatch(actual);
+            expectedMatcher = new j$.Any(expected);
+            pass = expectedMatcher.asymmetricMatch(actual);
         } catch (error) {
-          throw new Error(
-            usageError('Expected value is not a constructor function')
-          );
+            throw new Error(usageError('Expected value is not a constructor function'));
         }
 
         if (pass) {
           return {
             pass: true,
-            message:
-              'Expected instance of ' +
-              actualType +
-              ' not to be an instance of ' +
-              expectedType
+            message: 'Expected instance of ' + actualType + ' not to be an instance of ' + expectedType
           };
         } else {
           return {
             pass: false,
-            message:
-              'Expected instance of ' +
-              actualType +
-              ' to be an instance of ' +
-              expectedType
+            message: 'Expected instance of ' + actualType + ' to be an instance of ' + expectedType
           };
         }
       }
@@ -5144,6 +4979,7 @@ getJasmineRequireObj().toBeLessThan = function() {
    */
   function toBeLessThan() {
     return {
+
       compare: function(actual, expected) {
         return {
           pass: actual < expected
@@ -5167,6 +5003,7 @@ getJasmineRequireObj().toBeLessThanOrEqual = function() {
    */
   function toBeLessThanOrEqual() {
     return {
+
       compare: function(actual, expected) {
         return {
           pass: actual <= expected
@@ -5191,15 +5028,13 @@ getJasmineRequireObj().toBeNaN = function(j$) {
     return {
       compare: function(actual) {
         var result = {
-          pass: actual !== actual
+          pass: (actual !== actual)
         };
 
         if (result.pass) {
           result.message = 'Expected actual not to be NaN.';
         } else {
-          result.message = function() {
-            return 'Expected ' + j$.pp(actual) + ' to be NaN.';
-          };
+          result.message = function() { return 'Expected ' + j$.pp(actual) + ' to be NaN.'; };
         }
 
         return result;
@@ -5223,15 +5058,13 @@ getJasmineRequireObj().toBeNegativeInfinity = function(j$) {
     return {
       compare: function(actual) {
         var result = {
-          pass: actual === Number.NEGATIVE_INFINITY
+          pass: (actual === Number.NEGATIVE_INFINITY)
         };
 
         if (result.pass) {
           result.message = 'Expected actual not to be -Infinity.';
         } else {
-          result.message = function() {
-            return 'Expected ' + j$.pp(actual) + ' to be -Infinity.';
-          };
+          result.message = function() { return 'Expected ' + j$.pp(actual) + ' to be -Infinity.'; };
         }
 
         return result;
@@ -5277,15 +5110,13 @@ getJasmineRequireObj().toBePositiveInfinity = function(j$) {
     return {
       compare: function(actual) {
         var result = {
-          pass: actual === Number.POSITIVE_INFINITY
+          pass: (actual === Number.POSITIVE_INFINITY)
         };
 
         if (result.pass) {
           result.message = 'Expected actual not to be Infinity.';
         } else {
-          result.message = function() {
-            return 'Expected ' + j$.pp(actual) + ' to be Infinity.';
-          };
+          result.message = function() { return 'Expected ' + j$.pp(actual) + ' to be Infinity.'; };
         }
 
         return result;
@@ -5378,6 +5209,7 @@ getJasmineRequireObj().toContain = function() {
 
     return {
       compare: function(actual, expected) {
+
         return {
           pass: util.contains(actual, expected, customEqualityTesters)
         };
@@ -5408,12 +5240,7 @@ getJasmineRequireObj().toEqual = function(j$) {
           },
           diffBuilder = j$.DiffBuilder();
 
-        result.pass = util.equals(
-          actual,
-          expected,
-          customEqualityTesters,
-          diffBuilder
-        );
+        result.pass = util.equals(actual, expected, customEqualityTesters, diffBuilder);
 
         // TODO: only set error message if test fails
         result.message = diffBuilder.getMessage();
@@ -5427,10 +5254,8 @@ getJasmineRequireObj().toEqual = function(j$) {
 };
 
 getJasmineRequireObj().toHaveBeenCalled = function(j$) {
-  var getErrorMsg = j$.formatErrorMsg(
-    '<toHaveBeenCalled>',
-    'expect(<spyObj>).toHaveBeenCalled()'
-  );
+
+  var getErrorMsg = j$.formatErrorMsg('<toHaveBeenCalled>', 'expect(<spyObj>).toHaveBeenCalled()');
 
   /**
    * {@link expect} the actual (a {@link Spy}) to have been called.
@@ -5447,22 +5272,18 @@ getJasmineRequireObj().toHaveBeenCalled = function(j$) {
         var result = {};
 
         if (!j$.isSpy(actual)) {
-          throw new Error(
-            getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.')
-          );
+          throw new Error(getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.'));
         }
 
         if (arguments.length > 1) {
-          throw new Error(
-            getErrorMsg('Does not take arguments, use toHaveBeenCalledWith')
-          );
+          throw new Error(getErrorMsg('Does not take arguments, use toHaveBeenCalledWith'));
         }
 
         result.pass = actual.calls.any();
 
-        result.message = result.pass
-          ? 'Expected spy ' + actual.and.identity + ' not to have been called.'
-          : 'Expected spy ' + actual.and.identity + ' to have been called.';
+        result.message = result.pass ?
+          'Expected spy ' + actual.and.identity + ' not to have been called.' :
+          'Expected spy ' + actual.and.identity + ' to have been called.';
 
         return result;
       }
@@ -5473,10 +5294,8 @@ getJasmineRequireObj().toHaveBeenCalled = function(j$) {
 };
 
 getJasmineRequireObj().toHaveBeenCalledBefore = function(j$) {
-  var getErrorMsg = j$.formatErrorMsg(
-    '<toHaveBeenCalledBefore>',
-    'expect(<spyObj>).toHaveBeenCalledBefore(<spyObj>)'
-  );
+
+  var getErrorMsg = j$.formatErrorMsg('<toHaveBeenCalledBefore>', 'expect(<spyObj>).toHaveBeenCalledBefore(<spyObj>)');
 
   /**
    * {@link expect} the actual value (a {@link Spy}) to have been called before another {@link Spy}.
@@ -5491,26 +5310,20 @@ getJasmineRequireObj().toHaveBeenCalledBefore = function(j$) {
     return {
       compare: function(firstSpy, latterSpy) {
         if (!j$.isSpy(firstSpy)) {
-          throw new Error(
-            getErrorMsg('Expected a spy, but got ' + j$.pp(firstSpy) + '.')
-          );
+          throw new Error(getErrorMsg('Expected a spy, but got ' + j$.pp(firstSpy) + '.'));
         }
         if (!j$.isSpy(latterSpy)) {
-          throw new Error(
-            getErrorMsg('Expected a spy, but got ' + j$.pp(latterSpy) + '.')
-          );
+          throw new Error(getErrorMsg('Expected a spy, but got ' + j$.pp(latterSpy) + '.'));
         }
 
         var result = { pass: false };
 
         if (!firstSpy.calls.count()) {
-          result.message =
-            'Expected spy ' + firstSpy.and.identity + ' to have been called.';
+          result.message = 'Expected spy ' +  firstSpy.and.identity + ' to have been called.';
           return result;
         }
         if (!latterSpy.calls.count()) {
-          result.message =
-            'Expected spy ' + latterSpy.and.identity + ' to have been called.';
+          result.message = 'Expected spy ' +  latterSpy.and.identity + ' to have been called.';
           return result;
         }
 
@@ -5520,36 +5333,17 @@ getJasmineRequireObj().toHaveBeenCalledBefore = function(j$) {
         result.pass = latest1stSpyCall < first2ndSpyCall;
 
         if (result.pass) {
-          result.message =
-            'Expected spy ' +
-            firstSpy.and.identity +
-            ' to not have been called before spy ' +
-            latterSpy.and.identity +
-            ', but it was';
+          result.message = 'Expected spy ' + firstSpy.and.identity + ' to not have been called before spy ' + latterSpy.and.identity + ', but it was';
         } else {
           var first1stSpyCall = firstSpy.calls.first().invocationOrder;
           var latest2ndSpyCall = latterSpy.calls.mostRecent().invocationOrder;
 
-          if (first1stSpyCall < first2ndSpyCall) {
-            result.message =
-              'Expected latest call to spy ' +
-              firstSpy.and.identity +
-              ' to have been called before first call to spy ' +
-              latterSpy.and.identity +
-              ' (no interleaved calls)';
+          if(first1stSpyCall < first2ndSpyCall) {
+            result.message = 'Expected latest call to spy ' + firstSpy.and.identity + ' to have been called before first call to spy ' + latterSpy.and.identity + ' (no interleaved calls)';
           } else if (latest2ndSpyCall > latest1stSpyCall) {
-            result.message =
-              'Expected first call to spy ' +
-              latterSpy.and.identity +
-              ' to have been called after latest call to spy ' +
-              firstSpy.and.identity +
-              ' (no interleaved calls)';
+            result.message = 'Expected first call to spy ' + latterSpy.and.identity + ' to have been called after latest call to spy ' + firstSpy.and.identity + ' (no interleaved calls)';
           } else {
-            result.message =
-              'Expected spy ' +
-              firstSpy.and.identity +
-              ' to have been called before spy ' +
-              latterSpy.and.identity;
+            result.message = 'Expected spy ' + firstSpy.and.identity + ' to have been called before spy ' + latterSpy.and.identity;
           }
         }
 
@@ -5562,10 +5356,8 @@ getJasmineRequireObj().toHaveBeenCalledBefore = function(j$) {
 };
 
 getJasmineRequireObj().toHaveBeenCalledTimes = function(j$) {
-  var getErrorMsg = j$.formatErrorMsg(
-    '<toHaveBeenCalledTimes>',
-    'expect(<spyObj>).toHaveBeenCalledTimes(<Number>)'
-  );
+
+  var getErrorMsg = j$.formatErrorMsg('<toHaveBeenCalledTimes>', 'expect(<spyObj>).toHaveBeenCalledTimes(<Number>)');
 
   /**
    * {@link expect} the actual (a {@link Spy}) to have been called the specified number of times.
@@ -5580,41 +5372,23 @@ getJasmineRequireObj().toHaveBeenCalledTimes = function(j$) {
     return {
       compare: function(actual, expected) {
         if (!j$.isSpy(actual)) {
-          throw new Error(
-            getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.')
-          );
+          throw new Error(getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.'));
         }
 
         var args = Array.prototype.slice.call(arguments, 0),
           result = { pass: false };
 
         if (!j$.isNumber_(expected)) {
-          throw new Error(
-            getErrorMsg(
-              'The expected times failed is a required argument and must be a number.'
-            )
-          );
+          throw new Error(getErrorMsg('The expected times failed is a required argument and must be a number.'));
         }
 
         actual = args[0];
         var calls = actual.calls.count();
         var timesMessage = expected === 1 ? 'once' : expected + ' times';
         result.pass = calls === expected;
-        result.message = result.pass
-          ? 'Expected spy ' +
-            actual.and.identity +
-            ' not to have been called ' +
-            timesMessage +
-            '. It was called ' +
-            calls +
-            ' times.'
-          : 'Expected spy ' +
-            actual.and.identity +
-            ' to have been called ' +
-            timesMessage +
-            '. It was called ' +
-            calls +
-            ' times.';
+        result.message = result.pass ?
+          'Expected spy ' + actual.and.identity + ' not to have been called ' + timesMessage + '. It was called ' +  calls + ' times.' :
+          'Expected spy ' + actual.and.identity + ' to have been called ' + timesMessage + '. It was called ' +  calls + ' times.';
         return result;
       }
     };
@@ -5624,10 +5398,8 @@ getJasmineRequireObj().toHaveBeenCalledTimes = function(j$) {
 };
 
 getJasmineRequireObj().toHaveBeenCalledWith = function(j$) {
-  var getErrorMsg = j$.formatErrorMsg(
-    '<toHaveBeenCalledWith>',
-    'expect(<spyObj>).toHaveBeenCalledWith(...arguments)'
-  );
+
+  var getErrorMsg = j$.formatErrorMsg('<toHaveBeenCalledWith>', 'expect(<spyObj>).toHaveBeenCalledWith(...arguments)');
 
   /**
    * {@link expect} the actual (a {@link Spy}) to have been called with particular arguments at least once.
@@ -5647,82 +5419,43 @@ getJasmineRequireObj().toHaveBeenCalledWith = function(j$) {
           result = { pass: false };
 
         if (!j$.isSpy(actual)) {
-          throw new Error(
-            getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.')
-          );
+          throw new Error(getErrorMsg('Expected a spy, but got ' + j$.pp(actual) + '.'));
         }
 
         if (!actual.calls.any()) {
           result.message = function() {
-            return (
-              'Expected spy ' +
-              actual.and.identity +
-              ' to have been called with:\n' +
-              '  ' +
-              j$.pp(expectedArgs) +
-              '\nbut it was never called.'
-            );
+            return 'Expected spy ' + actual.and.identity + ' to have been called with:\n' +
+              '  ' + j$.pp(expectedArgs) +
+              '\nbut it was never called.';
           };
           return result;
         }
 
-        if (
-          util.contains(
-            actual.calls.allArgs(),
-            expectedArgs,
-            customEqualityTesters
-          )
-        ) {
+        if (util.contains(actual.calls.allArgs(), expectedArgs, customEqualityTesters)) {
           result.pass = true;
           result.message = function() {
-            return (
-              'Expected spy ' +
-              actual.and.identity +
-              ' not to have been called with:\n' +
-              '  ' +
-              j$.pp(expectedArgs) +
-              '\nbut it was.'
-            );
+            return 'Expected spy ' + actual.and.identity + ' not to have been called with:\n' +
+              '  ' + j$.pp(expectedArgs) +
+              '\nbut it was.';
           };
         } else {
           result.message = function() {
-            var prettyPrintedCalls = actual.calls
-              .allArgs()
-              .map(function(argsForCall) {
-                return '  ' + j$.pp(argsForCall);
-              });
+            var prettyPrintedCalls = actual.calls.allArgs().map(function(argsForCall) {
+              return '  ' + j$.pp(argsForCall);
+            });
 
-            var diffs = actual.calls
-              .allArgs()
-              .map(function(argsForCall, callIx) {
-                var diffBuilder = new j$.DiffBuilder();
-                util.equals(
-                  argsForCall,
-                  expectedArgs,
-                  customEqualityTesters,
-                  diffBuilder
-                );
-                return (
-                  'Call ' +
-                  callIx +
-                  ':\n' +
-                  diffBuilder.getMessage().replace(/^/gm, '  ')
-                );
-              });
+            var diffs = actual.calls.allArgs().map(function(argsForCall, callIx) {
+            var diffBuilder = new j$.DiffBuilder();
+              util.equals(argsForCall, expectedArgs, customEqualityTesters, diffBuilder);
+              return 'Call ' + callIx + ':\n' +
+                diffBuilder.getMessage().replace(/^/mg, '  ');
+            });
 
-            return (
-              'Expected spy ' +
-              actual.and.identity +
-              ' to have been called with:\n' +
-              '  ' +
-              j$.pp(expectedArgs) +
-              '\n' +
-              '' +
+            return 'Expected spy ' + actual.and.identity + ' to have been called with:\n' +
+              '  ' + j$.pp(expectedArgs) + '\n' + '' +
               'but actual calls were:\n' +
-              prettyPrintedCalls.join(',\n') +
-              '.\n\n' +
-              diffs.join('\n')
-            );
+              prettyPrintedCalls.join(',\n') + '.\n\n' +
+              diffs.join('\n');
           };
         }
 
@@ -5761,19 +5494,17 @@ getJasmineRequireObj().toHaveClass = function(j$) {
   }
 
   function isElement(maybeEl) {
-    return (
-      maybeEl && maybeEl.classList && j$.isFunction_(maybeEl.classList.contains)
-    );
+    return maybeEl &&
+      maybeEl.classList &&
+      j$.isFunction_(maybeEl.classList.contains);
   }
 
   return toHaveClass;
 };
 
 getJasmineRequireObj().toMatch = function(j$) {
-  var getErrorMsg = j$.formatErrorMsg(
-    '<toMatch>',
-    'expect(<expectation>).toMatch(<string> || <regexp>)'
-  );
+
+  var getErrorMsg = j$.formatErrorMsg('<toMatch>', 'expect(<expectation>).toMatch(<string> || <regexp>)');
 
   /**
    * {@link expect} the actual value to match a regular expression
@@ -5805,10 +5536,8 @@ getJasmineRequireObj().toMatch = function(j$) {
 };
 
 getJasmineRequireObj().toThrow = function(j$) {
-  var getErrorMsg = j$.formatErrorMsg(
-    '<toThrow>',
-    'expect(function() {<expectation>}).toThrow()'
-  );
+
+  var getErrorMsg = j$.formatErrorMsg('<toThrow>', 'expect(function() {<expectation>}).toThrow()');
 
   /**
    * {@link expect} a function to `throw` something.
@@ -5845,32 +5574,16 @@ getJasmineRequireObj().toThrow = function(j$) {
 
         if (arguments.length == 1) {
           result.pass = true;
-          result.message = function() {
-            return (
-              'Expected function not to throw, but it threw ' +
-              j$.pp(thrown) +
-              '.'
-            );
-          };
+          result.message = function() { return 'Expected function not to throw, but it threw ' + j$.pp(thrown) + '.'; };
 
           return result;
         }
 
         if (util.equals(thrown, expected)) {
           result.pass = true;
-          result.message = function() {
-            return 'Expected function not to throw ' + j$.pp(expected) + '.';
-          };
+          result.message = function() { return 'Expected function not to throw ' + j$.pp(expected) + '.'; };
         } else {
-          result.message = function() {
-            return (
-              'Expected function to throw ' +
-              j$.pp(expected) +
-              ', but it threw ' +
-              j$.pp(thrown) +
-              '.'
-            );
-          };
+          result.message = function() { return 'Expected function to throw ' + j$.pp(expected) + ', but it threw ' +  j$.pp(thrown) + '.'; };
         }
 
         return result;
@@ -5882,10 +5595,8 @@ getJasmineRequireObj().toThrow = function(j$) {
 };
 
 getJasmineRequireObj().toThrowError = function(j$) {
-  var getErrorMsg = j$.formatErrorMsg(
-    '<toThrowError>',
-    'expect(function() {<expectation>}).toThrowError(<ErrorConstructor>, <message>)'
-  );
+
+  var getErrorMsg =  j$.formatErrorMsg('<toThrowError>', 'expect(function() {<expectation>}).toThrowError(<ErrorConstructor>, <message>)');
 
   /**
    * {@link expect} a function to `throw` an `Error`.
@@ -5901,7 +5612,7 @@ getJasmineRequireObj().toThrowError = function(j$) {
    * expect(function() { return 'other'; }).toThrowError(/foo/);
    * expect(function() { return 'other'; }).toThrowError();
    */
-  function toThrowError() {
+  function toThrowError () {
     return {
       compare: function(actual) {
         var errorMatcher = getMatcher.apply(null, arguments),
@@ -5919,13 +5630,7 @@ getJasmineRequireObj().toThrowError = function(j$) {
         }
 
         if (!j$.isError_(thrown)) {
-          return fail(function() {
-            return (
-              'Expected function to throw an Error, but it threw ' +
-              j$.pp(thrown) +
-              '.'
-            );
-          });
+          return fail(function() { return 'Expected function to throw an Error, but it threw ' + j$.pp(thrown) + '.'; });
         }
 
         return errorMatcher.match(thrown);
@@ -5959,11 +5664,7 @@ getJasmineRequireObj().toThrowError = function(j$) {
     function anyMatcher() {
       return {
         match: function(error) {
-          return pass(
-            'Expected function not to throw an Error, but it threw ' +
-              j$.fnNameFor(error) +
-              '.'
-          );
+          return pass('Expected function not to throw an Error, but it threw ' + j$.fnNameFor(error) + '.');
         }
       };
     }
@@ -5971,13 +5672,9 @@ getJasmineRequireObj().toThrowError = function(j$) {
     function exactMatcher(expected, errorType) {
       if (expected && !isStringOrRegExp(expected)) {
         if (errorType) {
-          throw new Error(
-            getErrorMsg('Expected error message is not a string or RegExp.')
-          );
+          throw new Error(getErrorMsg('Expected error message is not a string or RegExp.'));
         } else {
-          throw new Error(
-            getErrorMsg('Expected is not an Error, string, or RegExp.')
-          );
+          throw new Error(getErrorMsg('Expected is not an Error, string, or RegExp.'));
         }
       }
 
@@ -5989,15 +5686,11 @@ getJasmineRequireObj().toThrowError = function(j$) {
         }
       }
 
-      var errorTypeDescription = errorType
-        ? j$.fnNameFor(errorType)
-        : 'an exception';
+      var errorTypeDescription = errorType ? j$.fnNameFor(errorType) : 'an exception';
 
       function thrownDescription(thrown) {
-        var thrownName = errorType
-            ? j$.fnNameFor(thrown.constructor)
-            : 'an exception',
-          thrownMessage = '';
+        var thrownName = errorType ? j$.fnNameFor(thrown.constructor) : 'an exception',
+            thrownMessage = '';
 
         if (expected) {
           thrownMessage = ' with message ' + j$.pp(thrown.message);
@@ -6017,33 +5710,20 @@ getJasmineRequireObj().toThrowError = function(j$) {
       }
 
       function matches(error) {
-        return (
-          (errorType === null || error instanceof errorType) &&
-          (expected === null || messageMatch(error.message))
-        );
+        return (errorType === null || error instanceof errorType) &&
+          (expected === null || messageMatch(error.message));
       }
 
       return {
         match: function(thrown) {
           if (matches(thrown)) {
             return pass(function() {
-              return (
-                'Expected function not to throw ' +
-                errorTypeDescription +
-                messageDescription() +
-                '.'
-              );
+              return 'Expected function not to throw ' + errorTypeDescription + messageDescription() + '.';
             });
           } else {
             return fail(function() {
-              return (
-                'Expected function to throw ' +
-                errorTypeDescription +
-                messageDescription() +
-                ', but it threw ' +
-                thrownDescription(thrown) +
-                '.'
-              );
+              return 'Expected function to throw ' + errorTypeDescription + messageDescription() +
+                ', but it threw ' + thrownDescription(thrown) + '.';
             });
           }
         }
@@ -6051,7 +5731,7 @@ getJasmineRequireObj().toThrowError = function(j$) {
     }
 
     function isStringOrRegExp(potential) {
-      return potential instanceof RegExp || typeof potential == 'string';
+      return potential instanceof RegExp || (typeof potential == 'string');
     }
 
     function isAnErrorType(type) {
@@ -6083,10 +5763,7 @@ getJasmineRequireObj().toThrowError = function(j$) {
 };
 
 getJasmineRequireObj().toThrowMatching = function(j$) {
-  var usageError = j$.formatErrorMsg(
-    '<toThrowMatching>',
-    'expect(function() {<expectation>}).toThrowMatching(<Predicate>)'
-  );
+  var usageError =  j$.formatErrorMsg('<toThrowMatching>', 'expect(function() {<expectation>}).toThrowMatching(<Predicate>)');
 
   /**
    * {@link expect} a function to `throw` something matching a predicate.
@@ -6118,18 +5795,12 @@ getJasmineRequireObj().toThrowMatching = function(j$) {
         }
 
         if (predicate(thrown)) {
-          return pass(
-            'Expected function not to throw an exception matching a predicate.'
-          );
+          return pass('Expected function not to throw an exception matching a predicate.');
         } else {
-          return fail(function() {
-            return (
-              'Expected function to throw an exception matching a predicate, ' +
-              'but it threw ' +
-              thrownDescription(thrown) +
-              '.'
-            );
-          });
+            return fail(function() {
+              return 'Expected function to throw an exception matching a predicate, ' +
+                'but it threw ' + thrownDescription(thrown) + '.';
+            });
         }
       }
     };
@@ -6137,11 +5808,8 @@ getJasmineRequireObj().toThrowMatching = function(j$) {
 
   function thrownDescription(thrown) {
     if (thrown && thrown.constructor) {
-      return (
-        j$.fnNameFor(thrown.constructor) +
-        ' with message ' +
-        j$.pp(thrown.message)
-      );
+      return j$.fnNameFor(thrown.constructor) + ' with message ' +
+        j$.pp(thrown.message);
     } else {
       return j$.pp(thrown);
     }
@@ -8119,7 +7787,7 @@ getJasmineRequireObj().StackTrace = function(j$) {
   }
 
   function messagePrefixLength(message, stackLines) {
-    if (!stackLines[0].match(/^w*Error/)) {
+    if (!stackLines[0].match(/^Error/)) {
       return 0;
     }
 

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -7787,7 +7787,7 @@ getJasmineRequireObj().StackTrace = function(j$) {
   }
 
   function messagePrefixLength(message, stackLines) {
-    if (!stackLines[0].match(/^Error/)) {
+    if (!stackLines[0].match(/^\w*Error/)) {
       return 0;
     }
 

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -7787,7 +7787,7 @@ getJasmineRequireObj().StackTrace = function(j$) {
   }
 
   function messagePrefixLength(message, stackLines) {
-    if (!stackLines[0].match(/^\w*Error/)) {
+    if (!stackLines[0].match(/^Error/)) {
       return 0;
     }
 

--- a/spec/core/StackTraceSpec.js
+++ b/spec/core/StackTraceSpec.js
@@ -213,4 +213,46 @@ describe('StackTrace', function() {
       }
     ]);
   });
+
+  it('consideres different types of errors', function() {
+    var error = {
+      message: 'nope',
+      stack:
+        'TypeError: nope\n' +
+        '    at UserContext.<anonymous> (http://localhost:8888/__spec__/core/UtilSpec.js:115:19)\n' +
+        '    at QueueRunner.run (http://localhost:8888/__jasmine__/jasmine.js:4320:20)'
+    };
+
+    var result = new jasmineUnderTest.StackTrace(error);
+
+    expect(result.message).toEqual('TypeError: nope');
+    expect(result.frames).toEqual([
+      {
+        raw:
+          '    at UserContext.<anonymous> (http://localhost:8888/__spec__/core/UtilSpec.js:115:19)',
+        func: 'UserContext.<anonymous>',
+        file: 'http://localhost:8888/__spec__/core/UtilSpec.js',
+        line: 115
+      },
+      {
+        raw:
+          '    at QueueRunner.run (http://localhost:8888/__jasmine__/jasmine.js:4320:20)',
+        func: 'QueueRunner.run',
+        file: 'http://localhost:8888/__jasmine__/jasmine.js',
+        line: 4320
+      }
+    ]);
+
+    var no_error = {
+      message: 'nope',
+      stack:
+        'Type Error: nope\n' +
+        '    at UserContext.<anonymous> (http://localhost:8888/__spec__/core/UtilSpec.js:115:19)\n' +
+        '    at QueueRunner.run (http://localhost:8888/__jasmine__/jasmine.js:4320:20)'
+    };
+
+    var result_no_error = new jasmineUnderTest.StackTrace(no_error);
+
+    expect(result_no_error.message).not.toEqual(jasmine.anything());
+  });
 });

--- a/src/core/StackTrace.js
+++ b/src/core/StackTrace.js
@@ -104,7 +104,7 @@ getJasmineRequireObj().StackTrace = function(j$) {
   }
 
   function messagePrefixLength(message, stackLines) {
-    if (!stackLines[0].match(/^Error/)) {
+    if (!stackLines[0].match(/^\w*Error/)) {
       return 0;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In extractMessage() the error message cannot be extracted if the stack trace starts with something else then "Error". For example the message for "TypeError" won't be extracted because function messagePrefixLength() in extractMessage() returns 0, because there is no match for "match(/^Error/)".

## Motivation and Context
messagePrefixLength() just considers error messages which start with "Error". It should also consider error messages like "TypeError" or "ReferenceError".

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

