### PR TITLE
Fix error for undefined message

### DIFF
--- a/spec/core/StackTraceSpec.js
+++ b/spec/core/StackTraceSpec.js
@@ -282,4 +282,16 @@ describe('StackTrace', function() {
 
     expect(result_no_error.message).not.toEqual(jasmine.anything());
   });
+
+  it('handles errors with no message without throwing', function() {
+    const error = {
+      stack:
+        'HttpError [UnprocessableEntityError]\n' +
+        '    at UserContext.<anonymous> (/spec/support/error.spec.js:4:17)\n' +
+        '    at QueueRunner.attempt (/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:7745:40)'
+    };
+    expect(function() {
+      new jasmineUnderTest.StackTrace(error);
+    }).not.toThrowError();
+  });
 });

--- a/spec/core/StackTraceSpec.js
+++ b/spec/core/StackTraceSpec.js
@@ -294,4 +294,11 @@ describe('StackTrace', function() {
       new jasmineUnderTest.StackTrace(error);
     }).not.toThrowError();
   });
+
+  it('handles errors with no stack without throwing', function() {
+    const error = { code: 'UnprocessableEntity', message: '' };
+    expect(function() {
+      new jasmineUnderTest.StackTrace(error);
+    }).not.toThrowError();
+  });
 });

--- a/src/core/StackTrace.js
+++ b/src/core/StackTrace.js
@@ -1,8 +1,10 @@
 getJasmineRequireObj().StackTrace = function(j$) {
   function StackTrace(error) {
-    let lines = error.stack.split('\n').filter(function(line) {
-      return line !== '';
-    });
+    let lines = error.stack
+      ? error.stack.split('\n').filter(function(line) {
+          return line !== '';
+        })
+      : [];
 
     const extractResult = extractMessage(error.message, lines);
 
@@ -101,7 +103,11 @@ getJasmineRequireObj().StackTrace = function(j$) {
   }
 
   function messagePrefixLength(message, stackLines) {
-    if (!stackLines[0].match(/^\w*Error/) || !message) {
+    if (
+      !message ||
+      stackLines.length === 0 ||
+      !stackLines[0].match(/^\w*Error/)
+    ) {
       return 0;
     }
 

--- a/src/core/StackTrace.js
+++ b/src/core/StackTrace.js
@@ -101,7 +101,7 @@ getJasmineRequireObj().StackTrace = function(j$) {
   }
 
   function messagePrefixLength(message, stackLines) {
-    if (!stackLines[0].match(/^\w*Error/)) {
+    if (!stackLines[0].match(/^\w*Error/) || !message) {
       return 0;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Check that a message and stack properties exists on an exception before trying to use `split`. 

## Motivation and Context

Fixes https://github.com/jasmine/jasmine/issues/2011 when an error is thrown without a message.

## How Has This Been Tested?
Ran unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

