### PR TITLE
Create oit (options it) function

### DIFF
--- a/spec/core/OptionsSpec.js
+++ b/spec/core/OptionsSpec.js
@@ -1,0 +1,305 @@
+function isEnabled() {
+  return true;
+}
+
+function isNotEnabled() {
+  return false;
+}
+
+function setEnable(isEnable) {
+  return isEnable;
+}
+
+function tenTimes() {
+  return 10;
+}
+
+function nTimes(n) {
+  return n;
+}
+
+function getDefaultArgs() {
+  return [[2, 3], [4, 4]];
+}
+
+function getRandomArgs(d1) {
+  let returnArray = [];
+  for (let i = 0; i < d1; i++) {
+    let a = Math.floor(Math.random() * 10) + 1;
+    let b = Math.floor(Math.random() * 10) + 1;
+
+    returnArray.push([a, b]);
+  }
+
+  return returnArray;
+}
+
+describe('option tests - ', () => {
+  oit(
+    'repeat 3',
+    () => {
+      let n = Math.random() * 10;
+      if (n < 5) {
+        expect(n).toBeLessThan(5);
+      } else {
+        expect(n).toBeGreaterThanOrEqual(5);
+      }
+    },
+    {
+      repeat: {
+        value: 3
+      }
+    }
+  );
+
+  oit(
+    'enable true',
+    () => {
+      expect(1).toBe(1);
+    },
+    {
+      enableIf: {
+        value: true
+      }
+    }
+  );
+
+  oit(
+    'enable false',
+    () => {
+      expect(1).toBe(1);
+    },
+    {
+      enableIf: {
+        value: false
+      }
+    }
+  );
+
+  oit(
+    'enable true with function without args',
+    () => {
+      expect(1).toBe(1);
+    },
+    {
+      enableIf: {
+        value: isEnabled
+      }
+    }
+  );
+
+  oit(
+    'enable true with function with args',
+    () => {
+      expect(1).toBe(1);
+    },
+    {
+      enableIf: {
+        value: {
+          fn: setEnable,
+          args: [true]
+        }
+      }
+    }
+  );
+
+  oit(
+    'enable false with function without args',
+    () => {
+      expect(1).toBe(1);
+    },
+    {
+      enableIf: {
+        value: isNotEnabled
+      }
+    }
+  );
+
+  oit(
+    'enable false with function with args',
+    () => {
+      expect(1).toBe(1);
+    },
+    {
+      enableIf: {
+        value: {
+          fn: setEnable,
+          args: [false]
+        }
+      }
+    }
+  );
+
+  oit(
+    'enable true and repeat 5',
+    () => {
+      let n = Math.random() * 10;
+      if (n < 5) {
+        expect(n).toBeLessThan(5);
+      } else {
+        expect(n).toBeGreaterThanOrEqual(5);
+      }
+    },
+    {
+      enableIf: {
+        value: true
+      },
+      repeat: {
+        value: 5
+      }
+    }
+  );
+
+  oit(
+    'enable false and repeat 5',
+    () => {
+      let n = Math.random() * 10;
+      if (n < 5) {
+        expect(n).toBeLessThan(5);
+      } else {
+        expect(n).toBeGreaterThanOrEqual(5);
+      }
+    },
+    {
+      enableIf: {
+        value: false
+      },
+      repeat: {
+        value: 5
+      }
+    }
+  );
+
+  oit(
+    'function with args',
+    (a, b) => {
+      if (a == b) {
+        expect(a).toBe(b);
+      } else {
+        expect(a).not.toBe(b);
+      }
+    },
+    {
+      parametersValues: {
+        value: [[1, 4], [2, 2], [4, 7]]
+      }
+    }
+  );
+
+  oit(
+    'repeat with function without arguments',
+    () => {
+      expect(1).toBe(1);
+    },
+    {
+      repeat: {
+        value: tenTimes
+      }
+    }
+  );
+
+  oit(
+    'repeat with functions with arguments',
+    () => {
+      expect(1).toBe(1);
+    },
+    {
+      repeat: {
+        value: {
+          fn: nTimes,
+          args: [10]
+        }
+      }
+    }
+  );
+
+  oit(
+    'parameters with function without args',
+    (a, b) => {
+      if (a != b) {
+        expect(a).not.toBe(b);
+      } else {
+        expect(a).toBe(b);
+      }
+    },
+    {
+      parametersValues: {
+        value: getDefaultArgs
+      }
+    }
+  );
+
+  oit(
+    'parameters with function with args',
+    (a, b) => {
+      if (a != b) {
+        expect(a).not.toBe(b);
+      } else {
+        expect(a).toBe(b);
+      }
+    },
+    {
+      parametersValues: {
+        value: {
+          fn: getRandomArgs,
+          args: [10]
+        }
+      }
+    }
+  );
+
+  oit(
+    'enable false with repeat 5 and parameters',
+    (a, b) => {
+      if (a != b) {
+        expect(a).not.toBe(b);
+      } else {
+        expect(a).toBe(b);
+      }
+    },
+    {
+      enableIf: {
+        value: false
+      },
+      repeat: {
+        value: {
+          fn: nTimes,
+          args: [5]
+        }
+      },
+      parametersValues: {
+        value: [[4, 5], [3, 3], [7, 4]]
+      }
+    }
+  );
+
+  oit(
+    'repeat 5 as an unified test',
+    () => {
+      expect(5).toBe(5);
+    },
+    {
+      repeat: {
+        value: 5,
+        args: {
+          unifiedTest: true
+        }
+      }
+    }
+  );
+
+  oit(
+    'transpose parameters',
+    (a, b) => {
+      expect(a).toBe(b);
+    },
+    {
+      parametersValues: {
+        value: [[2, 3, 1], [2, 3, 1]],
+        args: {
+          transposed: true
+        }
+      }
+    }
+  );
+});

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -719,6 +719,13 @@ getJasmineRequireObj().Env = function(j$) {
       return suiteBuilder.fit(description, fn, timeout, filename).metadata;
     };
 
