### PR TITLE
Allow option for spyOnAllFunctions to include non-enumerable props

### DIFF
--- a/src/core/requireInterface.js
+++ b/src/core/requireInterface.js
@@ -285,10 +285,11 @@ getJasmineRequireObj().interface = function(jasmine, env) {
      * @function
      * @global
      * @param {Object} obj - The object upon which to install the {@link Spy}s
+     * @param {boolean} includeNonEnumerable - Whether or not to add spies to non-enumerable properties
      * @returns {Object} the spied object
      */
-    spyOnAllFunctions: function(obj) {
-      return env.spyOnAllFunctions(obj);
+    spyOnAllFunctions: function(obj, includeNonEnumerable) {
+      return env.spyOnAllFunctions(obj, includeNonEnumerable);
     },
 
     jsApiReporter: new jasmine.JsApiReporter({


### PR DESCRIPTION
## Description

- Added a new optional parameter to `spyOnAllFunctions` which, when true, will also check non-enumerable properties of the passed object.
- Could instead be split into 2 functions.
- I set it up to ignore the Object prototype, but only when you are including non-enumerable so as not to change the old behaviour, so this while condition looks a bit strange.
- To make sure we don't spy on the constructor I'm just ignoring any non-enumerable properties called constructor (again, no change for when non-enumerable is falsey, just uses all the enumerable props).
-  try-catch added because now we are accessing non-enumerable properties we might get an error when trying to get a property (TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them). Not sure if there's a nicer way to make sure we can access a property before we try.
- Added a test to make sure non-enumerable properties are spied on when true is passed, and one to make sure Object.prototype is not spied on. Do all the existing `spyOnAllFunctions` tests need to run again for true being passed though?

## Motivation and Context
In newer JS and compiled TS using `class`, methods end up non-enumerable, so `spyOnAllFunctions` does not spy on anything.
See #1897 

## How Has This Been Tested?
Tested on:
node 12.13.0
chrome 90.0.4430.85
firefox 86.0.1

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project. (Ran prettier)
- [x] My change requires a change to the documentation. (New param for spyOnAllFunctions)
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

