### PR TITLE
new attempt for fixing #1906: add window.location.pathname to hrefs +…

### DIFF
--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -484,7 +484,7 @@ describe('HtmlReporter', function() {
       var suiteDetail = outerSuite.childNodes[0];
       var suiteLink = suiteDetail.childNodes[0];
       expect(suiteLink.innerHTML).toEqual('A Suite');
-      expect(suiteLink.getAttribute('href')).toEqual('?foo=bar&spec=A Suite');
+      expect(suiteLink.getAttribute('href')).toEqual('/?foo=bar&spec=A Suite');
 
       var specs = outerSuite.childNodes[1];
       var spec = specs.childNodes[0];
@@ -494,7 +494,7 @@ describe('HtmlReporter', function() {
       var specLink = spec.childNodes[0];
       expect(specLink.innerHTML).toEqual('with a spec');
       expect(specLink.getAttribute('href')).toEqual(
-        '?foo=bar&spec=A Suite with a spec'
+        '/?foo=bar&spec=A Suite with a spec'
       );
     });
 
@@ -1050,7 +1050,7 @@ describe('HtmlReporter', function() {
         var seedBar = container.querySelector('.jasmine-seed-bar');
         expect(seedBar.textContent).toBe(', randomized with seed 424242');
         var seedLink = container.querySelector('.jasmine-seed-bar a');
-        expect(seedLink.getAttribute('href')).toBe('?seed=424242');
+        expect(seedLink.getAttribute('href')).toBe('/?seed=424242');
       });
 
       it('should not show the current seed bar if not randomizing', function() {
@@ -1099,7 +1099,7 @@ describe('HtmlReporter', function() {
         reporter.jasmineDone({ order: { random: true } });
 
         var skippedLink = container.querySelector('.jasmine-skipped a');
-        expect(skippedLink.getAttribute('href')).toEqual('?foo=bar&spec=');
+        expect(skippedLink.getAttribute('href')).toEqual('/?foo=bar&spec=');
       });
     });
 

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -177,7 +177,10 @@ jasmineRequire.HtmlReporter = function(j$) {
           ' of ' +
           totalSpecsDefined +
           ' specs - run all';
-        var skippedLink = addToExistingQueryString('spec', '');
+        // include window.location.pathname to fix issue with karma-jasmine-html-reporter in angular: see https://github.com/jasmine/jasmine/issues/1906
+        var skippedLink =
+          (window.location.pathname || '') +
+          addToExistingQueryString('spec', '');
         alert.appendChild(
           createDom(
             'span',
@@ -604,7 +607,11 @@ jasmineRequire.HtmlReporter = function(j$) {
         suite = suite.parent;
       }
 
-      return addToExistingQueryString('spec', els.join(' '));
+      // include window.location.pathname to fix issue with karma-jasmine-html-reporter in angular: see https://github.com/jasmine/jasmine/issues/1906
+      return (
+        (window.location.pathname || '') +
+        addToExistingQueryString('spec', els.join(' '))
+      );
     }
 
     function addDeprecationWarnings(result, runnableType) {
@@ -668,11 +675,19 @@ jasmineRequire.HtmlReporter = function(j$) {
     }
 
     function specHref(result) {
-      return addToExistingQueryString('spec', result.fullName);
+      // include window.location.pathname to fix issue with karma-jasmine-html-reporter in angular: see https://github.com/jasmine/jasmine/issues/1906
+      return (
+        (window.location.pathname || '') +
+        addToExistingQueryString('spec', result.fullName)
+      );
     }
 
     function seedHref(seed) {
-      return addToExistingQueryString('seed', seed);
+      // include window.location.pathname to fix issue with karma-jasmine-html-reporter in angular: see https://github.com/jasmine/jasmine/issues/1906
+      return (
+        (window.location.pathname || '') +
+        addToExistingQueryString('seed', seed)
+      );
     }
 
     function defaultQueryString(key, value) {


### PR DESCRIPTION
… comments + fixed tests

## Description
Add window.location.pathname to hrefs in HtmlReports.js, in order to fix issue #1906 

## Motivation and Context
See issue #1906, and earlier PR [here](https://github.com/jasmine/jasmine/pull/1907#issue-616833019)

## How Has This Been Tested?
Ran & fixed specs in local environment.

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.

