### PR TITLE
fix jsdoc config.seed type

### DIFF
--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -53,7 +53,7 @@ getJasmineRequireObj().Env = function(j$) {
        * Null causes the seed to be determined randomly at the start of execution.
        * @name Configuration#seed
        * @since 3.3.0
-       * @type function
+       * @type number
        * @default null
        */
       seed: null,

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -53,7 +53,7 @@ getJasmineRequireObj().Env = function(j$) {
        * Null causes the seed to be determined randomly at the start of execution.
        * @name Configuration#seed
        * @since 3.3.0
-       * @type number
+       * @type (number|string)
        * @default null
        */
       seed: null,


### PR DESCRIPTION
## Description

I believe the `seed` configuration option should be a number but the docs say it should be a function.

Also according to the tests it can be a string? so I'm not sure if it should be a string or number, but I know it is not supposed to be a function.

## Motivation and Context

Docs are wrong.

## How Has This Been Tested?

There are already tests for the seed function passing a number as a string.

https://github.com/jasmine/jasmine/blob/cd1131354bea551ef11478e313fe66fb11721cf4/spec/core/integration/SpecRunningSpec.js#L697

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs Change (only documentation changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

