### PR TITLE
Implement callTracker.thisFor()

### DIFF
--- a/spec/core/CallTrackerSpec.js
+++ b/spec/core/CallTrackerSpec.js
@@ -37,9 +37,11 @@ describe('CallTracker', function() {
       this1 = {};
     callTracker.track({ object: this0, args: [] });
     callTracker.track({ object: this1, args: [] });
+    callTracker.track({ args: [] });
 
     expect(callTracker.thisFor(0)).toBe(this0);
     expect(callTracker.thisFor(1)).toBe(this1);
+    expect(callTracker.thisFor(2)).toBe(undefined);
   });
 
   it('returns any empty array when there was no call', function() {

--- a/spec/core/CallTrackerSpec.js
+++ b/spec/core/CallTrackerSpec.js
@@ -30,6 +30,18 @@ describe('CallTracker', function() {
     expect(callTracker.argsFor(1)).toEqual([0, 'foo']);
   });
 
+  it("tracks the 'this' object from each execution", function() {
+    var callTracker = new jasmineUnderTest.CallTracker();
+
+    var this0 = {},
+      this1 = {};
+    callTracker.track({ object: this0, args: [] });
+    callTracker.track({ object: this1, args: [] });
+
+    expect(callTracker.thisFor(0)).toBe(this0);
+    expect(callTracker.thisFor(1)).toBe(this1);
+  });
+
   it('returns any empty array when there was no call', function() {
     var callTracker = new jasmineUnderTest.CallTracker();
 

--- a/src/core/CallTracker.js
+++ b/src/core/CallTracker.js
@@ -50,6 +50,19 @@ getJasmineRequireObj().CallTracker = function(j$) {
     };
 
     /**
+     * Get the "this" object that was passed to a specific invocation of this spy.
+     * @name Spy#calls#thisFor
+     * @since 3.7.1
+     * @function
+     * @param {Integer} index The 0-based invocation index.
+     * @return {Object?}
+     */
+    this.thisFor = function(index) {
+      var call = calls[index];
+      return call ? call.object : undefined;
+    };
+
+    /**
      * Get the raw calls array for this spy.
      * @name Spy#calls#all
      * @since 2.0.0


### PR DESCRIPTION
## Description
I am proposing a simple change to spies, to allow easy retrieval of the `this` object for expectations.

## Motivation and Context
I had a need to inspect the `this` object for a spy call, but the API in this particular spot is cumbersome.  This merge request makes it much easier.    This fixes #1902, which I filed for this purpose.

## How Has This Been Tested?
I wrote the implementation and the automated test for this, specifically checking _only_ the results of the thisFor() call.  I tested it in Node 15 using `npm test`.

I did _not_ test it in any browser, as this was a pretty simple change and I didn't have the infrastructure set up to do the browser test.  (Sorry, but I'll need someone to walk me through that, perhaps with changes to the contributor's guide...)

No other tests or code have been changed.  This is a straight-forward API addition.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
