### PR TITLE
HtmlReporter: Handle child of number type

### DIFF
--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -641,8 +641,8 @@ jasmineRequire.HtmlReporter = function(j$) {
       for (var i = 2; i < arguments.length; i++) {
         var child = arguments[i];
 
-        if (typeof child === 'string') {
-          el.appendChild(createTextNode(child));
+        if (typeof child === 'string' || typeof child === 'number') {
+          el.appendChild(createTextNode(child.toString()));
         } else {
           if (child) {
             el.appendChild(child);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Really small change to handle the rendering of numerical child elements in the HtmlReporter `createDom` method.

> It is my first time contributing here so apologies if I've not done it correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently when the child element is a number it hits the `else` block and tries to use `appendChild` with a number. Unfortunately this breaks as shown in the screenshot below:

![image](https://user-images.githubusercontent.com/57188539/99075208-021fa700-25b1-11eb-8252-3baf9652f20e.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I discovered this having run tests in work code (sorry, it is confidential so cannot share). I changed the code within node_modules and re-ran my tests - results shown in screenshot below:

![image](https://user-images.githubusercontent.com/57188539/99074689-23cc5e80-25b0-11eb-8a3f-701c19951d07.png)

Also ran the existing tests `npm test` and `node spec/support/ci.js` when following the contributor guidelines.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

