### PR TITLE
htmlreporter: appendChild of a specDone only all 500ms

### DIFF
--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -70,6 +70,14 @@ describe('HtmlReporter', function() {
   });
 
   describe('when a spec is done', function() {
+    beforeEach(function() {
+      jasmine.clock().install();
+    });
+  
+    afterEach(function() {
+      jasmine.clock().uninstall();
+    });
+
     describe('and no expectations ran', function() {
       var container, reporter;
       beforeEach(function() {
@@ -108,13 +116,9 @@ describe('HtmlReporter', function() {
         expect(console.warn).toHaveBeenCalledWith(
           "Spec 'Some Name' has no expectations."
         );
-        return Promise.resolve()
-          // Let the specDone time to do its work.
-          .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
-          .then(() => {
-            var specEl = container.querySelector('.jasmine-symbol-summary li');
-            expect(specEl.getAttribute('class')).toEqual('jasmine-empty');
-        });
+        jasmine.clock().tick(1000);
+        var specEl = container.querySelector('.jasmine-symbol-summary li');
+        expect(specEl.getAttribute('class')).toEqual('jasmine-empty');
       });
 
       it('should log error to the console and print a failure symbol when empty spec status is failed', function() {
@@ -128,13 +132,9 @@ describe('HtmlReporter', function() {
         expect(console.error).toHaveBeenCalledWith(
           "Spec 'Some Name' has no expectations."
         );
-        return Promise.resolve()
-          // Let the specDone time to do its work.
-          .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
-          .then(() => {
-            var specEl = container.querySelector('.jasmine-symbol-summary li');
-            expect(specEl.getAttribute('class')).toEqual('jasmine-failed');
-        });
+        jasmine.clock().tick(1000);
+        var specEl = container.querySelector('.jasmine-symbol-summary li');
+        expect(specEl.getAttribute('class')).toEqual('jasmine-failed');
       });
     });
 
@@ -162,17 +162,13 @@ describe('HtmlReporter', function() {
         failedExpectations: []
       });
 
-      return Promise.resolve()
-        // Let the specDone time to do its work.
-        .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
-        .then(() => {
-          var specEl = container.querySelector('.jasmine-symbol-summary li');
-          expect(specEl.getAttribute('class')).toEqual('jasmine-excluded');
-          expect(specEl.getAttribute('id')).toEqual('spec_789');
-          expect(specEl.getAttribute('title')).toEqual(
-            'symbols should have titles'
-          );
-      });
+      jasmine.clock().tick(1000);
+      var specEl = container.querySelector('.jasmine-symbol-summary li');
+      expect(specEl.getAttribute('class')).toEqual('jasmine-excluded');
+      expect(specEl.getAttribute('id')).toEqual('spec_789');
+      expect(specEl.getAttribute('title')).toEqual(
+        'symbols should have titles'
+      );
     });
 
     it('reports the status symbol of a pending spec', function() {
@@ -199,14 +195,10 @@ describe('HtmlReporter', function() {
         failedExpectations: []
       });
 
-      return Promise.resolve()
-        // Let the specDone time to do its work.
-        .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
-        .then(() => {
-          var specEl = container.querySelector('.jasmine-symbol-summary li');
-          expect(specEl.getAttribute('class')).toEqual('jasmine-pending');
-          expect(specEl.getAttribute('id')).toEqual('spec_789');
-      });
+      jasmine.clock().tick(1000);
+      var specEl = container.querySelector('.jasmine-symbol-summary li');
+      expect(specEl.getAttribute('class')).toEqual('jasmine-pending');
+      expect(specEl.getAttribute('id')).toEqual('spec_789');
     });
 
     it('delays the status symbol of a passing spec', function() {
@@ -237,14 +229,10 @@ describe('HtmlReporter', function() {
       var specEl = statuses.querySelector('li');
       expect(specEl).toBe(null);
 
-      return Promise.resolve()
-        // Let the specDone time to do its work.
-        .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
-        .then(() => {
-          var statuses = container.querySelector('.jasmine-symbol-summary');
-          var specEl = statuses.querySelector('li');
-          expect(specEl).not.toBe(null);
-      });
+      jasmine.clock().tick(1000);
+      var statuses = container.querySelector('.jasmine-symbol-summary');
+      var specEl = statuses.querySelector('li');
+      expect(specEl).not.toBe(null);
     });
 
     it('reports the status symbol of a passing spec', function() {
@@ -271,15 +259,11 @@ describe('HtmlReporter', function() {
         failedExpectations: []
       });
 
-      return Promise.resolve()
-        // Let the specDone time to do its work.
-        .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
-        .then(() => {
-          var statuses = container.querySelector('.jasmine-symbol-summary');
-          var specEl = statuses.querySelector('li');
-          expect(specEl.getAttribute('class')).toEqual('jasmine-passed');
-          expect(specEl.getAttribute('id')).toEqual('spec_123');
-      });
+      jasmine.clock().tick(1000);
+      var statuses = container.querySelector('.jasmine-symbol-summary');
+      var specEl = statuses.querySelector('li');
+      expect(specEl.getAttribute('class')).toEqual('jasmine-passed');
+      expect(specEl.getAttribute('id')).toEqual('spec_123');
     });
 
     it('reports the status symbol of a failing spec', function() {
@@ -307,14 +291,10 @@ describe('HtmlReporter', function() {
         passedExpectations: []
       });
 
-      return Promise.resolve()
-        // Let the specDone time to do its work.
-        .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
-        .then(() => {
-          var specEl = container.querySelector('.jasmine-symbol-summary li');
-          expect(specEl.getAttribute('class')).toEqual('jasmine-failed');
-          expect(specEl.getAttribute('id')).toEqual('spec_345');
-      });
+      jasmine.clock().tick(1000);
+      var specEl = container.querySelector('.jasmine-symbol-summary li');
+      expect(specEl.getAttribute('class')).toEqual('jasmine-failed');
+      expect(specEl.getAttribute('id')).toEqual('spec_345');
     });
   });
 
@@ -903,6 +883,14 @@ describe('HtmlReporter', function() {
       });
     });
     describe('UI for hiding disabled specs', function() {
+      beforeEach(function() {
+        jasmine.clock().install();
+      });
+    
+      afterEach(function() {
+        jasmine.clock().uninstall();
+      });
+      
       it('should be unchecked if not hiding disabled specs', function() {
         var container = document.createElement('div'),
           getContainer = function() {
@@ -977,15 +965,11 @@ describe('HtmlReporter', function() {
           failedExpectations: []
         });
 
-        return Promise.resolve()
-          // Let the specDone time to do its work.
-          .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
-          .then(() => {
-            var specEl = container.querySelector('.jasmine-symbol-summary li');
-            expect(specEl.getAttribute('class')).toEqual(
-              'jasmine-excluded-no-display'
-            );
-        });
+        jasmine.clock().tick(1000);
+        var specEl = container.querySelector('.jasmine-symbol-summary li');
+        expect(specEl.getAttribute('class')).toEqual(
+          'jasmine-excluded-no-display'
+        );
       });
     });
     describe('UI for running tests in random order', function() {

--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -108,8 +108,13 @@ describe('HtmlReporter', function() {
         expect(console.warn).toHaveBeenCalledWith(
           "Spec 'Some Name' has no expectations."
         );
-        var specEl = container.querySelector('.jasmine-symbol-summary li');
-        expect(specEl.getAttribute('class')).toEqual('jasmine-empty');
+        return Promise.resolve()
+          // Let the specDone time to do its work.
+          .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
+          .then(() => {
+            var specEl = container.querySelector('.jasmine-symbol-summary li');
+            expect(specEl.getAttribute('class')).toEqual('jasmine-empty');
+        });
       });
 
       it('should log error to the console and print a failure symbol when empty spec status is failed', function() {
@@ -123,8 +128,13 @@ describe('HtmlReporter', function() {
         expect(console.error).toHaveBeenCalledWith(
           "Spec 'Some Name' has no expectations."
         );
-        var specEl = container.querySelector('.jasmine-symbol-summary li');
-        expect(specEl.getAttribute('class')).toEqual('jasmine-failed');
+        return Promise.resolve()
+          // Let the specDone time to do its work.
+          .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
+          .then(() => {
+            var specEl = container.querySelector('.jasmine-symbol-summary li');
+            expect(specEl.getAttribute('class')).toEqual('jasmine-failed');
+        });
       });
     });
 
@@ -152,12 +162,17 @@ describe('HtmlReporter', function() {
         failedExpectations: []
       });
 
-      var specEl = container.querySelector('.jasmine-symbol-summary li');
-      expect(specEl.getAttribute('class')).toEqual('jasmine-excluded');
-      expect(specEl.getAttribute('id')).toEqual('spec_789');
-      expect(specEl.getAttribute('title')).toEqual(
-        'symbols should have titles'
-      );
+      return Promise.resolve()
+        // Let the specDone time to do its work.
+        .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
+        .then(() => {
+          var specEl = container.querySelector('.jasmine-symbol-summary li');
+          expect(specEl.getAttribute('class')).toEqual('jasmine-excluded');
+          expect(specEl.getAttribute('id')).toEqual('spec_789');
+          expect(specEl.getAttribute('title')).toEqual(
+            'symbols should have titles'
+          );
+      });
     });
 
     it('reports the status symbol of a pending spec', function() {
@@ -184,9 +199,14 @@ describe('HtmlReporter', function() {
         failedExpectations: []
       });
 
-      var specEl = container.querySelector('.jasmine-symbol-summary li');
-      expect(specEl.getAttribute('class')).toEqual('jasmine-pending');
-      expect(specEl.getAttribute('id')).toEqual('spec_789');
+      return Promise.resolve()
+        // Let the specDone time to do its work.
+        .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
+        .then(() => {
+          var specEl = container.querySelector('.jasmine-symbol-summary li');
+          expect(specEl.getAttribute('class')).toEqual('jasmine-pending');
+          expect(specEl.getAttribute('id')).toEqual('spec_789');
+      });
     });
 
     it('reports the status symbol of a passing spec', function() {
@@ -213,10 +233,15 @@ describe('HtmlReporter', function() {
         failedExpectations: []
       });
 
-      var statuses = container.querySelector('.jasmine-symbol-summary');
-      var specEl = statuses.querySelector('li');
-      expect(specEl.getAttribute('class')).toEqual('jasmine-passed');
-      expect(specEl.getAttribute('id')).toEqual('spec_123');
+      return Promise.resolve()
+        // Let the specDone time to do its work.
+        .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
+        .then(() => {
+          var statuses = container.querySelector('.jasmine-symbol-summary');
+          var specEl = statuses.querySelector('li');
+          expect(specEl.getAttribute('class')).toEqual('jasmine-passed');
+          expect(specEl.getAttribute('id')).toEqual('spec_123');
+      });
     });
 
     it('reports the status symbol of a failing spec', function() {
@@ -244,9 +269,14 @@ describe('HtmlReporter', function() {
         passedExpectations: []
       });
 
-      var specEl = container.querySelector('.jasmine-symbol-summary li');
-      expect(specEl.getAttribute('class')).toEqual('jasmine-failed');
-      expect(specEl.getAttribute('id')).toEqual('spec_345');
+      return Promise.resolve()
+        // Let the specDone time to do its work.
+        .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
+        .then(() => {
+          var specEl = container.querySelector('.jasmine-symbol-summary li');
+          expect(specEl.getAttribute('class')).toEqual('jasmine-failed');
+          expect(specEl.getAttribute('id')).toEqual('spec_345');
+      });
     });
   });
 
@@ -909,10 +939,15 @@ describe('HtmlReporter', function() {
           failedExpectations: []
         });
 
-        var specEl = container.querySelector('.jasmine-symbol-summary li');
-        expect(specEl.getAttribute('class')).toEqual(
-          'jasmine-excluded-no-display'
-        );
+        return Promise.resolve()
+          // Let the specDone time to do its work.
+          .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
+          .then(() => {
+            var specEl = container.querySelector('.jasmine-symbol-summary li');
+            expect(specEl.getAttribute('class')).toEqual(
+              'jasmine-excluded-no-display'
+            );
+        });
       });
     });
     describe('UI for running tests in random order', function() {

--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -209,6 +209,44 @@ describe('HtmlReporter', function() {
       });
     });
 
