### PR TITLE
fix: use instanceof to check if obj is Node

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -309,8 +309,14 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
     return Object.prototype.toString.apply(value);
   };
 
+  const isBrowser =
+    typeof window !== 'undefined' && typeof window.document !== 'undefined';
+
   j$.isDomNode = function(obj) {
     // Node is a function, because constructors
+    if (isBrowser) {
+      return obj instanceof Node;
+    }
     return typeof jasmineGlobal.Node !== 'undefined'
       ? obj instanceof jasmineGlobal.Node
       : obj !== null &&


### PR DESCRIPTION
Use instanceof Node when jasmine runs in a browser.

## Description

I work on DOM serialization into javascript Objects, and because isDomNode incorrectly identify the serialized objects as DOM nodes, my test passes even though the serialization was incorrect.

## Motivation and Context

```typescript
  it("should fail but it does not", () => {
    expect({
      nodeType: 1,
      nodeName: "a"
    }).toEqual({
      nodeType: 2,
      nodeName: "b"
    });
  });
```

## How Has This Been Tested?
npm run test
npm run serve and manually checked in Firefox, Chrome, Safari.
npm test
npm run build and retested

I did not understand this step though:
`4. Revert your changes to jasmine.js and jasmine-html.js.`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project. (Not sure but happy to change)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

