### PR TITLE
Add toHaveClasses matcher

### DIFF
--- a/spec/core/integration/MatchersSpec.js
+++ b/spec/core/integration/MatchersSpec.js
@@ -621,6 +621,20 @@ describe('Matchers (Integration)', function() {
     });
   });
 
+  describe('toHaveClasses', function() {
+    verifyPasses(function(env) {
+      const el = specHelpers.domHelpers.createElementWithClassName(
+        'foo bar baz'
+      );
+      env.expect(el).toHaveClasses(['bar', 'baz']);
+    });
+
+    verifyFails(function(env) {
+      const el = specHelpers.domHelpers.createElementWithClassName('foo bar');
+      env.expect(el).toHaveClasses(['bar', 'baz']);
+    });
+  });
+
   describe('toHaveSpyInteractions', function() {
     let spyObj;
     beforeEach(function() {

--- a/spec/core/matchers/toHaveClassesSpec.js
+++ b/spec/core/matchers/toHaveClassesSpec.js
@@ -1,0 +1,48 @@
+describe('toHaveClasses', function() {
+  it('fails for a DOM element that lacks all the expected classes', function() {
+    const matcher = jasmineUnderTest.matchers.toHaveClasses(),
+      result = matcher.compare(
+        specHelpers.domHelpers.createElementWithClassName(''),
+        ['foo', 'bar']
+      );
+
+    expect(result.pass).toBe(false);
+  });
+
+  it('passes for a DOM element that has all the expected classes', function() {
+    const matcher = jasmineUnderTest.matchers.toHaveClasses(),
+      el = specHelpers.domHelpers.createElementWithClassName('foo bar baz');
+
+    expect(matcher.compare(el, ['foo', 'bar']).pass).toBe(true);
+  });
+
+  it('fails for a DOM element that only has some matching classes', function() {
+    const matcher = jasmineUnderTest.matchers.toHaveClasses(),
+      el = specHelpers.domHelpers.createElementWithClassName('foo bar');
+
+    expect(matcher.compare(el, ['foo', 'can']).pass).toBe(false);
+  });
+
+  it('throws an exception when actual is not a DOM element', function() {
+    const matcher = jasmineUnderTest.matchers.toHaveClasses({
+      pp: jasmineUnderTest.makePrettyPrinter()
+    });
+
+    expect(function() {
+      matcher.compare('x', ['foo']);
+    }).toThrowError("'x' is not a DOM element");
+
+    expect(function() {
+      matcher.compare(undefined, ['foo']);
+    }).toThrowError('undefined is not a DOM element');
+
+    const textNode = specHelpers.domHelpers.document.createTextNode('');
+    expect(function() {
+      matcher.compare(textNode, ['foo']);
+    }).toThrowError('HTMLNode is not a DOM element');
+
+    expect(function() {
+      matcher.compare({ classList: '' }, ['foo']);
+    }).toThrowError("Object({ classList: '' }) is not a DOM element");
+  });
+});

--- a/src/core/matchers/requireMatchers.js
+++ b/src/core/matchers/requireMatchers.js
@@ -27,6 +27,7 @@ getJasmineRequireObj().requireMatchers = function(jRequire, j$) {
       'toHaveBeenCalledTimes',
       'toHaveBeenCalledWith',
       'toHaveClass',
+      'toHaveClasses',
       'toHaveSpyInteractions',
       'toMatch',
       'toThrow',

--- a/src/core/matchers/toHaveClasses.js
+++ b/src/core/matchers/toHaveClasses.js
@@ -1,0 +1,36 @@
+getJasmineRequireObj().toHaveClasses = function(j$) {
+  /**
+   * {@link expect} the actual value to be a DOM element that has the expected classes
+   * @function
+   * @name matchers#toHaveClasses
+   * @since 3.0.0
+   * @param {Object} expected - The class names to test for
+   * @example
+   * const el = document.createElement('div');
+   * el.className = 'foo bar baz';
+   * expect(el).toHaveClasses(['bar', 'baz']);
+   */
+  function toHaveClasses(matchersUtil) {
+    return {
+      compare: function(actual, expected) {
+        if (!isElement(actual)) {
+          throw new Error(matchersUtil.pp(actual) + ' is not a DOM element');
+        }
+
+        return {
+          pass: expected.every(e =>
+            actual.classList.value.split(' ').some(c => c === e)
+          )
+        };
+      }
+    };
+  }
+
+  function isElement(maybeEl) {
+    return (
+      maybeEl && maybeEl.classList && j$.isFunction_(maybeEl.classList.contains)
+    );
+  }
+
+  return toHaveClasses;
+};

--- a/src/core/matchers/toHaveClasses.js
+++ b/src/core/matchers/toHaveClasses.js
@@ -3,7 +3,7 @@ getJasmineRequireObj().toHaveClasses = function(j$) {
    * {@link expect} the actual value to be a DOM element that has the expected classes
    * @function
    * @name matchers#toHaveClasses
-   * @since 3.0.0
+   * @since 5.6.0
    * @param {Object} expected - The class names to test for
    * @example
    * const el = document.createElement('div');

--- a/src/core/matchers/toHaveClasses.js
+++ b/src/core/matchers/toHaveClasses.js
@@ -18,9 +18,7 @@ getJasmineRequireObj().toHaveClasses = function(j$) {
         }
 
         return {
-          pass: expected.every(e =>
-            actual.classList.value.split(' ').some(c => c === e)
-          )
+          pass: expected.every(e => actual.classList.contains(e))
         };
       }
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a new matcher to verify that an array of individual classes are all included in an element's `classList`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Occasionally I need to test that a set of classes are dynamically added to an element and I got tired of writing multiple `toHaveClass` expectations in each test. As an alternative to this new matcher, I'd be open to dropping it and expanding the functionality of `toHaveClass`, but for now I figured this was a good learning opportunity for me, and there are other matchers that are similar to each other (at least by name), so this shouldn't be too far off the mark and is the least obtrusive way to add this functionality.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Per the contribution guidelines, all tests have been run in Node as well as Chrome, Firefox, and Edge.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

This would of course need new documentation, but I didn't see any information in the contribution guidelines about where/how to do this.

