### PR TITLE
Use queueMicrotask in clearStack

### DIFF
--- a/spec/core/ClearStackSpec.js
+++ b/spec/core/ClearStackSpec.js
@@ -56,12 +56,7 @@ describe('ClearStack', function() {
 
     describe('when MessageChannel is unavailable', function() {
       usesQueueMicrotaskWithSetTimeout(function() {
-        return {
-          navigator: {
-            userAgent: 'CERN-LineMode/2.15 libwww/2.17b3',
-            MessageChannel: undefined
-          }
-        };
+        return { MessageChannel: undefined };
       });
     });
   });

--- a/spec/core/ClearStackSpec.js
+++ b/spec/core/ClearStackSpec.js
@@ -9,20 +9,7 @@ describe('ClearStack', function() {
     });
   });
 
-  describe('in Safari', function() {
-    usesQueueMicrotaskWithSetTimeout(function() {
-      return {
-        navigator: {
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.0.8 (KHTML, like Gecko) Version/15.1 Safari/605.0.8'
-        },
-        // queueMicrotask should be used even though MessageChannel is present
-        MessageChannel: fakeMessageChannel
-      };
-    });
-  });
-
-  describe("in WebKit (Playwright's build for Windows)", function() {
+  describe('in browsers', function() {
     usesQueueMicrotaskWithSetTimeout(function() {
       return {
         navigator: {
@@ -31,18 +18,6 @@ describe('ClearStack', function() {
         },
         // queueMicrotask should be used even though MessageChannel is present
         MessageChannel: fakeMessageChannel
-      };
-    });
-  });
-
-  describe('in browsers other than Safari', function() {
-    usesMessageChannel(function() {
-      return {
-        navigator: {
-          // Chrome's user agent string contains "Safari" so it's a good test case
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36'
-        }
       };
     });
 


### PR DESCRIPTION
As discussed in #1835, `queueMicrotask` is faster than `MessageChannel` in most situations if `setTimeout` clamping is taken care of. This can be done by interleaving `setTimeout` and `MessageChannel`.
<!--- Provide a general summary of your changes in the Title above -->

## Description
* All browsers use the same `clearStack` implementation
* always call `queueMicrotask`
* every 10 `queueMicrotask` calls: call `setTimeout` (clears the stack)
* every 4 `setTimeout` calls: call `MessageChannel` (prevents clamping `setTimeout` to 4 ms)
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes #1835
Fixes #2008

## How Has This Been Tested?
Ran on an existing ~10 K tests suite in five (mostly headless) browsers. See analysis: https://github.com/jasmine/jasmine/issues/1835#issuecomment-2254546734
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Not really breaking, but
Because of the changed run-time behavior of spec suites this may change the outcome of specs in race cases.
However, since Safari already uses `queueMicrotask`, suites that were green in Safari are very likely to be green in other browsers.

#### Performance
* Test suites may run slower in Firefox unless `dom.clamp.timeout.nesting.level` is set to `-1`. 
* The Jasmine suite `npm run serve` runs slower in headful Chrome. This is because we create fresh instances of `clearStack`, which resets the `currentSetTimeoutCallCount` to zero, missing `setTimeout` calls by previous specs, ultimately leading to browser `setTimeout` clamping. The full speed can be verified with `let currentSetTimeoutCallCount = maxSetTimeoutWithoutClampingCallCount` (though this will fail the respective test).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

