### PR TITLE
update base.js docs, mention setting DEFAULT_TIMEOUT_INTERVAL to a high number while debugging

### DIFF
--- a/src/core/base.js
+++ b/src/core/base.js
@@ -5,7 +5,7 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
 
   /**
    * Maximum object depth the pretty printer will print to.
-   * Set this to a lower value to speed up pretty printing if you have large objects.
+   * Set this to a lower value to speed up pretty printing if you have large objects. The default value is 8.
    * @name jasmine.MAX_PRETTY_PRINT_DEPTH
    * @since 1.3.0
    */
@@ -13,20 +13,23 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
   /**
    * Maximum number of array elements to display when pretty printing objects.
    * This will also limit the number of keys and values displayed for an object.
-   * Elements past this number will be ellipised.
+   * Elements past this number will be ellipised. The default value is 50.
    * @name jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH
    * @since 2.7.0
    */
   j$.MAX_PRETTY_PRINT_ARRAY_LENGTH = 50;
   /**
    * Maximum number of characters to display when pretty printing objects.
-   * Characters past this number will be ellipised.
+   * Characters past this number will be ellipised. The default value is 1000.
    * @name jasmine.MAX_PRETTY_PRINT_CHARS
    * @since 2.9.0
    */
   j$.MAX_PRETTY_PRINT_CHARS = 1000;
   /**
    * Default number of milliseconds Jasmine will wait for an asynchronous spec to complete.
+   * While debugging tests, you may want to set this to a large
+   * number no bigger than 2147483647 so that `before` or `after` hooks do not run in the middle of an
+   * async test that you are stepping through in a debugger. The default value is 5000.
    * @name jasmine.DEFAULT_TIMEOUT_INTERVAL
    * @since 1.3.0
    */


### PR DESCRIPTION
This info is useful because if someone does not set the number to a high enough value while stepping through test code, before or after hooks may be triggered mid-test while the user is debugging which will be confusing.

Related: #1930 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