+    it('delays the status symbol of a passing spec', function() {
+      var container = document.createElement('div'),
+        getContainer = function() {
+          return container;
+        },
+        reporter = new jasmineUnderTest.HtmlReporter({
+          env: env,
+          getContainer: getContainer,
+          createElement: function() {
+            return document.createElement.apply(document, arguments);
+          },
+          createTextNode: function() {
+            return document.createTextNode.apply(document, arguments);
+          }
+        });
+      reporter.initialize();
+
+      reporter.specDone({
+        id: 123,
+        status: 'passed',
+        passedExpectations: [{ passed: true }],
+        failedExpectations: []
+      });
+
+      var statuses = container.querySelector('.jasmine-symbol-summary');
+      var specEl = statuses.querySelector('li');
+      expect(specEl).toBe(null);
+
+      return Promise.resolve()
+        // Let the specDone time to do its work.
+        .then(() => { return new Promise((resolve) => setTimeout(resolve, 500)); })
+        .then(() => {
+          var statuses = container.querySelector('.jasmine-symbol-summary');
+          var specEl = statuses.querySelector('li');
+          expect(specEl).not.toBe(null);
+      });
+    });
+
     it('reports the status symbol of a passing spec', function() {
       var container = document.createElement('div'),
         getContainer = function() {

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -110,7 +110,7 @@ jasmineRequire.HtmlReporter = function(j$) {
 
     var failures = [];
     var specDoneTimeoutId = 0;
-    var specDoneFragment = getContainer().ownerDocument.createDocumentFragment();
+    var specDoneFragment;
     this.specDone = function(result) {
       stateBuilder.specDone(result);
 
@@ -127,8 +127,11 @@ jasmineRequire.HtmlReporter = function(j$) {
         symbols = find('.jasmine-symbol-summary');
       }
 
+      if(!specDoneFragment) {
+        specDoneFragment = getContainer().ownerDocument.createDocumentFragment();
+      }
       if(!specDoneTimeoutId){
-        specDoneTimeoutId = getContainer().ownerDocument.defaultView.setTimeout(function(){
+        specDoneTimeoutId = getContainer().ownerDocument.defaultView.setTimeout(function() {
           specDoneTimeoutId = 0;
           symbols.appendChild(specDoneFragment);
         }, 500);

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -109,6 +109,8 @@ jasmineRequire.HtmlReporter = function(j$) {
     };
 
     var failures = [];
+    var specDoneTimeoutId = 0;
+    var specDoneFragment = getContainer().ownerDocument.createDocumentFragment();
     this.specDone = function(result) {
       stateBuilder.specDone(result);
 
@@ -125,7 +127,13 @@ jasmineRequire.HtmlReporter = function(j$) {
         symbols = find('.jasmine-symbol-summary');
       }
 
-      symbols.appendChild(
+      if(!specDoneTimeoutId){
+        specDoneTimeoutId = getContainer().ownerDocument.defaultView.setTimeout(function(){
+          specDoneTimeoutId = 0;
+          symbols.appendChild(specDoneFragment);
+        }, 500);
+      }
+      specDoneFragment.appendChild(
         createDom('li', {
           className: this.displaySpecInCorrectFormat(result),
           id: 'spec_' + result.id,

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -130,11 +130,11 @@ jasmineRequire.HtmlReporter = function(j$) {
       if(!specDoneFragment) {
         specDoneFragment = getContainer().ownerDocument.createDocumentFragment();
       }
-      if(!specDoneTimeoutId){
+      if(!specDoneTimeoutId) {
         specDoneTimeoutId = getContainer().ownerDocument.defaultView.setTimeout(function() {
           specDoneTimeoutId = 0;
           symbols.appendChild(specDoneFragment);
-        }, 500);
+        }, 100);
       }
       specDoneFragment.appendChild(
         createDom('li', {


### PR DESCRIPTION
## Description
appendChild with all success full spec costs time because it forces the browser to rerender every dot.

## Motivation and Context
Ran 2 of 4822 specs => 27 seconds with the main branch
Screenshot from devtools performance trace shows constant "layout", "update layer tree", "paint":
![image](https://user-images.githubusercontent.com/2410353/114697115-ca628a00-9d1d-11eb-933d-ceb2d22bc4d6.png)

Ran 2 of 4822 specs => 12 seconds with this branch
Screenshot from devtools performance trace shows "layout", "update layer tree", "paint" only every 500ms:
![image](https://user-images.githubusercontent.com/2410353/114697047-b6b72380-9d1d-11eb-99f8-fafc687f61f8.png)

## How Has This Been Tested?
Ran many tests with success and failures.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