+    this.oit = function(description, fn, options, timeout) {
+      ensureIsNotNested('oit');
+      const filename = callerCallerFilename();
+      return suiteBuilder.oit(description, fn, timeout, filename, options)
+        .metadata;
+    };
+
     /**
      * Sets a user-defined property that will be provided to reporters as part of the properties field of {@link SpecResult}
      * @name Env#setSpecProperty

--- a/src/core/Options.js
+++ b/src/core/Options.js
@@ -1,0 +1,333 @@
+getJasmineRequireObj().options = function() {
+  const options = {};
+
+  options.CONSTANTS = {
+    PARAMETERS_VALUES: 'parametersValues',
+    REPEAT: 'repeat',
+    ENABLE_IF: 'enableIf'
+  };
+
+  const ARGS = new Object();
+
+  ARGS[options.CONSTANTS.ENABLE_IF] = {};
+
+  ARGS[options.CONSTANTS.REPEAT] = {
+    unifiedTest: {
+      type: 'boolean',
+      fn: function(args, repeatNumber) {
+        let fns = [];
+        for (let index = 0; index < args.unitTests.length; index++) {
+          fns.push(args.unitTests[index].fn.bind({}));
+        }
+
+        let fn = () => {
+          for (let fnIndex = 0; fnIndex < fns.length; fnIndex++) {
+            let newFn = fns[fnIndex];
+            for (let index = 0; index < repeatNumber; index++) {
+              newFn();
+            }
+          }
+        };
+
+        let unitTest = args.unitTests[0];
+        unitTest.fn = fn;
+        unitTest.stopOnFailure = true;
+        args.unitTests = [];
+        args.unitTests.push(unitTest);
+
+        return args.unitTests;
+      }
+    }
+  };
+
+  ARGS[options.CONSTANTS.PARAMETERS_VALUES] = {
+    transposed: {
+      type: 'boolean',
+      fn: function(executionsArray) {
+        if (executionsArray.length == 0) {
+          return executionsArray;
+        }
+        return executionsArray[0].map((_, colIndex) =>
+          executionsArray.map(row => row[colIndex])
+        );
+      }
+    }
+  };
+
+  options[options.CONSTANTS.ENABLE_IF] = function(optionMap, args) {
+    let optionKey = options.CONSTANTS.ENABLE_IF;
+    validateObject(optionMap, optionKey);
+    validateArgs(optionMap, optionKey);
+
+    let value = getValue(optionMap, optionKey, isBoolean);
+
+    let excludedMsg = value
+      ? undefined
+      : `test skipped by the condition in option ${optionKey}`;
+
+    if (args.unitTests.length == 0) {
+      args.unitTests.push({
+        description: args.originalValues.description,
+        timeout: args.originalValues.timeout,
+        filename: args.originalValues.filename,
+        fn: args.originalValues.fn,
+        excludedMsg: excludedMsg
+      });
+    } else {
+      for (let index = 0; index < args.unitTests.length; index++) {
+        args.unitTests[index].excludedMsg = excludedMsg;
+      }
+    }
+
+    return args.unitTests;
+  };
+
+  options[options.CONSTANTS.REPEAT] = function(optionMap, args) {
+    let optionKey = options.CONSTANTS.REPEAT;
+    validateObject(optionMap, optionKey);
+    validateArgs(optionMap, optionKey);
+
+    let repeatNumber = getValue(optionMap, optionKey, isInt);
+
+    if (args.unitTests.length == 0) {
+      args.unitTests.push({
+        description: args.originalValues.description,
+        timeout: args.originalValues.timeout,
+        filename: args.originalValues.filename,
+        fn: args.originalValues.fn,
+        excludeMsg: undefined
+      });
+    }
+
+    if (repeatNumber > 1) {
+      if (
+        'args' in optionMap &&
+        'unifiedTest' in optionMap.args &&
+        optionMap.args.unifiedTest
+      ) {
+        args.unitTests = ARGS[options.CONSTANTS.REPEAT].unifiedTest.fn(
+          args,
+          repeatNumber
+        );
+      } else {
+        let newUnitTests = [];
+        for (let index = 0; index < args.unitTests.length; index++) {
+          let unitTest = args.unitTests[index];
+          for (let index = 1; index < repeatNumber; index++) {
+            newUnitTests.push({
+              description: unitTest.description,
+              timeout: unitTest.timeout,
+              filename: unitTest.filename,
+              fn: unitTest.fn,
+              excludeMsg: unitTest.excludeMsg
+            });
+          }
+        }
+
+        args.unitTests.push(...newUnitTests);
+      }
+    }
+
+    return args.unitTests;
+  };
+
+  options[options.CONSTANTS.PARAMETERS_VALUES] = function(optionMap, args) {
+    let optionKey = options.CONSTANTS.PARAMETERS_VALUES;
+    validateObject(optionMap, optionKey);
+    validateArgs(optionMap, optionKey);
+
+    let executionsArray = getValue(optionMap, optionKey, is2dArray);
+
+    if (
+      'args' in optionMap &&
+      'transposed' in optionMap.args &&
+      optionMap.args.transposed
+    ) {
+      executionsArray = ARGS[options.CONSTANTS.PARAMETERS_VALUES].transposed.fn(
+        executionsArray
+      );
+    }
+
+    for (let index = 0; index < executionsArray.length; index++) {
+      let executionArray = executionsArray[index];
+      args.unitTests.push({
+        description: args.originalValues.description,
+        timeout: args.originalValues.timeout,
+        filename: args.originalValues.filename,
+        fn: () => {
+          args.originalValues.fn.apply(null, executionArray);
+        },
+        excludeMsg: undefined
+      });
+    }
+
+    return args.unitTests;
+  };
+
+  options.checkKeys = function(keys) {
+    for (let index = 0; index < keys.length; index++) {
+      if (!(keys[index] in options)) {
+        throw new Error(`unknown key in options: ${keys[index]}.`);
+      }
+    }
+  };
+
+  options.haveParametersValuesKey = function(keys) {
+    return keys.includes(options.CONSTANTS.PARAMETERS_VALUES);
+  };
+
+  options.sortKeys = function(keys) {
+    let returnList = [];
+    let optionKeys = Object.keys(options.CONSTANTS);
+    for (let index = 0; index < optionKeys.length; index++) {
+      if (keys.includes(options.CONSTANTS[optionKeys[index]])) {
+        returnList.push(options.CONSTANTS[optionKeys[index]]);
+      }
+    }
+
+    return returnList;
+  };
+
+  // https://stackoverflow.com/a/14794066/3723543
+  function isInt(value) {
+    if (isNaN(value)) {
+      return false;
+    }
+    let x = parseFloat(value);
+    return (x | 0) === x;
+  }
+
+  function getValue(optionMap, optionKey, typeCheckFn) {
+    let value = optionMap.value;
+    let error = !typeCheckFn(value);
+    if (error) {
+      if (value instanceof Object && !(value instanceof Function)) {
+        let fn = value.fn;
+        let args = value.args;
+        value = fn.apply(null, args);
+      } else if (value instanceof Function) {
+        value = value();
+      }
+      error = !typeCheckFn(value);
+    }
+
+    if (error) {
+      throw new Error(
+        `type error for "value" key on option ${optionKey}. ` +
+          `value -> ${value}`
+      );
+    }
+
+    return value;
+  }
+
+  function isBoolean(value) {
+    return typeof value == 'boolean';
+  }
+
+  function is2dArray(value) {
+    let error = !(value instanceof Array);
+    if (!error) {
+      let size = 0;
+      for (let index = 0; index < value.length && !error; index++) {
+        if (!error && size != 0 && value[index].length != size) {
+          error = true;
+        }
+
+        size = value[index].length;
+      }
+      if (size == 0) {
+        error = true;
+      }
+    }
+
+    return !error;
+  }
+
+  function validateObject(object, optionKey) {
+    let error = !(object instanceof Object) || !('value' in object);
+    if (
+      !error &&
+      object.value instanceof Object &&
+      !(object.value instanceof Function) &&
+      !(object.value instanceof Array)
+    ) {
+      error = !('fn' in object.value) || !('args' in object.value);
+      if (
+        !error &&
+        (!(object.value.fn instanceof Function) ||
+          !(object.value.args instanceof Array))
+      ) {
+        error = true;
+      }
+    }
+
+    if (error) {
+      throw new Error(`The option ${optionKey} is invalid.`);
+    }
+  }
+
+  function getAllArgs(optionsKey) {
+    return ARGS[optionsKey];
+  }
+
+  function validateArgs(object, optionKey) {
+    if (!('args' in object)) {
+      return;
+    }
+
+    let error = !(object.args instanceof Object);
+
+    if (!error) {
+      let possibleArgs = getAllArgs(optionKey);
+      let currentArgs = object.args;
+
+      let keys = Object.keys(possibleArgs);
+      for (let index = 0; index < keys.length && !error; index++) {
+        if (keys[index] in currentArgs) {
+          let argRealType = possibleArgs[keys[index]].type;
+          let argType = currentArgs[keys[index]];
+          error = typeof argType != argRealType;
+        }
+      }
+    }
+
+    if (error) {
+      throw new Error(`The args of option ${optionKey} is invalid`);
+    }
+  }
+
+  options.getOptionsProcessor = function(optionsObject, j$) {
+    let instance = new Object();
+
+    instance.args = optionsObject;
+
+    instance.j$ = j$;
+
+    instance.execute = function() {
+      if (this.args.originalValues.options == undefined) {
+        throw new Error('options argument cannot be undefined');
+      }
+
+      // check options map
+      let optionKeys = Object.keys(this.args.originalValues.options);
+      this.j$.options.checkKeys(optionKeys);
+
+      // reorder option keys
+      optionKeys = this.j$.options.sortKeys(optionKeys);
+      // execute each option
+      for (let index = 0; index < optionKeys.length; index++) {
+        this.args.unitTests = this.j$.options[optionKeys[index]](
+          this.args.originalValues.options[optionKeys[index]],
+          this.args
+        );
+      }
+
+      return this.args.unitTests;
+    };
+
+    return instance;
+  };
+
+  return options;
+};

--- a/src/core/SuiteBuilder.js
+++ b/src/core/SuiteBuilder.js
@@ -103,6 +103,51 @@ getJasmineRequireObj().SuiteBuilder = function(j$) {
       return spec;
     }
 
+    oit(description, fn, timeout, filename, options) {
+      if (arguments.length > 1 && typeof fn !== 'undefined') {
+        ensureIsFunctionOrAsync(fn, 'it');
+      }
+
+      let optionsObjects = {
+        suiteBuilder: this,
+        unitTests: [],
+        originalValues: {
+          description: description,
+          fn: fn,
+          timeout: timeout,
+          filename: filename,
+          options: options
+        }
+      };
+
+      let optionsProcessor = j$.options.getOptionsProcessor(optionsObjects, j$);
+      let unitTests = optionsProcessor.execute();
+
+      let specs = [];
+      for (
+        let unitTestIndex = 0;
+        unitTestIndex < unitTests.length;
+        unitTestIndex++
+      ) {
+        let unitTest = unitTests[unitTestIndex];
+        const spec = this.it_(
+          unitTest.description,
+          unitTest.fn,
+          unitTest.timeout,
+          unitTest.filename
+        );
+        if (unitTest.excludedMsg != undefined) {
+          spec.exclude(unitTest.excludedMsg);
+        }
+        if (unitTest.stopOnFailure != undefined && unitTest.stopOnFailure) {
+          spec.throwOnExpectationFailure = true;
+        }
+        specs.push(spec);
+      }
+
+      return specs;
+    }
+
     beforeEach(beforeEachFunction, timeout) {
       ensureIsFunctionOrAsync(beforeEachFunction, 'beforeEach');
 

--- a/src/core/requireCore.js
+++ b/src/core/requireCore.js
@@ -91,6 +91,7 @@ var getJasmineRequireObj = (function(jasmineGlobal) {
     j$.ObjectPath = jRequire.ObjectPath(j$);
     j$.MismatchTree = jRequire.MismatchTree(j$);
     j$.GlobalErrors = jRequire.GlobalErrors(j$);
+    j$.options = jRequire.options();
 
     j$.Truthy = jRequire.Truthy(j$);
     j$.Falsy = jRequire.Falsy(j$);

--- a/src/core/requireInterface.js
+++ b/src/core/requireInterface.js
@@ -109,6 +109,22 @@ getJasmineRequireObj().interface = function(jasmine, env) {
     },
 
     /**
+     * An [`it`]{@link it} with options.
+     * The option can smoothly change the execution of [`it`]{@link it}
+     * @name oit
+     * @since 5.1.0
+     * @function
+     * @global
+     * @param {String} description Textual description of what this spec is checking.
+     * @param {implementationCallback} testFunction Function that contains the code of your test.
+     * @param {Object} options The options that changes the test execution
+     * @param {Int} [timeout={@link jasmine.DEFAULT_TIMEOUT_INTERVAL}] Custom timeout for an async spec.
+     */
+    oit: function() {
+      return env.oit.apply(env, arguments);
+    },
+
+    /**
      * Run some shared setup before each of the specs in the {@link describe} in which it is called.
      * @name beforeEach
      * @since 1.3.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This Pull Request add a function `oit`, which is the same as `it` with options. These options are described below.

## Motivation and Context
(see below)

## How Has This Been Tested?
An `OptionsSpec.js` file has been created with all the necessary tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation (new feature only).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

# Test Smells

Code smell is code that does not follow good software engineering practices. Code like this can cause several problems, like misunderstandings, bugs, or maintenance problems.

```javascript
// from https://blog.bitsrc.io/your-javascript-smells-3574121bcfbe
let a = "start";
let b;

for(let i = 0; i < 5; i++) {
  b += a[i].toUpperCase();
}
```

Like code smell, there is test smell, which is applied to test code. The following code is an example of a test smell:

```javascript
it("testing network", () => {
    if (!isOffline) {
        expect(testNetwork()).toBe(true);
    }
});
```

In the above test, if the constant `isOffline` has a true value, then the assert will not be executed. In this case, it gave the impression that it had passed.

How can we deal with the test smell? One way is to refactor the smell as soon as it is detected. Test code has unique structures that make it distinct from the code smell, like isolation of tests or repetition of code executions. Because of this, we can't use the same solutions for code smells.

## One solution

One solution for this problem is to use markers on a test. With markers, that test will execute slightly differently. For example, to simulate a network attack, you can run a specific test 500 times. Instead of a for loop, you can use a marker that makes that test repeat 500 times. So, what are the differences? Well, in that case, readability. To illustrate that, see the next section.

## JUnit 5 annotations

JUnit has an annotation called `@RepeatedTest`. That annotation can make a test repeat n times. Take the following example:

```java
@Test
void networkAttackTest() {
    for (int i = 0; i < 500; i++) {
        // code of test with asserts
    }
}
```

<!-- Why is this test a smell? -->

With the annotation of JUnit 5,

```java
@RepeatedTest(500)
void networkAttackTest() {
    // code of test with asserts
}
```

The second piece of code is more readable, only with the test code, without the for loop.

JUnt 5 has a lot of test annotations to deal with test smells, like `@enableIf` or `@ParameterizedTest`. These annotations can improve rediability and reduce test smells.

## Decorators?

Jasmine doesn't work with *decorators* to modify tests. However, *annotations* (in the context of Java) are metadata applied to the annotated target. So we can work this way, applying metadata to the test to change its execution. We show how we can apply this to Jasmine in the next section.

# Option it!

Instead of using decorators, we can use a function, something similar to `it`. And add metadata through a parameter or *option*.

First, let's create the option object:

```javascript
var option = {
    enableIf: {
        value: true
    }
};
```

This *option* is metadata that tells us that we want `enableIf` active. So, our goal with this is to only enable the test under certain circumstances.

After that, just add the metadata to the test. To do this, we need to create a function similar to `it`. We create a function called `oit`, which means *option it*, following the patterns of other jasmine functions, i.e., `xit` and `fit`. The `oit` has all parameters of `it`, adding a new one: *options*.

Following the last example, just add the option to the test:

```javascript
oit("generic test", () => {
    expect(2 == 2).toBe(true)
}, {
    enableIf: {
        value: true
    }
});
```

## Types

There are three options: `enableIf`, `repeat`, and `parametersValue`.

### enableIf

The `enableIf` option enables the test under some conditions. Example: Just enable the *networkAttackTest* if the vpn is turned on,

```javascript
oit("networkAttackTest", () => {
    expect(networkAttack()).toBe(true);
}, {
    enableIf: {
        value: !isOffline
    }
});
```

If the condition is not satisfied, the test is not executed. Similar to the `xit` function, it's excluded from execution.

You can use a *boolean* value.

### repeat

The `repeat` option makes the test repeat *n* times, as individuals test. Example: A network attack that attacks something once isn't a real network attack, right? So, do this test 500 times,

```javascript
oit("networkAttackTest", () => {
    expect(networkAttack()).toBe(true);
}, {
    repeat: {
        value: 500
    }
});
```

Each test is a separate test, and any failure of one will not interfere with the others. If you need the repetitions to behave like a single test, where one failure stops the entire process, then the `repeat` option has a `unifiedTest` parameter. Example:

```javascript
oit("networkAttackTest", () => {
    expect(networkAttack()).toBe(true);
}, {
    repeat: {
        value: 500,
        args: {
            unifiedTest: true
        }
    }
});
```

With this parameter, if failure occurs, the test will be terminated.

You can use an *integer* value.

### parametersValues

Normally, the test for *Jasmine* has no parameters. What if we could add some parameters? And test various value scenarios for these same parameters? This option allows it. Example: In our scenario of a network attack, we now need to test several values of retry and delay (in ms).

```javascript
oit("networkAttackTest", (retry, delay) => {
    expect(networkAttack(retry, delay)).toBe(true);
}, {
    parametersValues: {
        value: [[1,20],[5,50],[10,200]]
    }
});
```

Note that parameter values are positioned line by line, i.e., the values of each variable are read in sequence for each test set scenario. Instead, you can transpose the values using the `transpose` parameter:

```javascript
oit("networkAttackTest", (retry, delay) => {
    expect(networkAttack(retry, delay)).toBe(true);
}, {
    parametersValues: {
        value: [[1,5,10],[20,50,200]],
        args: {
            transposed: true
        }
    }
});
```

In the example above, all possible values for a variable are given immediately before the next variable.

You can use a two-dimensional array value.

### Mixing options

You can mix several options. The next example shows using `enableIf` and `repeat` in the same test.

```javascript
oit("networkAttackTest", () => {
    expect(networkAttack()).toBe(true);
}, {
    enableIf: {
        value: !isOffline
    },
    repeat: {
        value: 500
    }
});
```

### Using functions instead of variables values

You can use functions with no arguments or functions with arguments instead of variables in *value*.

Before each case, consider the following example:

```javascript
const isOffline = false;

oit("networkAttackTest", () => {
    expect(networkAttack()).toBe(true);
}, {
    enableIf: {
        value: !isOffline
    }
});
```

Now, we can use a function without arguments in the value:

```javascript
function isOffline() {
    return false;
}

oit("networkAttackTest", () => {
    expect(networkAttack()).toBe(true);
}, {
    enableIf: {
        value: isOffline
    }
});
```

Or a function with arguments:

```javascript
const systemPassword = "555";
function isOffline(password) {
    return (systemPassword == password)
}

oit("networkAttackTest", () => {
    expect(networkAttack()).toBe(true);
}, {
    enableIf: {
        value: {
            fn: isOffline,
            args: ["333"]
        }
    }
});
```

# Turning **it** to **oit**

To turn an `it` into an `oit`, just change the function name from `it` to `oit` and add an option object as one of its parameters.

Original test:

```javascript
it("test example", () => {
    // expect
});
```

Modified test:

```javascript
oit("test example", () => {
    // expect
}, {
    enableIf: {
        value: booleanVariable
    }
});
```

So, that's it! Your option object will change the test execution. In the case of parameters option, maybe you need to modify the test, but nothing too complicated.

```javascript
oit("test example", (a, b) => {
    // expect using a and b
}, {
    parametersValues: {
        value: [[2,3],[5,6]]
    }
});
```

# References

E. Soares, M. Ribeiro, R. Gheyi, G. Amaral and A. Santos, "Refactoring Test Smells With JUnit 5: Why Should Developers Keep Up-to-Date?," in IEEE Transactions on Software Engineering, vol. 49, no. 3, pp. 1152-1170, 1 March 2023, doi: 10.1109/TSE.2022.3172654.