### PR TITLE
Improve performance on Playwright Windows WebKit

### DIFF
--- a/spec/core/ClearStackSpec.js
+++ b/spec/core/ClearStackSpec.js
@@ -22,6 +22,19 @@ describe('ClearStack', function() {
     });
   });
 
+  describe('in WebKit (Playwright\'s build for Windows)', function() {
+    usesQueueMicrotaskWithSetTimeout(function() {
+      return {
+        navigator: {
+          userAgent:
+            'Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/605.1.15 (KHTML, like Gecko)'
+        },
+        // queueMicrotask should be used even though MessageChannel is present
+        MessageChannel: fakeMessageChannel
+      };
+    });
+  });
+
   describe('in browsers other than Safari', function() {
     usesMessageChannel(function() {
       return {

--- a/spec/core/ClearStackSpec.js
+++ b/spec/core/ClearStackSpec.js
@@ -22,7 +22,7 @@ describe('ClearStack', function() {
     });
   });
 
-  describe('in WebKit (Playwright\'s build for Windows)', function() {
+  describe("in WebKit (Playwright's build for Windows)", function() {
     usesQueueMicrotaskWithSetTimeout(function() {
       return {
         navigator: {

--- a/spec/helpers/nodeDefineJasmineUnderTest.js
+++ b/spec/helpers/nodeDefineJasmineUnderTest.js
@@ -16,7 +16,9 @@
       return path.join(__dirname, '../../', 'src/', file);
     });
 
-    const files = src_files.flatMap(g => glob.sync(g));
+    const files = src_files.flatMap(g =>
+      glob.sync(g, { windowsPathsNoEscape: true })
+    );
     files.forEach(function(resolvedFile) {
       require(resolvedFile);
     });

--- a/src/core/ClearStack.js
+++ b/src/core/ClearStack.js
@@ -68,8 +68,8 @@ getJasmineRequireObj().clearStack = function(j$) {
       global.process.versions &&
       typeof global.process.versions.node === 'string';
 
-    // Windows builds of WebKit have a fairly generic user agent string when no application name is provided.
-    // See: https://github.com/WebKit/WebKit/blob/d898a3cffd9c992980016cb1fbdba272cb0c992d/Source/WebCore/platform/win/UserAgentWin.cpp#L37
+    // Windows builds of WebKit have a fairly generic user agent string when no application name is provided:
+    // e.g. "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/605.1.15 (KHTML, like Gecko)"
     const SAFARI_OR_WIN_WEBKIT =
       global.navigator &&
       /(^((?!chrome|android).)*safari)|(Win64; x64\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\)$)/i.test(
@@ -84,8 +84,9 @@ getJasmineRequireObj().clearStack = function(j$) {
       SAFARI_OR_WIN_WEBKIT ||
       j$.util.isUndefined(global.MessageChannel) /* tests */
     ) {
-      // queueMicrotask is dramatically faster than MessageChannel in Safari,
-      // at least through version 16.
+      // queueMicrotask is dramatically faster than MessageChannel in Safari
+      // and other WebKit-based browsers, such as the one distributed by Playwright
+      // to test Safari-like behavior on Windows.
       // Some of our own integration tests provide a mock queueMicrotask in all
       // environments because it's simpler to mock than MessageChannel.
       return browserQueueMicrotaskImpl(global);

--- a/src/core/ClearStack.js
+++ b/src/core/ClearStack.js
@@ -70,7 +70,9 @@ getJasmineRequireObj().clearStack = function(j$) {
 
     const SAFARI =
       global.navigator &&
-      /^((?!chrome|android).)*safari/i.test(global.navigator.userAgent);
+      /(^((?!chrome|android).)*safari)|(^((?!chrome|android|firefox).)+$)/i.test(
+        global.navigator.userAgent
+      );
 
     if (NODE_JS) {
       // Unlike browsers, Node doesn't require us to do a periodic setTimeout

--- a/src/core/ClearStack.js
+++ b/src/core/ClearStack.js
@@ -68,9 +68,11 @@ getJasmineRequireObj().clearStack = function(j$) {
       global.process.versions &&
       typeof global.process.versions.node === 'string';
 
-    const SAFARI =
+    // Windows builds of WebKit have a fairly generic user agent string when no application name is provided.
+    // See: https://github.com/WebKit/WebKit/blob/d898a3cffd9c992980016cb1fbdba272cb0c992d/Source/WebCore/platform/win/UserAgentWin.cpp#L37
+    const SAFARI_OR_WIN_WEBKIT =
       global.navigator &&
-      /(^((?!chrome|android).)*safari)|(^((?!chrome|android|firefox).)+$)/i.test(
+      /(^((?!chrome|android).)*safari)|(Win64; x64\) AppleWebKit\/[0-9.]+ \(KHTML, like Gecko\)$)/i.test(
         global.navigator.userAgent
       );
 
@@ -79,7 +81,7 @@ getJasmineRequireObj().clearStack = function(j$) {
       // so we avoid the overhead.
       return nodeQueueMicrotaskImpl(global);
     } else if (
-      SAFARI ||
+      SAFARI_OR_WIN_WEBKIT ||
       j$.util.isUndefined(global.MessageChannel) /* tests */
     ) {
       // queueMicrotask is dramatically faster than MessageChannel in Safari,


### PR DESCRIPTION
## Description
1. (primary change) Expanded the user agent string regex used to identify Safari browsers so that it also covers the Windows WebKit browser used by Playwright. There is an existing code comment that explains that `queueMicrotask` should be used on Safari because it is "dramatically faster" than `MessageChannel`. The same is true for the Windows WebKit browser.
2. (minor change) Update `glob` call in test setup code to work on Windows machines.

## Motivation and Context
Running tests on Windows against the WebKit browser installed by Playwright is an order of magnitude slower than running the same tests on other browsers. This is especially evident when focusing only a small number of tests, as skipped tests still take a fraction of a second each (on WebKit).

## How Has This Been Tested?
Ran all tests in this repo. Ran my repo's tests with this modification on Windows WebKit and saw huge improvement in performance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

