### PR TITLE
refactor(Clock): Fix throttling test unit conversion bug

### DIFF
--- a/spec/core/ClockSpec.js
+++ b/spec/core/ClockSpec.js
@@ -788,23 +788,25 @@ describe('Clock (acceptance)', function() {
     });
 
     it('avoids throttling in browsers other than Safari', async () => {
-      if (
-        typeof navigator !== 'undefined' &&
+      if (typeof navigator === 'undefined' || typeof window === 'undefined') {
+        // Node does not throttle timeouts so this test isn't necessary
+        pending('This test only runs in browsers.');
+      } else if (
         /^((?!chrome|android|firefox).)*safari/i.test(navigator.userAgent)
       ) {
-        return;
+        pending('Timeout throttling prevention does not work in Safari.');
       }
       // This test ensures the setTimeout loop isn't getting throttled by browsers
       const promises = [];
-      // 2000 timers at ~4ms throttling = 8_000ms would time out if we weren't
+      // 100 timers at ~4ms throttling = 400ms would time out if we weren't
       // preventing the throttle with the MessageChannel trick.
-      for (let i = 0; i < 2000; i++) {
+      for (let i = 0; i < 100; i++) {
         promises.push(new Promise(resolve => clock.setTimeout(resolve)));
       }
-      const startTimeMs = performance.now() / 1000;
+      const startTimeMs = performance.now();
       await Promise.all(promises);
-      const endTimeMs = performance.now() / 1000;
-      expect(endTimeMs - startTimeMs).toBeLessThan(1000);
+      const endTimeMs = performance.now();
+      expect(endTimeMs - startTimeMs).toBeLessThan(50);
     });
 
     it('is easy to test async functions with interleaved timers and microtasks', async () => {


### PR DESCRIPTION
* fixes the throttling timeout test which incorrectly converted from milliseconds to seconds before making an assertion expecting milliseconds.
* reduces number of timeouts from 2000 to 100, which is still more than enough to observe throttling (or lackthereof).
* Omits Node from the test since it does not throttle timeouts
