### PR TITLE
Avoid NPE exception when  is null under IE9

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -679,12 +679,18 @@ getJasmineRequireObj().util = function(j$) {
     // Don't throw and catch. That makes it harder for users to debug their
     // code with exception breakpoints, and it's unnecessary since all
     // supported environments populate new Error().stack
-    return new Error();
+    const err = new Error();
+    if (err.stack) {
+      return err;
+    }
   };
 
   function callerFile() {
-    var trace = new j$.StackTrace(util.errorWithStack());
-    return trace.frames[2].file;
+    var err = util.errorWithStack();
+    if (err) {
+      var trace = new j$.StackTrace(err);
+      return trace.frames[2].file;
+    }
   }
 
   util.jasmineFile = (function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`Error.stack` Is not supported under IE9, and it means that an NPE exception will be thrown when trying to access `error.stack.split` under the method `StackTrace()`.

## Motivation and Context

To avoid this blocking exception.

## How Has This Been Tested?

Integrated with Krama, and TrifleJS.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

