### PR TITLE
fix(env): `throwOnExpectationFailure` sets `failFast`

### DIFF
--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -482,13 +482,13 @@ getJasmineRequireObj().Env = function(j$) {
      * @since 2.3.0
      * @function
      * @param {Boolean} value Whether to throw when a expectation fails
-     * @deprecated Use the `oneFailurePerSpec` option with {@link Env#configure}
+     * @deprecated Use the `failFast` option with {@link Env#configure}
      */
     this.throwOnExpectationFailure = function(value) {
       this.deprecated(
         'Setting throwOnExpectationFailure directly on Env is deprecated and will be removed in a future version of Jasmine, please use the oneFailurePerSpec option in `configure`'
       );
-      this.configure({ oneFailurePerSpec: !!value });
+      this.configure({ failFast: !!value });
     };
 
     this.throwingExpectationFailures = function() {


### PR DESCRIPTION
Fix `throwOnExpectationFailure` backward compatibility mode. It should set `failFast` rather than `oneFailurePerSpec`

## Motivation and Context

I was really confused about the deprecation message and implementation.

## How Has This Been Tested?

T.B.H, not tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Technically a breaking change. But only for this backward compatibility layer.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (the deprecation message)
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

