### PR TITLE
perf(clock): use setImmediate for autoTick macrotask in Node

### DIFF
--- a/spec/core/ClockSpec.js
+++ b/spec/core/ClockSpec.js
@@ -715,6 +715,20 @@ describe('Clock (acceptance)', function() {
       clock.uninstall();
     });
 
+    it('flushes microtask queue between macrotasks', async () => {
+      const log = [];
+      await new Promise(r => clock.setTimeout(r, 10)).then(() => {
+        log.push(1);
+        Promise.resolve().then(() => log.push(2));
+        Promise.resolve().then(() => log.push(3));
+      });
+      await new Promise(r => clock.setTimeout(r, 10)).then(() => {
+        log.push(4);
+        Promise.resolve().then(() => log.push(5));
+      });
+      expect(log).toEqual([1, 2, 3, 4, 5]);
+    });
+
     it('can run setTimeouts/setIntervals asynchronously', function() {
       const recurring = jasmine.createSpy('recurring'),
         fn1 = jasmine.createSpy('fn1'),

--- a/src/core/Clock.js
+++ b/src/core/Clock.js
@@ -222,6 +222,12 @@ callbacks to execute _before_ running the next one.
     //
     // @return {!Promise<undefined>}
     async function newMacrotask() {
+      if (NODE_JS) {
+        // setImmediate is generally faster than setTimeout in Node
+        // https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout
+        return new Promise(resolve => void setImmediate(resolve));
+      }
+
       // MessageChannel ensures that setTimeout is not throttled to 4ms.
       // https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#reasons_for_delays_longer_than_specified
       // https://stackblitz.com/edit/stackblitz-starters-qtlpcc


### PR DESCRIPTION
When called within an I/O cycle, `setImmediate` is generally faster because it is designed to execute immediately after the current I/O event completes, whereas `setTimeout(0)` gets placed in the timers queue and might be subject to delays.

> The main advantage to using setImmediate() over setTimeout() is setImmediate()
> will always be executed before any timers if scheduled within an I/O cycle,
> independently of how many timers are present.

* https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#setimmediate-vs-settimeout
* https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#poll
* https://nodejs.org/en/learn/asynchronous-work/understanding-setimmediate
