### PR TITLE
Don't try to handle number as DOM node

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -655,7 +655,7 @@ jasmineRequire.HtmlReporter = function(j$) {
       for (var i = 2; i < arguments.length; i++) {
         var child = arguments[i];
 
-        if (typeof child === 'string') {
+        if (typeof child === 'string' || typeof child === 'number') {
           el.appendChild(createTextNode(child));
         } else {
           if (child) {

--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -656,7 +656,7 @@ jasmineRequire.HtmlReporter = function(j$) {
         var child = arguments[i];
 
         if (typeof child === 'string' || typeof child === 'number') {
-          el.appendChild(createTextNode(child));
+          el.appendChild(createTextNode(child.toString()));
         } else {
           if (child) {
             el.appendChild(child);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a `number` comes in, handle it like a `string`, so jasmine won't try to handle it like a `Node` and fail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I was running into problems when using [karma-jasmine-order-reporter](https://www.npmjs.com/package/karma-jasmine-order-reporter). I was getting errors like this:

```
Chrome Headless 85.0.4183.83 (Linux x86_64) ERROR
  An error was thrown in afterAll
  TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'.
      at <Jasmine>
      at createDom (/home/paul.heising/dev/pwa/node_modules/karma-jasmine-html-reporter/src/lib/html.jasmine.reporter.js:660:16)
      at HtmlReporter.jasmineDone (/home/paul.heising/dev/pwa/node_modules/karma-jasmine-html-reporter/src/lib/html.jasmine.reporter.js:257:11)
```

Even though this problem only occurs with karma-jasmine-order-reporter, I think the change is a quite obvious fix for the case that a `number` comes in here, because of course it causes an error if you try to handle a `number` like a `Node`.


<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I did some local testing, by modifying the corresponding file inside the `node_modules` of my project that depends on jasmine. Bit since the change is small and obvious in my eyes, I did not test quite extensively.
<!--- Include details of your testing environment, and the tests you ran to -->
Environment:

- Ubuntu 20.04
- Chrome 85
- Node 12.18.3

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

