### PR TITLE
Allow callThrough to call constructor functions without errors

### DIFF
--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -823,6 +823,12 @@ describe("Env integration", function() {
       }).not.toThrow();
 
       expect(function() {
+        var result = new spy('passing', 'extra', 'arguments', 'to', 'constructor');
+        expect(result instanceof MyClass).toBeTruthy();
+        expect(result.foo).toEqual('passing');
+      }).not.toThrow();
+
+      expect(function() {
         spy('hello world');
       }).toThrowError('You must use the new keyword.');
     });
@@ -840,8 +846,8 @@ describe("Env integration", function() {
     env.allowRespy(true);
     env.addReporter({ jasmineDone: done });
 
-    env.describe('test suite', function(){
-      env.it('spec 0', function(){
+    env.describe('test suite', function() {
+      env.it('spec 0', function() {
         env.spyOn(foo,'bar');
 
         var error = null;

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -808,6 +808,25 @@ describe("Env integration", function() {
       expect(originalFunctionWasCalled).toEqual(true);
     });
 
+    env.it("works with constructors when using callThrough spy strategy", function() {
+      function MyClass(foo) {
+        if (!(this instanceof MyClass)) throw new Error('You must use the new keyword.');
+        this.foo = foo;
+      }
+      var subject = { MyClass: MyClass };
+      var spy = env.spyOn(subject, 'MyClass').and.callThrough();
+
+      expect(function() {
+        var result = new spy('hello world');
+        expect(result instanceof MyClass).toBeTruthy();
+        expect(result.foo).toEqual('hello world');
+      }).not.toThrow();
+
+      expect(function() {
+        spy('hello world');
+      }).toThrowError('You must use the new keyword.');
+    });
+
     env.execute();
   });
 

--- a/src/core/Spy.js
+++ b/src/core/Spy.js
@@ -20,8 +20,8 @@ getJasmineRequireObj().Spy = function(j$) {
     getPromise
   ) {
     var numArgs = typeof originalFn === 'function' ? originalFn.length : 0,
-      wrapper = makeFunc(numArgs, function(context, args, isConstructor) {
-        return spy(context, args, isConstructor);
+      wrapper = makeFunc(numArgs, function(context, args, invokeNew) {
+        return spy(context, args, invokeNew);
       }),
       strategyDispatcher = new SpyStrategyDispatcher({
         name: name,
@@ -33,7 +33,7 @@ getJasmineRequireObj().Spy = function(j$) {
         getPromise: getPromise
       }),
       callTracker = new j$.CallTracker(),
-      spy = function(context, args, isConstructor) {
+      spy = function(context, args, invokeNew) {
         /**
          * @name Spy.callData
          * @property {object} object - `this` context for the invocation.
@@ -47,7 +47,7 @@ getJasmineRequireObj().Spy = function(j$) {
         };
 
         callTracker.track(callData);
-        var returnValue = strategyDispatcher.exec(this, args, isConstructor);
+        var returnValue = strategyDispatcher.exec(context, args, invokeNew);
         callData.returnValue = returnValue;
 
         return returnValue;
@@ -56,44 +56,44 @@ getJasmineRequireObj().Spy = function(j$) {
     function makeFunc(length, fn) {
       switch (length) {
         case 1:
-          return function fnargs(a) {
-            return fn(this, arguments, this instanceof fnargs);
+          return function wrap1(a) {
+            return fn(this, arguments, this instanceof wrap1);
           };
         case 2:
-          return function fnargs(a, b) {
-            return fn(this, arguments, this instanceof fnargs);
+          return function wrap2(a, b) {
+            return fn(this, arguments, this instanceof wrap2);
           };
         case 3:
-          return function fnargs(a, b, c) {
-            return fn(this, arguments, this instanceof fnargs);
+          return function wrap3(a, b, c) {
+            return fn(this, arguments, this instanceof wrap3);
           };
         case 4:
-          return function fnargs(a, b, c, d) {
-            return fn(this, arguments, this instanceof fnargs);
+          return function wrap4(a, b, c, d) {
+            return fn(this, arguments, this instanceof wrap4);
           };
         case 5:
-          return function fnargs(a, b, c, d, e) {
-            return fn(this, arguments, this instanceof fnargs);
+          return function wrap5(a, b, c, d, e) {
+            return fn(this, arguments, this instanceof wrap5);
           };
         case 6:
-          return function fnargs(a, b, c, d, e, f) {
-            return fn(this, arguments, this instanceof fnargs);
+          return function wrap6(a, b, c, d, e, f) {
+            return fn(this, arguments, this instanceof wrap6);
           };
         case 7:
-          return function fnargs(a, b, c, d, e, f, g) {
-            return fn(this, arguments, this instanceof fnargs);
+          return function wrap7(a, b, c, d, e, f, g) {
+            return fn(this, arguments, this instanceof wrap7);
           };
         case 8:
-          return function fnargs(a, b, c, d, e, f, g, h) {
-            return fn(this, arguments, this instanceof fnargs);
+          return function wrap8(a, b, c, d, e, f, g, h) {
+            return fn(this, arguments, this instanceof wrap8);
           };
         case 9:
-          return function fnargs(a, b, c, d, e, f, g, h, i) {
-            return fn(this, arguments, this instanceof fnargs);
+          return function wrap9(a, b, c, d, e, f, g, h, i) {
+            return fn(this, arguments, this instanceof wrap9);
           };
         default:
-          return function fnargs() {
-            return fn(this, arguments, this instanceof fnargs);
+          return function wrap() {
+            return fn(this, arguments, this instanceof wrap);
           };
       }
     }
@@ -150,7 +150,7 @@ getJasmineRequireObj().Spy = function(j$) {
 
     this.and = baseStrategy;
 
-    this.exec = function(spy, args, isConstructor) {
+    this.exec = function(spy, args, invokeNew) {
       var strategy = argsStrategies.get(args);
 
       if (!strategy) {
@@ -167,7 +167,7 @@ getJasmineRequireObj().Spy = function(j$) {
         }
       }
 
-      return strategy.exec(spy, args, isConstructor);
+      return strategy.exec(spy, args, invokeNew);
     };
 
     this.withArgs = function() {

--- a/src/core/Spy.js
+++ b/src/core/Spy.js
@@ -20,8 +20,8 @@ getJasmineRequireObj().Spy = function(j$) {
     getPromise
   ) {
     var numArgs = typeof originalFn === 'function' ? originalFn.length : 0,
-      wrapper = makeFunc(numArgs, function() {
-        return spy.apply(this, Array.prototype.slice.call(arguments));
+      wrapper = makeFunc(numArgs, function(context, args, isConstructor) {
+        return spy(context, args, isConstructor);
       }),
       strategyDispatcher = new SpyStrategyDispatcher({
         name: name,
@@ -33,7 +33,7 @@ getJasmineRequireObj().Spy = function(j$) {
         getPromise: getPromise
       }),
       callTracker = new j$.CallTracker(),
-      spy = function() {
+      spy = function(context, args, isConstructor) {
         /**
          * @name Spy.callData
          * @property {object} object - `this` context for the invocation.
@@ -41,13 +41,13 @@ getJasmineRequireObj().Spy = function(j$) {
          * @property {Array} args - The arguments passed for this invocation.
          */
         var callData = {
-          object: this,
+          object: context,
           invocationOrder: nextOrder(),
-          args: Array.prototype.slice.apply(arguments)
+          args: Array.prototype.slice.apply(args)
         };
 
         callTracker.track(callData);
-        var returnValue = strategyDispatcher.exec(this, arguments);
+        var returnValue = strategyDispatcher.exec(this, args, isConstructor);
         callData.returnValue = returnValue;
 
         return returnValue;
@@ -56,44 +56,44 @@ getJasmineRequireObj().Spy = function(j$) {
     function makeFunc(length, fn) {
       switch (length) {
         case 1:
-          return function(a) {
-            return fn.apply(this, arguments);
+          return function fnargs(a) {
+            return fn(this, arguments, this instanceof fnargs);
           };
         case 2:
-          return function(a, b) {
-            return fn.apply(this, arguments);
+          return function fnargs(a, b) {
+            return fn(this, arguments, this instanceof fnargs);
           };
         case 3:
-          return function(a, b, c) {
-            return fn.apply(this, arguments);
+          return function fnargs(a, b, c) {
+            return fn(this, arguments, this instanceof fnargs);
           };
         case 4:
-          return function(a, b, c, d) {
-            return fn.apply(this, arguments);
+          return function fnargs(a, b, c, d) {
+            return fn(this, arguments, this instanceof fnargs);
           };
         case 5:
-          return function(a, b, c, d, e) {
-            return fn.apply(this, arguments);
+          return function fnargs(a, b, c, d, e) {
+            return fn(this, arguments, this instanceof fnargs);
           };
         case 6:
-          return function(a, b, c, d, e, f) {
-            return fn.apply(this, arguments);
+          return function fnargs(a, b, c, d, e, f) {
+            return fn(this, arguments, this instanceof fnargs);
           };
         case 7:
-          return function(a, b, c, d, e, f, g) {
-            return fn.apply(this, arguments);
+          return function fnargs(a, b, c, d, e, f, g) {
+            return fn(this, arguments, this instanceof fnargs);
           };
         case 8:
-          return function(a, b, c, d, e, f, g, h) {
-            return fn.apply(this, arguments);
+          return function fnargs(a, b, c, d, e, f, g, h) {
+            return fn(this, arguments, this instanceof fnargs);
           };
         case 9:
-          return function(a, b, c, d, e, f, g, h, i) {
-            return fn.apply(this, arguments);
+          return function fnargs(a, b, c, d, e, f, g, h, i) {
+            return fn(this, arguments, this instanceof fnargs);
           };
         default:
-          return function() {
-            return fn.apply(this, arguments);
+          return function fnargs() {
+            return fn(this, arguments, this instanceof fnargs);
           };
       }
     }
@@ -150,7 +150,7 @@ getJasmineRequireObj().Spy = function(j$) {
 
     this.and = baseStrategy;
 
-    this.exec = function(spy, args) {
+    this.exec = function(spy, args, isConstructor) {
       var strategy = argsStrategies.get(args);
 
       if (!strategy) {
@@ -167,7 +167,7 @@ getJasmineRequireObj().Spy = function(j$) {
         }
       }
 
-      return strategy.exec(spy, args);
+      return strategy.exec(spy, args, isConstructor);
     };
 
     this.withArgs = function() {

--- a/src/core/SpyStrategy.js
+++ b/src/core/SpyStrategy.js
@@ -96,11 +96,11 @@ getJasmineRequireObj().SpyStrategy = function(j$) {
    * @since 2.0.0
    * @function
    */
-  SpyStrategy.prototype.exec = function(context, args, isConstructor) {
+  SpyStrategy.prototype.exec = function(context, args, invokeNew) {
     var list = [context].concat(args ? Array.prototype.slice.call(args) : []);
     var target = this.plan.bind.apply(this.plan, list);
 
-    if (isConstructor) {
+    if (invokeNew) {
       return new target();
     } else {
       return target();

--- a/src/core/SpyStrategy.js
+++ b/src/core/SpyStrategy.js
@@ -96,8 +96,15 @@ getJasmineRequireObj().SpyStrategy = function(j$) {
    * @since 2.0.0
    * @function
    */
-  SpyStrategy.prototype.exec = function(context, args) {
-    return this.plan.apply(context, args);
+  SpyStrategy.prototype.exec = function(context, args, isConstructor) {
+    var list = [context].concat(args ? Array.prototype.slice.call(args) : []);
+    var target = this.plan.bind.apply(this.plan, list);
+
+    if (isConstructor) {
+      return new target();
+    } else {
+      return target();
+    }
   };
 
   /**

--- a/src/core/SpyStrategy.js
+++ b/src/core/SpyStrategy.js
@@ -97,14 +97,12 @@ getJasmineRequireObj().SpyStrategy = function(j$) {
    * @function
    */
   SpyStrategy.prototype.exec = function(context, args, invokeNew) {
-    var list = [context].concat(args ? Array.prototype.slice.call(args) : []);
-    var target = this.plan.bind.apply(this.plan, list);
+    var contextArgs = [context].concat(
+      args ? Array.prototype.slice.call(args) : []
+    );
+    var target = this.plan.bind.apply(this.plan, contextArgs);
 
-    if (invokeNew) {
-      return new target();
-    } else {
-      return target();
-    }
+    return invokeNew ? new target() : target();
   };
 
   /**


### PR DESCRIPTION
## Description
This is an initial stab at fixing https://github.com/jasmine/jasmine/issues/1760.

The idea is that if you spy on a constructor function and `callThrough`, and then construct that object, it should work as expected without errors.  Unfortunately, this ends up requiring quite a bit of plumbing changes, as there's not really any way to pass the information that this is a `new` call all the way from the end caller down to the eventual spy strategy using the current implementation.

I'm not 100% certain this functionality is worth this much churn, there may be a safer way to do this I'm not seeing yet.

## Motivation and Context
See https://github.com/jasmine/jasmine/issues/1760 -- this is hopefully to fix overreach by spyOnAllFunctions.

## How Has This Been Tested?
Ran basic tests, added an integration test confirming it works on common patterns (used by node packages like `aws-sdk`, etc.)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

