### PR TITLE
fixes problems that occur when jasmine.clock.install() is in action

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -3003,7 +3003,7 @@ getJasmineRequireObj().clearStack = function(j$) {
         channel.port2.postMessage(0);
       } else {
         currentCallCount = 0;
-        setTimeout(fn);
+        global.setTimeout(fn);
       }
     };
   }


### PR DESCRIPTION
I found out that Jasmine is terribly slow for me.

After hours of debugging, the reason seems to be the typo.

The PR is quite obvious, as this really looks like a typo: `setTimeout` instead of `global.setTimeout`.

So when the "default" `setTimeout" is mocked, then things go wrong. Do I get it right?

The PR patches it. 

P.S. You don't want to use `queueMicrotask` here, right? Using `setTimeout/setImmediate` on purpose, to let things render etc?