### PR TITLE
allow spy throwError to throw an Object

### DIFF
--- a/spec/core/SpyStrategySpec.js
+++ b/spec/core/SpyStrategySpec.js
@@ -70,7 +70,7 @@ describe('SpyStrategy', function() {
     expect(originalFn).not.toHaveBeenCalled();
   });
 
-  it('allows a non-Error to be thrown, wrapping it into an exception when executed', function() {
+  it('allows a string to be thrown, wrapping it into an exception when executed', function() {
     var originalFn = jasmine.createSpy('original'),
       spyStrategy = new jasmineUnderTest.SpyStrategy({ fn: originalFn });
 
@@ -79,6 +79,18 @@ describe('SpyStrategy', function() {
     expect(function() {
       spyStrategy.exec();
     }).toThrowError(Error, 'bar');
+    expect(originalFn).not.toHaveBeenCalled();
+  });
+
+  it('allows a non-Error to be thrown when executed', function() {
+    var originalFn = jasmine.createSpy('original'),
+      spyStrategy = new jasmineUnderTest.SpyStrategy({ fn: originalFn });
+
+    spyStrategy.throwError({ code: 'ESRCH' });
+
+    expect(function() {
+      spyStrategy.exec();
+    }).toThrow({ code: 'ESRCH' });
     expect(originalFn).not.toHaveBeenCalled();
   });
 

--- a/src/core/SpyStrategy.js
+++ b/src/core/SpyStrategy.js
@@ -150,10 +150,10 @@ getJasmineRequireObj().SpyStrategy = function(j$) {
    * @name SpyStrategy#throwError
    * @since 2.0.0
    * @function
-   * @param {Error|String} something Thing to throw
+   * @param {Error|Object|String} something Thing to throw
    */
   SpyStrategy.prototype.throwError = function(something) {
-    var error = something instanceof Error ? something : new Error(something);
+    var error = j$.isString_(something) ? new Error(something) : something;
     this.plan = function() {
       throw error;
     };


### PR DESCRIPTION
## Description

When using the following code to simulate a node error:

```javascript
spyOn(process, 'kill').and.throwError({code: 'ESRCH'})
```

The object passed in will be converted to a string by the Error constructor and result in `'[object Object]'` which is not very useful. This PR changes the ``throwError`` spy strategy to only convert
strings into an Error object, but any other objects which are passed in will be thrown as is. This means the spy strategy can never emulate throwing a bare string ``throw 'error'``, but this would be a backward incompatible change.

## Motivation and Context

To more easily throw a node like object / allow `throwError` to match `throw expression` better.

## How Has This Been Tested?

This is change just reverses an if/else check and checks for a string instead of an Error object so it's a constrained change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

