### PR TITLE
Skip parsing cause if it is not an Error object

### DIFF
--- a/spec/core/ExceptionFormatterSpec.js
+++ b/spec/core/ExceptionFormatterSpec.js
@@ -291,6 +291,26 @@ describe('ExceptionFormatter', function() {
           .withContext('first root cause stack frame')
           .toContain('ExceptionFormatterSpec.js');
       });
+
+      it('does not throw if cause is a non Error', function() {
+        const formatter = new jasmineUnderTest.ExceptionFormatter();
+
+        expect(function() {
+          formatter.stack(
+            new Error('error', {
+              cause: function() {}
+            })
+          );
+        }).not.toThrowError();
+
+        expect(function() {
+          formatter.stack(
+            new Error('error', {
+              cause: 'another error'
+            })
+          );
+        }).not.toThrowError();
+      });
     });
   });
 });

--- a/src/core/ExceptionFormatter.js
+++ b/src/core/ExceptionFormatter.js
@@ -67,7 +67,7 @@ getJasmineRequireObj().ExceptionFormatter = function(j$) {
         lines.unshift(stackTrace.message);
       }
 
-      if (error.cause) {
+      if (error.cause && error.cause instanceof Error) {
         const substack = this.stack_(error.cause, {
           messageHandling: 'require'
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Don't try to parse `error.cause` if `cause` is not an instance of `Error`,

## Motivation and Context
Fix #2011.    See discussion from https://github.com/jasmine/jasmine/pull/2012#issuecomment-1641362584

## How Has This Been Tested?
Ran unit tests. Ran example code with updated jasmine.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

