### PR TITLE
improved error msg on toBeRehectedWithError and all other built-in as…

### DIFF
--- a/spec/core/matchers/async/toBePendingSpec.js
+++ b/spec/core/matchers/async/toBePendingSpec.js
@@ -38,6 +38,8 @@ describe('toBePending', function() {
       return matcher.compare(actual);
     }
 
-    expect(f).toThrowError('Expected toBePending to be called on a promise.');
+    expect(f).toThrowError(
+      `Expected toBePending to be called on a promise but was on a ${typeof actual}.`
+    );
   });
 });

--- a/spec/core/matchers/async/toBeRejectedSpec.js
+++ b/spec/core/matchers/async/toBeRejectedSpec.js
@@ -28,6 +28,8 @@ describe('toBeRejected', function() {
       return matcher.compare(actual);
     }
 
-    expect(f).toThrowError('Expected toBeRejected to be called on a promise.');
+    expect(f).toThrowError(
+      `Expected toBeRejected to be called on a promise but was on a ${typeof actual}.`
+    );
   });
 });

--- a/spec/core/matchers/async/toBeRejectedWithErrorSpec.js
+++ b/spec/core/matchers/async/toBeRejectedWithErrorSpec.js
@@ -232,7 +232,7 @@ describe('#toBeRejectedWithError', function() {
     }
 
     expect(f).toThrowError(
-      'Expected toBeRejectedWithError to be called on a promise.'
+      `Expected toBeRejectedWithError to be called on a promise but was on a ${typeof actual}.`
     );
   });
 });

--- a/spec/core/matchers/async/toBeRejectedWithSpec.js
+++ b/spec/core/matchers/async/toBeRejectedWithSpec.js
@@ -83,7 +83,7 @@ describe('#toBeRejectedWith', function() {
     }
 
     expect(f).toThrowError(
-      'Expected toBeRejectedWith to be called on a promise.'
+      `Expected toBeRejectedWith to be called on a promise but was on a ${typeof actual}.`
     );
   });
 });

--- a/spec/core/matchers/async/toBeResolvedSpec.js
+++ b/spec/core/matchers/async/toBeResolvedSpec.js
@@ -35,6 +35,8 @@ describe('toBeResolved', function() {
       return matcher.compare(actual);
     }
 
-    expect(f).toThrowError('Expected toBeResolved to be called on a promise.');
+    expect(f).toThrowError(
+      `Expected toBeResolved to be called on a promise but was on a ${typeof actual}.`
+    );
   });
 });

--- a/spec/core/matchers/async/toBeResolvedToSpec.js
+++ b/spec/core/matchers/async/toBeResolvedToSpec.js
@@ -93,7 +93,7 @@ describe('#toBeResolvedTo', function() {
     }
 
     expect(f).toThrowError(
-      'Expected toBeResolvedTo to be called on a promise.'
+      `Expected toBeResolvedTo to be called on a promise but was on a ${typeof actual}.`
     );
   });
 });

--- a/src/core/matchers/async/toBePending.js
+++ b/src/core/matchers/async/toBePending.js
@@ -12,7 +12,9 @@ getJasmineRequireObj().toBePending = function(j$) {
     return {
       compare: function(actual) {
         if (!j$.isPromiseLike(actual)) {
-          throw new Error('Expected toBePending to be called on a promise.');
+          throw new Error(
+            `Expected toBePending to be called on a promise but was on a ${typeof actual}.`
+          );
         }
         const want = {};
         return Promise.race([actual, Promise.resolve(want)]).then(

--- a/src/core/matchers/async/toBeRejected.js
+++ b/src/core/matchers/async/toBeRejected.js
@@ -14,7 +14,9 @@ getJasmineRequireObj().toBeRejected = function(j$) {
     return {
       compare: function(actual) {
         if (!j$.isPromiseLike(actual)) {
-          throw new Error('Expected toBeRejected to be called on a promise.');
+          throw new Error(
+            `Expected toBeRejected to be called on a promise but was on a ${typeof actual}.`
+          );
         }
         return actual.then(
           function() {

--- a/src/core/matchers/async/toBeRejectedWith.js
+++ b/src/core/matchers/async/toBeRejectedWith.js
@@ -16,7 +16,7 @@ getJasmineRequireObj().toBeRejectedWith = function(j$) {
       compare: function(actualPromise, expectedValue) {
         if (!j$.isPromiseLike(actualPromise)) {
           throw new Error(
-            'Expected toBeRejectedWith to be called on a promise.'
+            `Expected toBeRejectedWith to be called on a promise but was on a ${typeof actualPromise}.`
           );
         }
 

--- a/src/core/matchers/async/toBeRejectedWithError.js
+++ b/src/core/matchers/async/toBeRejectedWithError.js
@@ -19,7 +19,7 @@ getJasmineRequireObj().toBeRejectedWithError = function(j$) {
       compare: function(actualPromise, arg1, arg2) {
         if (!j$.isPromiseLike(actualPromise)) {
           throw new Error(
-            'Expected toBeRejectedWithError to be called on a promise.'
+            `Expected toBeRejectedWithError to be called on a promise but was on a ${typeof actualPromise}.`
           );
         }
 

--- a/src/core/matchers/async/toBeResolved.js
+++ b/src/core/matchers/async/toBeResolved.js
@@ -14,7 +14,9 @@ getJasmineRequireObj().toBeResolved = function(j$) {
     return {
       compare: function(actual) {
         if (!j$.isPromiseLike(actual)) {
-          throw new Error('Expected toBeResolved to be called on a promise.');
+          throw new Error(
+            `Expected toBeResolved to be called on a promise but was on a ${typeof actual}.`
+          );
         }
 
         return actual.then(

--- a/src/core/matchers/async/toBeResolvedTo.js
+++ b/src/core/matchers/async/toBeResolvedTo.js
@@ -15,7 +15,9 @@ getJasmineRequireObj().toBeResolvedTo = function(j$) {
     return {
       compare: function(actualPromise, expectedValue) {
         if (!j$.isPromiseLike(actualPromise)) {
-          throw new Error('Expected toBeResolvedTo to be called on a promise.');
+          throw new Error(
+            `Expected toBeResolvedTo to be called on a promise but was on a ${typeof actualPromise}.`
+          );
         }
 
         function prefix(passed) {


### PR DESCRIPTION
…ync matchers

<!--- Provide a general summary of your changes in the Title above -->
I've modified async matchers from src and spec
## Description
<!--- Describe your changes in detail -->
Used a more descriptive err mesage like
 `Expected toBeResolvedTo to be called on a promise but was on a ${typeof actualPromise}.`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previous err message was unclear
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/jasmine/jasmine/issues/2037

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I run npm test, build and test again
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

