### PR TITLE
fix(env): expose setSpec/SuiteProperty on interface

### DIFF
--- a/src/core/requireInterface.js
+++ b/src/core/requireInterface.js
@@ -169,6 +169,30 @@ getJasmineRequireObj().interface = function(jasmine, env) {
     },
 
     /**
+     * Sets a user-defined property that will be provided to reporters as part of {@link SpecResult#properties}
+     * @name Env#setSpecProperty
+     * @since 3.6.0
+     * @function
+     * @param {String} key The name of the property
+     * @param {*} value The value of the property
+     */
+    setSpecProperty: function(key, value) {
+      return env.setSpecProperty(key, value);
+    },
+
+    /**
+     * Sets a user-defined property that will be provided to reporters as part of {@link SuiteResult#properties}
+     * @name Env#setSuiteProperty
+     * @since 3.6.0
+     * @function
+     * @param {String} key The name of the property
+     * @param {*} value The value of the property
+     */
+    setSuiteProperty: function(key, value) {
+      return env.setSuiteProperty(key, value);
+    },
+
+    /**
      * Create an expectation for a spec.
      * @name expect
      * @since 1.3.0


### PR DESCRIPTION
In using the (prerelease) setSpecProperty() I found that users will want to access the feature in tests as they do say `expect()`.