### PR TITLE
Add string shortening in `DiffBuilder`

### DIFF
--- a/spec/core/matchers/DiffBuilderSpec.js
+++ b/spec/core/matchers/DiffBuilderSpec.js
@@ -210,4 +210,32 @@ describe('DiffBuilder', function() {
 
     expect(diffBuilder.getMessage()).toEqual(expectedMsg);
   });
+
+  it('shortens strings', function() {
+    var abc = 'abcdefghijklmnopqrstuvwxyz',
+      repeatedABC = '';
+    for (var i = 0; i < 100; i++) {
+      repeatedABC += abc;
+    }
+    var expected = repeatedABC;
+    var actual =
+      repeatedABC.substring(0, 1800) + 'XXXXX' + repeatedABC.substring(1805);
+
+    var prettyPrinter = jasmineUnderTest.makePrettyPrinter([]),
+      diffBuilder = new jasmineUnderTest.DiffBuilder({
+        prettyPrinter: prettyPrinter
+      });
+
+    diffBuilder.setRoots(actual, expected);
+    diffBuilder.recordMismatch();
+
+    var expectedMsg =
+      "Expected '[1761 omitted " +
+      'characters...]tuvwxyzabcdefghijklmnopqrstuvwxyzabcdefXXXXXlmnopqrstuvwxyzabcdefghijklmnopqrstu[...759 ' +
+      "omitted characters]' to equal '[1761 omitted " +
+      'characters...]tuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstu[...759 ' +
+      "omitted characters]'.";
+
+    expect(diffBuilder.getMessage()).toBe(expectedMsg);
+  });
 });

--- a/src/core/matchers/DiffBuilder.js
+++ b/src/core/matchers/DiffBuilder.js
@@ -28,9 +28,13 @@ getJasmineRequireObj().DiffBuilder = function(j$) {
               actualRoot,
               expectedRoot,
               prettyPrinter
-            ),
-            actual = derefResult.actual,
-            expected = derefResult.expected;
+            );
+          var shortened = shortenStrings(
+            derefResult.actual,
+            derefResult.expected
+          );
+          var actual = shortened.shortenedActual;
+          var expected = shortened.shortenedExpected;
 
           if (formatter) {
             messages.push(formatter(actual, expected, path, prettyPrinter));
@@ -114,5 +118,119 @@ getJasmineRequireObj().DiffBuilder = function(j$) {
     }
 
     return { actual: actual, expected: expected };
+  }
+
+  function shortenStrings(actual, expected) {
+    if (!(typeof actual === 'string' && typeof expected === 'string')) {
+      return { shortenedActual: actual, shortenedExpected: expected };
+    }
+    var shortened = shortenValues(actual, expected);
+    var shortenedActual = shortened.actual;
+    var shortenedExpected = shortened.expected;
+    return {
+      shortenedActual: shortenedActual,
+      shortenedExpected: shortenedExpected
+    };
+  }
+
+  /**
+   * Builds shortened versions of `actual` and `expected`, such that their
+   * difference is easily visible.
+   * @param {!string} actual
+   * @param {!string} expected
+   * @return {object}
+   */
+  function shortenValues(actual, expected) {
+    var iofdc = getIndexOfFirstDifferentCharacter(actual, expected);
+    var prettyActual = getStringAbout(actual, iofdc);
+    var prettyExpected = getStringAbout(expected, iofdc);
+    return { actual: prettyActual, expected: prettyExpected };
+
+    /**
+     * Returns index of first different character among `a` and `b`. If either
+     * is an initial substring (a substring starting at index 0) of the other,
+     * `-1` is returned. If `a == b`, `-1` is returned.
+     * @param {string} a
+     * @param {string} b
+     */
+    function getIndexOfFirstDifferentCharacter(a, b) {
+      var shortestLength = Math.min(a.length, b.length);
+      for (var i = 0; i < shortestLength; i++) {
+        var aChar = a[i];
+        var bChar = b[i];
+        if (aChar !== bChar) {
+          return i;
+        }
+      }
+      return -1;
+    }
+
+    /**
+     * Returns a string containing: 1) a substring of `str` of maximum
+     * `MAX_LENGTH` characters about index `center`, 2) if applicable, an
+     * indication of the number of omitted leading characters and 3) if
+     * applicable, an indication of the number of omitted trailing characters.
+     * For example, given that `str = '01234567890123456789'`, `center= 10`
+     * and `MAX_LENGTH = 3` the return value would be `"[9 omitted
+     * characters]...901...[8 omitted characters]"`. If `center` is not a
+     * valid index for `str`, `0` is used instead.
+     * @param {string} str
+     * @param {number} center
+     * @param {number=80} MAX_LENGTH
+     */
+    function getStringAbout(str, center, MAX_LENGTH) {
+      if (!MAX_LENGTH) {
+        MAX_LENGTH = 80;
+      }
+      var length = str.length;
+      if (!(0 <= center && center < length)) {
+        center = 0;
+      }
+      var half = MAX_LENGTH / 2;
+      var isEven = isInteger(half);
+      var flooredHalf = Math.floor(half);
+      var allowedLeft = flooredHalf - isEven;
+      var allowedRight = flooredHalf;
+      var availableLeft = center;
+      var availableRight = length - center - 1;
+      var actualLeft = Math.min(allowedLeft, availableLeft);
+      var actualRight = Math.min(allowedRight, availableRight);
+      var omittedLeft = availableLeft - actualLeft;
+      var omittedRight = availableRight - actualRight;
+      var omittedLeftIndicator = getOmittedCharactersIndicator(
+        omittedLeft,
+        'left'
+      );
+      var omittedRightIndicator = getOmittedCharactersIndicator(
+        omittedRight,
+        'right'
+      );
+      var substring = str.substr(center - actualLeft, MAX_LENGTH);
+      return omittedLeftIndicator + substring + omittedRightIndicator;
+
+      function isInteger(value) {
+        return (
+          typeof value === 'number' &&
+          isFinite(value) &&
+          Math.floor(value) === value
+        );
+      }
+
+      function getOmittedCharactersIndicator(number, side) {
+        var message;
+        if (number === 0) {
+          return '';
+        } else if (number === 1) {
+          message = '1 omitted character';
+        } else {
+          message = number + ' omitted characters';
+        }
+        if (side === 'left') {
+          return '[' + message + '...]';
+        } else {
+          return '[...' + message + ']';
+        }
+      }
+    }
   }
 };


### PR DESCRIPTION
* Fixes #1870

<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a function to modify the `actual` and `expected` used to `getMessage` in `DiffBuilder`. This function will be a no-op if `actual` or `expected` is not a string. When both are, the function shortens the used value of each so that at least the first different parts of the strings compared are shown. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Added a spec.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

