### PR TITLE
GlobalErrors: use global.onError in browserRejectionHandler so can overwrite

### DIFF
--- a/spec/core/GlobalErrorsSpec.js
+++ b/spec/core/GlobalErrorsSpec.js
@@ -12,6 +12,23 @@ describe('GlobalErrors', function() {
     expect(handler).toHaveBeenCalledWith('foo');
   });
 
+  it('enables external interception of error by overriding global.onerror', function() {
+    var fakeGlobal = { onerror: null },
+      handler = jasmine.createSpy('errorHandler'),
+      hijackHandler = jasmine.createSpy('hijackErrorHandler'),
+      errors = new jasmineUnderTest.GlobalErrors(fakeGlobal);
+
+    errors.install();
+    errors.pushListener(handler);
+
+    fakeGlobal.onerror = hijackHandler;
+
+    fakeGlobal.onerror('foo');
+
+    expect(hijackHandler).toHaveBeenCalledWith('foo');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it('calls the global error handler with all parameters', function() {
     var fakeGlobal = { onerror: null },
       handler = jasmine.createSpy('errorHandler'),

--- a/src/core/GlobalErrors.js
+++ b/src/core/GlobalErrors.js
@@ -67,9 +67,9 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
           if (j$.isError_(event.reason)) {
             event.reason.jasmineMessage =
               'Unhandled promise rejection: ' + event.reason;
-            onerror(event.reason);
+            global.onerror(event.reason);
           } else {
-            onerror('Unhandled promise rejection: ' + event.reason);
+            global.onerror('Unhandled promise rejection: ' + event.reason);
           }
         };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A recent [change](https://github.com/jasmine/jasmine/pull/1778) started forwarding unhandled promise errors to the jasmine onerror handler, via an "unhandledrejection" listener. This PR tweaks this code to call the jasmine onerror function via `global.onerror`, not the `onerror` local variable.
 
## Motivation and Context
When testing global error handling in our own code, it's sometimes useful to disable jasmine's global error handling temporarily, to prevent clashes. This is doable by replacing (jasmine's) `global.onerror` with our own function: `global.onerror = ownOnError`. However, this approach fails with the recent unhandledrejection [change](https://github.com/jasmine/jasmine/pull/1778), as this new logic calls jasmine's error function directly via the `onerror` local variable, rather than `global.onerror`.

This PR  tweaks this unhandledrejection code to call the jasmine onerror function via `global.onerror`, so enabling the onerror overriding approach to work again. It also ensures that this overriding approach behaves consistently for errors triggered from both promise and non-promise situations.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran the jasmine test suite.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

