### PR TITLE
feat(GlobalErrors): Route unhandledrejections to onerror

### DIFF
--- a/spec/core/GlobalErrorsSpec.js
+++ b/spec/core/GlobalErrorsSpec.js
@@ -193,4 +193,34 @@ describe('GlobalErrors', function() {
       'foo'
     );
   });
+
+  it('reports unhandledRejection in browser', function() {
+    var fakeGlobal = {
+        addEventListener: jasmine.createSpy('addEventListener'),
+        removeEventListener: jasmine.createSpy('removeEventListener'),
+        onerror: jasmine.createSpy('onerror')
+      },
+      handler = jasmine.createSpy('errorHandler'),
+      errors = new jasmineUnderTest.GlobalErrors(fakeGlobal);
+
+    errors.install();
+    expect(fakeGlobal.addEventListener).toHaveBeenCalledWith(
+      'unhandledrejection',
+      jasmine.any(Function)
+    );
+
+    errors.pushListener(handler);
+
+    var addedListener = fakeGlobal.addEventListener.calls.argsFor(0)[1];
+    addedListener({ reason: new Error('bar') });
+
+    expect(handler).toHaveBeenCalledWith('Unhandled Rejection: Error: bar');
+
+    errors.uninstall();
+
+    expect(fakeGlobal.removeEventListener).toHaveBeenCalledWith(
+      'unhandledrejection',
+      addedListener
+    );
+  });
 });

--- a/src/core/GlobalErrors.js
+++ b/src/core/GlobalErrors.js
@@ -63,8 +63,25 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
         var originalHandler = global.onerror;
         global.onerror = onerror;
 
+        var browserRejectionHandler = function browserRejectionHandler(event) {
+          onerror('Unhandled Rejection: ' + event.reason);
+        };
+
+        if (global.addEventListener) {
+          global.addEventListener(
+            'unhandledrejection',
+            browserRejectionHandler
+          );
+        }
+
         this.uninstall = function uninstall() {
           global.onerror = originalHandler;
+          if (global.removeEventListener) {
+            global.removeEventListener(
+              'unhandledrejection',
+              browserRejectionHandler
+            );
+          }
         };
       }
     };


### PR DESCRIPTION
Fixes #1777

BREAKING CHANGE: Existing tests that throw in promises will begin to fail (correctly).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Added test
<!--- Include details of your testing environment, and the tests you ran to -->
npm test
<!--- see how your change affects other areas of the code, etc. -->
Shouldn't have any impact.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

