### PR TITLE
fix(clock): Avoid generating timers with IDs that conflict with native

### DIFF
--- a/src/core/DelayedFunctionScheduler.js
+++ b/src/core/DelayedFunctionScheduler.js
@@ -6,7 +6,7 @@ getJasmineRequireObj().DelayedFunctionScheduler = function(j$) {
     this.scheduledLookup_ = [];
     this.scheduledFunctions_ = {};
     this.currentTime_ = 0;
-    this.delayedFnCount_ = 0;
+    this.delayedFnStartCount_ = 1e12; // arbitrarily large number to avoid collisions with native timer IDs;
     this.deletedKeys_ = [];
 
     this.tick = function(millis, tickDate) {
@@ -38,7 +38,7 @@ getJasmineRequireObj().DelayedFunctionScheduler = function(j$) {
       }
 
       millis = millis || 0;
-      timeoutKey = timeoutKey || ++this.delayedFnCount_;
+      timeoutKey = timeoutKey || ++this.delayedFnStartCount_;
       runAtMillis = runAtMillis || this.currentTime_ + millis;
 
       const funcToSchedule = {


### PR DESCRIPTION
This commit attempts to ensure that the timers created by jasmine mock clock do not conflict with the native timers. This also retains pre-existing behavior whereby a native scheduled function cannot be cleared if it was created prior to the mock clock being installed (unless the mock clock is uninstalled first).

Prior to this commit, attempting to clear a native timer would result in clearing a mocked scheduled function instead, in some scenarios where the IDs conflicted.

fixes #2068
