### PR TITLE
Add test for resolveTo/rejectWith with empty parameters

### DIFF
--- a/spec/core/SpyStrategySpec.js
+++ b/spec/core/SpyStrategySpec.js
@@ -140,6 +140,28 @@ describe('SpyStrategy', function() {
         .catch(done.fail);
     });
 
+    it('allows an empty resolved promise to be returned', function(done) {
+      jasmine.getEnv().requirePromises();
+
+      var originalFn = jasmine.createSpy('original'),
+        getPromise = function() {
+          return Promise;
+        },
+        spyStrategy = new jasmineUnderTest.SpyStrategy({
+          fn: originalFn,
+          getPromise: getPromise
+        });
+
+      spyStrategy.resolveTo();
+      spyStrategy
+        .exec()
+        .then(function(returnValue) {
+          expect(returnValue).toBe();
+          done();
+        })
+        .catch(done.fail);
+    });
+
     it('fails if promises are not available', function() {
       var originalFn = jasmine.createSpy('original'),
         spyStrategy = new jasmineUnderTest.SpyStrategy({ fn: originalFn });
@@ -171,6 +193,29 @@ describe('SpyStrategy', function() {
         .then(done.fail)
         .catch(function(error) {
           expect(error).toEqual(new Error('oops'));
+          done();
+        })
+        .catch(done.fail);
+    });
+
+    it('allows an empty rejected promise to be returned', function(done) {
+      jasmine.getEnv().requirePromises();
+
+      var originalFn = jasmine.createSpy('original'),
+        getPromise = function() {
+          return Promise;
+        },
+        spyStrategy = new jasmineUnderTest.SpyStrategy({
+          fn: originalFn,
+          getPromise: getPromise
+        });
+
+      spyStrategy.rejectWith();
+      spyStrategy
+        .exec()
+        .then(done.fail)
+        .catch(function(error) {
+          expect(error).toBe();
           done();
         })
         .catch(done.fail);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
resolveTo/rejectWith were added as options on a spy in a https://github.com/jasmine/jasmine/pull/1688, and had tests when you pass in parameters. It is possible to use them without passing in any parameters, and everything still works. Now I am adding tests to officially document this behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Motivation is related DefinitelyTyped typings PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42967.
You can also see this work in client code in https://codepen.io/chivesrs/pen/XWbzMMa.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test added (npm test), and the codepen above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
None of the above? New feature maybe?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.