### PR TITLE
fix HTML reporter appendChild for number type

### DIFF
--- a/spec/html/HtmlReporterSpec.js
+++ b/spec/html/HtmlReporterSpec.js
@@ -1232,6 +1232,36 @@ describe('HtmlReporter', function() {
         expect(seedLink.getAttribute('href')).toBe('/?seed=424242');
       });
 
+      it('should succeed appending number seed to DOM', function() {
+        const container = document.createElement('div'),
+          getContainer = function() {
+            return container;
+          },
+          reporter = new jasmineUnderTest.HtmlReporter({
+            env: env,
+            getContainer: getContainer,
+            createElement: function() {
+              return document.createElement.apply(document, arguments);
+            },
+            createTextNode: function() {
+              return document.createTextNode.apply(document, arguments);
+            }
+          });
+
+        reporter.initialize();
+        reporter.jasmineDone({
+          order: {
+            random: true,
+            seed: 424242
+          }
+        });
+
+        const seedBar = container.querySelector('.jasmine-seed-bar');
+        expect(seedBar.textContent).toBe(', randomized with seed 424242');
+        const seedLink = container.querySelector('.jasmine-seed-bar a');
+        expect(seedLink.getAttribute('href')).toBe('/?seed=424242');
+      });
+
       it('should not show the current seed bar if not randomizing', function() {
         const container = document.createElement('div'),
           getContainer = function() {

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -758,7 +758,7 @@ jasmineRequire.HtmlReporter = function(j$) {
       for (let i = 0; i < children.length; i++) {
         const child = children[i];
 
-        if (typeof child === 'string') {
+        if (typeof child === 'string' || typeof child === 'number') {
           el.appendChild(createTextNode(child));
         } else {
           if (child) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I am failing to complete test execution as the HTML reporter attempts to append the `seed` used in test execution to the DOM. In this example, I have a fixed seed: `99683`.

Catching the error, I'm presented with the following:
```
TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'.
    at createDom (jasmine-html.js?c0209b90f32271a5a637e922e6e77ecb95e00316:798:16)
    at HtmlReporter.jasmineDone (jasmine-html.js?c0209b90f32271a5a637e922e6e77ecb95e00316:272:11)
    at UserContext.fn (jasmine.js?82bf6cfb195b9d0c4c25fbbafc07176191bc7d93:7780:23)
    at ZoneQueueRunner.attempt (jasmine.js?82bf6cfb195b9d0c4c25fbbafc07176191bc7d93:7608:40)
    at ZoneQueueRunner.QueueRunner.run (jasmine.js?82bf6cfb195b9d0c4c25fbbafc07176191bc7d93:7646:27)
    at ZoneQueueRunner.call [as execute] (jasmine.js?82bf6cfb195b9d0c4c25fbbafc07176191bc7d93:7500:10)
    at ZoneQueueRunner.execute (:9876/_karma_webpack_/webpack:/node_modules/zone.js/dist/zone-testing.js:710:46)
    at queueRunnerFactory (jasmine.js?82bf6cfb195b9d0c4c25fbbafc07176191bc7d93:1527:35)
    at jasmine.js?82bf6cfb195b9d0c4c25fbbafc07176191bc7d93:1628:16
    at dispatch (jasmine.js?82bf6cfb195b9d0c4c25fbbafc07176191bc7d93:7755:7)
```
![jasmine_html_seed_append_failure](https://user-images.githubusercontent.com/10604101/196795012-a2c276b6-ec52-4e31-aed2-84649e1f9f7d.GIF)


## Motivation and Context
Change allows test execution to complete.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Pipeline is executed with a fixed seed. First execution yields the error above. Second, with branch fix which allows execution to proceed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

