### PR TITLE
Support source maps

### DIFF
--- a/spec/core/ExceptionFormatterSpec.js
+++ b/spec/core/ExceptionFormatterSpec.js
@@ -86,6 +86,37 @@ describe('ExceptionFormatter', function() {
       );
     });
 
+    it('filters Jasmine stack frames from V8-style traces but leaves unmatched lines intact', function() {
+      var error = {
+        message: 'nope',
+        stack:
+          'C:\\__spec__\\core\\UtilSpec.ts:120\n' +
+          "                new Error('nope');\n" +
+          '                ^\n' +
+          '\n' +
+          'Error: nope\n' +
+          '    at fn1 (C:\\__spec__\\core\\UtilSpec.js:115:19)\n' +
+          '        -> C:\\__spec__\\core\\UtilSpec.ts:120:15\n' +
+          '    at fn2 (C:\\__jasmine__\\lib\\jasmine-core\\jasmine.js:7533:40)\n' +
+          '    at fn3 (C:\\__jasmine__\\lib\\jasmine-core\\jasmine.js:7575:25)\n' +
+          '    at fn4 (node:internal/timers:462:21)\n'
+      };
+      var subject = new jasmineUnderTest.ExceptionFormatter({
+        jasmineFile: 'C:\\__jasmine__\\lib\\jasmine-core\\jasmine.js'
+      });
+      var result = subject.stack(error);
+      expect(result).toEqual(
+        'C:\\__spec__\\core\\UtilSpec.ts:120\n' +
+          "                new Error('nope');\n" +
+          '                ^\n' +
+          'Error: nope\n' +
+          '    at fn1 (C:\\__spec__\\core\\UtilSpec.js:115:19)\n' +
+          '        -> C:\\__spec__\\core\\UtilSpec.ts:120:15\n' +
+          '    at <Jasmine>\n' +
+          '    at fn4 (node:internal/timers:462:21)'
+      );
+    });
+
     it('filters Jasmine stack frames from V8 style traces', function() {
       var error = {
         message: 'nope',

--- a/src/core/ExceptionFormatter.js
+++ b/src/core/ExceptionFormatter.js
@@ -63,7 +63,7 @@ getJasmineRequireObj().ExceptionFormatter = function(j$) {
           stackTrace.style === 'webkit' ? '<Jasmine>' : '    at <Jasmine>';
 
       stackTrace.frames.forEach(function(frame) {
-        if (frame.file && frame.file !== jasmineFile) {
+        if (frame.file !== jasmineFile) {
           result.push(frame.raw);
         } else if (result[result.length - 1] !== jasmineMarker) {
           result.push(jasmineMarker);


### PR DESCRIPTION
## Description
Node.js >=12.12.0 has support for source maps when run with the flag [`--enable-source-maps`](https://nodejs.org/dist/latest/docs/api/cli.html#cli_enable_source_maps) but the additional stack trace information is not being shown by Jasmine's stack traces. This pull request stops stack trace information from being discarded. Among other things, this causes the source map information to show up.

## Motivation and Context
Currently Jasmine discards source map information from stack traces when the `file` property is not set on those stack frames.
This would proably fix https://github.com/jasmine/jasmine/issues/491.

It might be relevant that the "competing" framework Mocha has specific support for `--enable-source-maps`: https://mochajs.org/#-enable-source-maps

Personally, I would prefer a completely unmodified stack trace from Node/V8, because I think that most users are educated enough to be able to read those. The extra information is just too valuable.

## How Has This Been Tested?

I have manually tested this with a test suite that throws an error. Before running Jasmine I had to set the following environment variable:

```powershell
# Setting environment variables might look different in your shell. This is what I ran in PowerShell:
$env:NODE_OPTIONS = '--enable-source-maps'
```

 The stack trace looks much more complete now and it finally includes the source map information. I am not sure if it's feasible to add an automated test, because the feature requires at least Node.js v12.12.0, so the test would fail on Node.js 10. Additionally, we would have to `--enable-source-maps` for the test process.

Output before:

```
  Stack:
        at <Jasmine>
        at UserContext.<anonymous> (C:\test\spec\spec.js:3:15)
        at <Jasmine>
        at processImmediate (node:internal/timers:462:21)
```

Output after:

```
  Stack:
    C:\test\spec\spec.ts:9
            throw new Error('This is a test');
                  ^
    Error: This is a test
        at UserContext.<anonymous> (C:\test\spec\spec.js:3:15)
            -> C:\test\spec\spec.ts:9:15
        at <Jasmine>
        at processImmediate (node:internal/timers:462:21)
```
Note that this includes the correct TypeScript filename as well as correct line/column numbers. Many editors (such as VS Code) can turn this into a clickable link that directly opens the source file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

