### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -1042,7 +1042,7 @@ getJasmineRequireObj().Spec = function(j$) {
       boilerplateEnd =
         boilerplateStart + Spec.pendingSpecExceptionMessage.length;
 
-    return fullMessage.substr(boilerplateEnd);
+    return fullMessage.slice(boilerplateEnd);
   };
 
   Spec.pendingSpecExceptionMessage = '=> marked Pending';

--- a/spec/core/asymmetric_equality/ArrayContainingSpec.js
+++ b/spec/core/asymmetric_equality/ArrayContainingSpec.js
@@ -58,8 +58,8 @@ describe('ArrayContaining', function() {
       if (
         typeof a == 'string' &&
         typeof b == 'string' &&
-        a.substr(0, 3) == 'foo' &&
-        b.substr(0, 3) == 'foo'
+        a.slice(0, 3) == 'foo' &&
+        b.slice(0, 3) == 'foo'
       ) {
         return true;
       }

--- a/spec/core/asymmetric_equality/ArrayWithExactContentsSpec.js
+++ b/spec/core/asymmetric_equality/ArrayWithExactContentsSpec.js
@@ -48,8 +48,8 @@ describe('ArrayWithExactContents', function() {
       if (
         typeof a == 'string' &&
         typeof b == 'string' &&
-        a.substr(0, 3) == 'foo' &&
-        b.substr(0, 3) == 'foo'
+        a.slice(0, 3) == 'foo' &&
+        b.slice(0, 3) == 'foo'
       ) {
         return true;
       }

--- a/spec/core/asymmetric_equality/ObjectContainingSpec.js
+++ b/spec/core/asymmetric_equality/ObjectContainingSpec.js
@@ -121,8 +121,8 @@ describe('ObjectContaining', function() {
       if (
         typeof a == 'string' &&
         typeof b == 'string' &&
-        a.substr(0, 3) == 'foo' &&
-        b.substr(0, 3) == 'foo'
+        a.slice(0, 3) == 'foo' &&
+        b.slice(0, 3) == 'foo'
       ) {
         return true;
       }

--- a/spec/core/integration/CustomMatchersSpec.js
+++ b/spec/core/integration/CustomMatchersSpec.js
@@ -81,8 +81,8 @@ describe('Custom Matchers (Integration)', function() {
         if (
           typeof a == 'string' &&
           typeof b == 'string' &&
-          a.substr(0, 3) == 'foo' &&
-          b.substr(0, 3) == 'foo'
+          a.slice(0, 3) == 'foo' &&
+          b.slice(0, 3) == 'foo'
         ) {
           return true;
         }

--- a/src/core/Spec.js
+++ b/src/core/Spec.js
@@ -316,7 +316,7 @@ getJasmineRequireObj().Spec = function(j$) {
       boilerplateEnd =
         boilerplateStart + Spec.pendingSpecExceptionMessage.length;
 
-    return fullMessage.substr(boilerplateEnd);
+    return fullMessage.slice(boilerplateEnd);
   };
 
   Spec.pendingSpecExceptionMessage = '=> marked Pending';


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I have tested the return of each statement to make sure it's the same

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

