### PR TITLE
Speed up tests in Safari

### DIFF
--- a/src/core/ClearStack.js
+++ b/src/core/ClearStack.js
@@ -2,7 +2,8 @@ getJasmineRequireObj().clearStack = function(j$) {
   const maxInlineCallCount = 10;
 
   function browserQueueMicrotaskImpl(global) {
-    const { setTimeout, queueMicrotask } = global;
+    const unclampedSetTimeout = getUnclampedSetTimeout(global);
+    const { queueMicrotask } = global;
     let currentCallCount = 0;
     return function clearStack(fn) {
       currentCallCount++;
@@ -11,7 +12,7 @@ getJasmineRequireObj().clearStack = function(j$) {
         queueMicrotask(fn);
       } else {
         currentCallCount = 0;
-        setTimeout(fn);
+        unclampedSetTimeout(fn);
       }
     };
   }

--- a/src/core/ClearStack.js
+++ b/src/core/ClearStack.js
@@ -41,6 +41,18 @@ getJasmineRequireObj().clearStack = function(j$) {
     };
   }
 
+  function getUnclampedSetTimeout(global) {
+    const { setTimeout } = global;
+    if (j$.util.isUndefined(global.MessageChannel)) return setTimeout;
+
+    const postMessage = getPostMessage(global);
+    return function unclampedSetTimeout(fn) {
+      postMessage(function() {
+        setTimeout(fn);
+      });
+    };
+  }
+
   function getPostMessage(global) {
     const { MessageChannel, setTimeout } = global;
     const channel = new MessageChannel();


### PR DESCRIPTION
In #2035 we found out that using only `queueMicrotask` and `setTimeout` leads to `setTimeout` clamping in Safari.
As in other browsers, `postMessage` is able to reset the clamping.

## Description

In the Safari clear-stack implementation,`setTimeout` is now wrapped in a `postMessage`.

## Motivation and Context
Fixes #2008.
Background discussion: #2035.

## How Has This Been Tested?

* `npm run build && npm run serve`
* Open http://localhost:8888 in Safari 17.6
  * Slowest of 5 runs: 1.651s
* Use the `main` branch and do the same
  * Fastest of 5 runs: 4.148s

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

