### PR TITLE
toEqual does not compare symbols that cannot be enumerated

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -5589,8 +5589,15 @@ getJasmineRequireObj().MatchersUtil = function(j$) {
           keys.push(key);
         }
       }
-      // eslint-disable-next-line compat/compat
-      return keys.concat(Object.getOwnPropertySymbols(o));
+
+      var symbols = Object.getOwnPropertySymbols(o);
+      for (var i = 0; i < symbols.length; i++) {
+        if (o.propertyIsEnumerable(symbols[i])) {
+          keys.push(symbols[i]);
+        }
+      }
+
+      return keys;
     })(obj);
 
     if (!isArray) {

--- a/spec/core/matchers/toEqualSpec.js
+++ b/spec/core/matchers/toEqualSpec.js
@@ -1042,6 +1042,29 @@ describe('toEqual', function() {
   // == Symbols ==
 
   describe('Symbols', function() {
+    it('Enumerable symbols are compared', function() {
+      const sym = Symbol('foo');
+      const actual = {};
+      Object.defineProperty(actual, sym, {
+        value: '',
+        enumerable: true
+      });
+      const expected = { [sym]: '' };
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('Symbols that cannot be enumerated are not compared ', function() {
+      const sym = Symbol('foo');
+      const actual = {};
+      Object.defineProperty(actual, sym, {
+        value: '',
+        enumerable: false
+      });
+      const expected = {};
+      expect(actual).toEqual(expected);
+    });
+
     it('Fails if Symbol compared to Object', function() {
       const sym = Symbol('foo');
       const obj = {};

--- a/src/core/matchers/matchersUtil.js
+++ b/src/core/matchers/matchersUtil.js
@@ -532,8 +532,15 @@ getJasmineRequireObj().MatchersUtil = function(j$) {
           keys.push(key);
         }
       }
-      // eslint-disable-next-line compat/compat
-      return keys.concat(Object.getOwnPropertySymbols(o));
+
+      var symbols = Object.getOwnPropertySymbols(o);
+      for (var i = 0; i < symbols.length; i++) {
+        if (o.propertyIsEnumerable(symbols[i])) {
+          keys.push(symbols[i]);
+        }
+      }
+
+      return keys;
     })(obj);
 
     if (!isArray) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ignore symbols that cannot be enumerated by the keys function of MatchersUtil.
`object.getOwnPropertySymbols` returns all found symbols directly, so it needs to be checked if it is enumerable.

Related to https://github.com/jasmine/jasmine/pull/1879

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for ignoring non-enumerable symbols and comparing enumerable symbols.
Run `npm test` and `npm run serve` to make sure all tests were green.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

