### PR TITLE
Add toBeNullish matcher

### DIFF
--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -150,7 +150,6 @@ getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
       'toBeTrue',
       'toBeTruthy',
       'toBeUndefined',
-      'toBeNullish',
       'toContain',
       'toEqual',
       'toHaveSize',
@@ -6009,28 +6008,6 @@ getJasmineRequireObj().toBeNull = function() {
   }
 
   return toBeNull;
-};
-
-getJasmineRequireObj().toBeNullish = function() {
-  /**
-   * {@link expect} the actual value to be `null` or `undefined`.
-   * @function
-   * @name matchers#toBeNullish
-   * @since 5.6.0
-   * @example
-   * expect(result).toBeNullish():
-   */
-  function toBeNullish() {
-    return {
-      compare: function(actual) {
-        return {
-          pass: null === actual || void 0 === actual
-        };
-      }
-    };
-  }
-
-  return toBeNullish;
 };
 
 getJasmineRequireObj().toBePositiveInfinity = function(j$) {

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -150,6 +150,7 @@ getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
       'toBeTrue',
       'toBeTruthy',
       'toBeUndefined',
+      'toBeNullish',
       'toContain',
       'toEqual',
       'toHaveSize',

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -6011,6 +6011,28 @@ getJasmineRequireObj().toBeNull = function() {
   return toBeNull;
 };
 
+getJasmineRequireObj().toBeNullish = function() {
+  /**
+   * {@link expect} the actual value to be `null` or `undefined`.
+   * @function
+   * @name matchers#toBeNullish
+   * @since 5.6.0
+   * @example
+   * expect(result).toBeNullish():
+   */
+  function toBeNullish() {
+    return {
+      compare: function(actual) {
+        return {
+          pass: null === actual || void 0 === actual
+        };
+      }
+    };
+  }
+
+  return toBeNullish;
+};
+
 getJasmineRequireObj().toBePositiveInfinity = function(j$) {
   /**
    * {@link expect} the actual value to be `Infinity` (infinity).

--- a/spec/core/integration/MatchersSpec.js
+++ b/spec/core/integration/MatchersSpec.js
@@ -481,7 +481,6 @@ describe('Matchers (Integration)', function() {
     verifyFails(function(env) {
       env.expect(1).toBeNullish();
     });
-
   });
 
   describe('toContain', function() {

--- a/spec/core/integration/MatchersSpec.js
+++ b/spec/core/integration/MatchersSpec.js
@@ -469,6 +469,21 @@ describe('Matchers (Integration)', function() {
     });
   });
 
+  describe('toBeNullish', function() {
+    verifyPasses(function(env) {
+      env.expect(undefined).toBeNullish();
+    });
+
+    verifyPasses(function(env) {
+      env.expect(null).toBeNullish();
+    });
+
+    verifyFails(function(env) {
+      env.expect(1).toBeNullish();
+    });
+
+  });
+
   describe('toContain', function() {
     verifyPasses(function(env) {
       env.addCustomEqualityTester(function(a, b) {

--- a/spec/core/integration/MatchersSpec.js
+++ b/spec/core/integration/MatchersSpec.js
@@ -481,6 +481,10 @@ describe('Matchers (Integration)', function() {
     verifyFails(function(env) {
       env.expect(1).toBeNullish();
     });
+
+    verifyFails(function(env) {
+      env.expect('').toBeNullish();
+    });
   });
 
   describe('toContain', function() {

--- a/spec/core/matchers/toBeNullishSpec.js
+++ b/spec/core/matchers/toBeNullishSpec.js
@@ -16,4 +16,42 @@ describe('toBeNullish', function() {
     const result = matcher.compare('foo');
     expect(result.pass).toBe(false);
   });
+
+  describe('falsy values', () => {
+    it('fails for 0', function() {
+      const matcher = jasmineUnderTest.matchers.toBeNullish();
+      const result = matcher.compare(0);
+      expect(result.pass).toBe(false);
+    });
+
+    it('fails for -0', function() {
+      const matcher = jasmineUnderTest.matchers.toBeNullish();
+      const result = matcher.compare(-0);
+      expect(result.pass).toBe(false);
+    });
+
+    it('fails for empty string', function() {
+      const matcher = jasmineUnderTest.matchers.toBeNullish();
+      const result = matcher.compare('');
+      expect(result.pass).toBe(false);
+    });
+
+    it('fails for false', function() {
+      const matcher = jasmineUnderTest.matchers.toBeNullish();
+      const result = matcher.compare(false);
+      expect(result.pass).toBe(false);
+    });
+
+    it('fails for NaN', function() {
+      const matcher = jasmineUnderTest.matchers.toBeNullish();
+      const result = matcher.compare(NaN);
+      expect(result.pass).toBe(false);
+    });
+
+    it('fails for 0n', function() {
+      const matcher = jasmineUnderTest.matchers.toBeNullish();
+      const result = matcher.compare(BigInt(0));
+      expect(result.pass).toBe(false);
+    });
+  });
 });

--- a/spec/core/matchers/toBeNullishSpec.js
+++ b/spec/core/matchers/toBeNullishSpec.js
@@ -1,0 +1,19 @@
+describe('toBeNullish', function() {
+  it('passes for null values', function() {
+    const matcher = jasmineUnderTest.matchers.toBeNullish();
+    const result = matcher.compare(null);
+    expect(result.pass).toBe(true);
+  });
+
+  it('passes for undefined values', function() {
+    const matcher = jasmineUnderTest.matchers.toBeNullish();
+    const result = matcher.compare(void 0);
+    expect(result.pass).toBe(true);
+  });
+
+  it('fails when matching defined values', function() {
+    const matcher = jasmineUnderTest.matchers.toBeNullish();
+    const result = matcher.compare('foo');
+    expect(result.pass).toBe(false);
+  });
+});

--- a/src/core/matchers/requireMatchers.js
+++ b/src/core/matchers/requireMatchers.js
@@ -18,6 +18,7 @@ getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
       'toBeTrue',
       'toBeTruthy',
       'toBeUndefined',
+      'toBeNullish',
       'toContain',
       'toEqual',
       'toHaveSize',

--- a/src/core/matchers/toBeNullish.js
+++ b/src/core/matchers/toBeNullish.js
@@ -1,0 +1,21 @@
+getJasmineRequireObj().toBeNullish = function() {
+  /**
+   * {@link expect} the actual value to be `null` or `undefined`.
+   * @function
+   * @name matchers#toBeNullish
+   * @since 5.6.0
+   * @example
+   * expect(result).toBeNullish():
+   */
+  function toBeNullish() {
+    return {
+      compare: function(actual) {
+        return {
+          pass: null === actual || void 0 === actual
+        };
+      }
+    };
+  }
+
+  return toBeNullish;
+};


### PR DESCRIPTION
## Description
Add a new matcher that would resolve https://github.com/jasmine/jasmine/issues/2018.

Supports users expectations for when expected values are either `null` or `undefined`.

## Motivation and Context
This discussion has come up in multiple places including [an issue in jest](https://github.com/jestjs/jest/issues/3872#issue-237508391). Where there is also this suggestion to use the naming `toBeNullish` is also made.

[Chai also has the method](https://www.chaijs.com/api/bdd/#method_exist) `.exist`/`.exists` which fits this same usecase.

## How Has This Been Tested?
Following the guide for testing in `CONTRIBUTING.md`, this has been testing with the specs in chrome, safari, and firefox, as well as node. (I did not run in Edge as of yet as I don't have a straight forward way of doing this 👀)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [TODO] I have updated the documentation accordingly. (happy to contribute to 5.6)
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

