### PR TITLE
Make saveArgumentsByValue clone Date objects correctly

### DIFF
--- a/spec/core/UtilSpec.js
+++ b/spec/core/UtilSpec.js
@@ -140,6 +140,32 @@ describe('jasmineUnderTest.util', function() {
     });
   });
 
+  describe('cloneArgs', function() {
+    it('clones primitives as-is', function() {
+      expect(jasmineUnderTest.util.cloneArgs([true, false])).toEqual([
+        true,
+        false
+      ]);
+      expect(jasmineUnderTest.util.cloneArgs([0, 1])).toEqual([0, 1]);
+      expect(jasmineUnderTest.util.cloneArgs(['str'])).toEqual(['str']);
+    });
+
+    it('clones Regexp objects as-is', function() {
+      var regex = /match/;
+      expect(jasmineUnderTest.util.cloneArgs([regex])).toEqual([regex]);
+    });
+
+    it('clones Date objects as-is', function() {
+      var date = new Date(2022, 1, 1);
+      expect(jasmineUnderTest.util.cloneArgs([date])).toEqual([date]);
+    });
+
+    it('clones null and undefined', function() {
+      expect(jasmineUnderTest.util.cloneArgs([null])).toEqual([null]);
+      expect(jasmineUnderTest.util.cloneArgs([undefined])).toEqual([undefined]);
+    });
+  });
+
   describe('getPropertyDescriptor', function() {
     it('get property descriptor from object', function() {
       var obj = { prop: 1 },

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -64,6 +64,8 @@ getJasmineRequireObj().util = function(j$) {
       // All falsey values are either primitives, `null`, or `undefined.
       if (!argsAsArray[i] || str.match(primitives)) {
         clonedArgs.push(argsAsArray[i]);
+      } else if (str === '[object Date]') {
+        clonedArgs.push(new Date(argsAsArray[i].valueOf()));
       } else {
         clonedArgs.push(j$.util.clone(argsAsArray[i]));
       }


### PR DESCRIPTION


## Description
Clones Date objects by value, so that saveArgumentsByValue works as expected

## Motivation and Context
* Fixes #1885
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

