### PR TITLE
Allow passing a function into a spy's `saveArgumentsByValue` to customize cloning

### DIFF
--- a/spec/core/CallTrackerSpec.js
+++ b/spec/core/CallTrackerSpec.js
@@ -134,6 +134,42 @@ describe('CallTracker', function() {
     expect(callTracker.mostRecent().args[1]).toEqual(arrayArg);
   });
 
+  it('allows object arguments to be deep cloned', function() {
+    const callTracker = new jasmineUnderTest.CallTracker();
+    callTracker.saveArgumentsByValue(args => JSON.parse(JSON.stringify(args)));
+
+    const objectArg = { foo: { bar: { baz: ['qux'] } } },
+      arrayArg = ['foo', 'bar'];
+
+    callTracker.track({
+      object: {},
+      args: [objectArg, arrayArg, false, undefined, null, NaN, '', 0, 1.0]
+    });
+
+    objectArg.foo.bar.baz.push('quux');
+
+    expect(callTracker.mostRecent().args[0]).not.toBe(objectArg);
+    expect(callTracker.mostRecent().args[0]).not.toEqual(objectArg);
+    expect(callTracker.mostRecent().args[0]).toEqual({
+      foo: { bar: { baz: ['qux'] } }
+    });
+    expect(callTracker.mostRecent().args[1]).not.toBe(arrayArg);
+    expect(callTracker.mostRecent().args[1]).toEqual(arrayArg);
+  });
+
+  it('can take any function to transform arguments when saving by value', function() {
+    const callTracker = new jasmineUnderTest.CallTracker();
+    callTracker.saveArgumentsByValue(JSON.stringify);
+
+    const objectArg = { foo: { bar: { baz: ['qux'] } } },
+      arrayArg = ['foo', 'bar'],
+      args = [objectArg, arrayArg, false, undefined, null, NaN, '', 0, 1.0];
+
+    callTracker.track({ object: {}, args });
+
+    expect(callTracker.mostRecent().args).toEqual(JSON.stringify(args));
+  });
+
   it('saves primitive arguments by value', function() {
     const callTracker = new jasmineUnderTest.CallTracker(),
       args = [undefined, null, false, '', /\s/, 0, 1.2, NaN];

--- a/src/core/CallTracker.js
+++ b/src/core/CallTracker.js
@@ -9,7 +9,7 @@ getJasmineRequireObj().CallTracker = function(j$) {
 
     this.track = function(context) {
       if (opts.cloneArgs) {
-        context.args = j$.util.cloneArgs(context.args);
+        context.args = opts.argsCloner(context.args);
       }
       calls.push(context);
     };
@@ -117,13 +117,15 @@ getJasmineRequireObj().CallTracker = function(j$) {
     };
 
     /**
-     * Set this spy to do a shallow clone of arguments passed to each invocation.
+     * Set this spy to do a clone of arguments passed to each invocation.
      * @name Spy#calls#saveArgumentsByValue
      * @since 2.5.0
+     * @param {Function} [argsCloner] A function to use to clone the arguments. Defaults to a shallow cloning function.
      * @function
      */
-    this.saveArgumentsByValue = function() {
+    this.saveArgumentsByValue = function(argsCloner = j$.util.cloneArgs) {
       opts.cloneArgs = true;
+      opts.argsCloner = argsCloner;
     };
 
     this.unverifiedCount = function() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
This fixes #1886. Now users can pass their own cloning function into `saveArgumentsByValue` to influence how spy call args are saved/cloned. On modern platforms, they could use [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone) to do a deep clone.

## How Has This Been Tested?
I mostly just ran the tests in the repo here. Adding the optional arguments seems fairly low stakes. I tested in the latest Firefox, Chrome, and Safari.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

