### PR TITLE
Improve the error message of the toHaveSize matcher.

### DIFF
--- a/spec/core/matchers/toHaveSizeSpec.js
+++ b/spec/core/matchers/toHaveSizeSpec.js
@@ -15,6 +15,17 @@ describe('toHaveSize', function() {
     expect(result.pass).toBe(false);
   });
 
+  it('informs about the size of an array whose length does not match', function() {
+    const matcher = jasmineUnderTest.matchers.toHaveSize({
+        pp: jasmineUnderTest.makePrettyPrinter()
+      }),
+      result = matcher.compare([1, 2, 3], 2);
+
+    expect(result.message()).toEqual(
+      'Expected [ 1, 2, 3 ] with size 3 to have size 2.'
+    );
+  });
+
   it('passes for an object with the proper number of keys', function() {
     const matcher = jasmineUnderTest.matchers.toHaveSize(),
       result = matcher.compare({ a: 1, b: 2 }, 2);

--- a/src/core/matchers/toHaveSize.js
+++ b/src/core/matchers/toHaveSize.js
@@ -9,7 +9,7 @@ getJasmineRequireObj().toHaveSize = function(j$) {
    * array = [1,2];
    * expect(array).toHaveSize(2);
    */
-  function toHaveSize() {
+  function toHaveSize(matchersUtil) {
     return {
       compare: function(actual, expected) {
         const result = {
@@ -24,12 +24,29 @@ getJasmineRequireObj().toHaveSize = function(j$) {
           throw new Error('Cannot get size of ' + actual + '.');
         }
 
+        let actualSize;
         if (j$.isSet(actual) || j$.isMap(actual)) {
-          result.pass = actual.size === expected;
+          actualSize = actual.size;
         } else if (isLength(actual.length)) {
-          result.pass = actual.length === expected;
+          actualSize = actual.length;
         } else {
-          result.pass = Object.keys(actual).length === expected;
+          actualSize = Object.keys(actual).length;
+        }
+
+        result.pass = actualSize === expected;
+
+        if (!result.pass) {
+          result.message = function() {
+            return (
+              'Expected ' +
+              matchersUtil.pp(actual) +
+              ' with size ' +
+              actualSize +
+              ' to have size ' +
+              expected +
+              '.'
+            );
+          };
         }
 
         return result;


### PR DESCRIPTION
We include the size of the thing that didn't meet the size expectation.

## Description
In the error message of a failed toHaveSize expectation, we'll print the size of the
thing whose size we want to check after its contents, such that the error looks like in the following example:
`Expected [ 1, 2, 3 ] with size 3 to have size 2.`

## Motivation and Context
This allows us to see the size and we don't have to count  based on pretty-printed contents.

## How Has This Been Tested?
Added a unit test.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

