### PR TITLE
Make j$.isError_ compatible with Trusted Types

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -270,6 +270,16 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
     if (value instanceof Error) {
       return true;
     }
+    if (
+      typeof window !== 'undefined' &&
+      typeof window.trustedTypes !== 'undefined'
+    ) {
+      return (
+        value &&
+        typeof value.stack === 'string' &&
+        typeof value.message === 'string'
+      );
+    }
     if (value && value.constructor && value.constructor.constructor) {
       var valueGlobal = value.constructor.constructor('return this');
       if (j$.isFunction_(valueGlobal)) {

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -102,6 +102,16 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
     if (value instanceof Error) {
       return true;
     }
+    if (
+      typeof window !== 'undefined' &&
+      typeof window.trustedTypes !== 'undefined'
+    ) {
+      return (
+        value &&
+        typeof value.stack === 'string' &&
+        typeof value.message === 'string'
+      );
+    }
     if (value && value.constructor && value.constructor.constructor) {
       var valueGlobal = value.constructor.constructor('return this');
       if (j$.isFunction_(valueGlobal)) {


### PR DESCRIPTION
The isError_ check uses a heuristic that calls the Function constructor
to determine if the given value is an Error object. This results in a
runtime violation in test suites that enforce Trusted Types.

Since Trusted Types are only supported in modern browsers (currently,
Chromium-based browsers), we can use a more straightforward heuristic in
environments where Trusted Types are supported.

Fixes #1910. See that thread for more details.

## How Has This Been Tested?
With `npm test` as well as `npm run serve` and running the test suite in Chrome 91 (which supports Trusted Types) and Safari 14.1 (which does not support Trusted Types), both on macOS.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

cc @sgravrock 