### PR TITLE
fix issue #1775

### DIFF
--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -321,9 +321,11 @@ jasmineRequire.HtmlReporter = function(j$) {
 
         find('.jasmine-failures-menu').onclick = function() {
           setMenuModeTo('jasmine-failure-list');
+          return false;
         };
         find('.jasmine-spec-list-menu').onclick = function() {
           setMenuModeTo('jasmine-spec-list');
+          return false;
         };
 
         setMenuModeTo('jasmine-failure-list');


### PR DESCRIPTION
fix #1775

<!--- Provide a general summary of your changes in the Title above -->

## Description
Returning `false ` as below will cause 'zone.js' to invoke `e.preventDefault()`, preventing the page from reloading.

```
find('.jasmine-failures-menu').onclick = function() {
    setMenuModeTo('jasmine-failure-list');
    return false; // new code
};
```
```
find('.jasmine-spec-list-menu').onclick = function() {
    setMenuModeTo('jasmine-spec-list');
    return false; // new code
};
```

## Motivation and Context
fix issue #1775

## How Has This Been Tested?
Changing the node package locally.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

