### PR TITLE
fix a typo in the comment for async-matcher toBePending

### DIFF
--- a/src/core/matchers/async/toBePending.js
+++ b/src/core/matchers/async/toBePending.js
@@ -1,7 +1,7 @@
 /* eslint-disable compat/compat */
 getJasmineRequireObj().toBePending = function(j$) {
   /**
-   * Expect a promise to be pending, ie. the promise is neither resolved nor rejected.
+   * Expect a promise to be pending, i.e. the promise is neither resolved nor rejected.
    * @function
    * @async
    * @name async-matchers#toBePending


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a typo in the `toBePending` async matcher's doc comment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I have no idea if it's worth updating these kinds of small typos, but it came up in a pull request to the `DefinitelyTyped` project. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46912

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran `npm test` to verify that the formatting didn't need to change or anything

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

