### PR TITLE
Have properties added by createSpyObj() be enumerable.

### DIFF
--- a/spec/core/SpySpec.js
+++ b/spec/core/SpySpec.js
@@ -183,14 +183,13 @@ describe('Spies', function() {
       var spyObj = env.createSpyObj('base', ['method1'], ['prop1']);
 
       expect(spyObj).toEqual({
-        method1: jasmine.any(Function)
+        method1: jasmine.any(Function),
+        prop1: undefined
       });
 
       var descriptor = Object.getOwnPropertyDescriptor(spyObj, 'prop1');
       expect(descriptor.get.and.identity).toEqual('base.prop1.get');
       expect(descriptor.set.and.identity).toEqual('base.prop1.set');
-
-      expect(spyObj.prop1).toBeUndefined();
     });
 
     it('creates an object with property names and return values if second object is passed', function() {
@@ -200,7 +199,9 @@ describe('Spies', function() {
       });
 
       expect(spyObj).toEqual({
-        method1: jasmine.any(Function)
+        method1: jasmine.any(Function),
+        prop1: 'foo',
+        prop2: 37
       });
 
       expect(spyObj.prop1).toEqual('foo');

--- a/src/core/SpyFactory.js
+++ b/src/core/SpyFactory.js
@@ -38,6 +38,7 @@ getJasmineRequireObj().SpyFactory = function(j$) {
       var properties = normalizeKeyValues(propertyNames);
       for (var i = 0; i < properties.length; i++) {
         descriptor = {
+          enumerable: true,
           get: self.createSpy(baseName + '.' + properties[i][0] + '.get'),
           set: self.createSpy(baseName + '.' + properties[i][0] + '.set')
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Make the properties that `createSpyObj()` adds enumerable. This allows properties added by spy objects to be copied to other objects using `Object.assign` or spread syntax (i.e. `{...someSpyObj}`).

## Motivation and Context

Fixes [#1837](https://github.com/jasmine/jasmine/issues/1837).

## How Has This Been Tested?

Updates to existing tests in SpySpec.js exercise these changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

