### PR TITLE
feat(`getSpecProperty`) get a user-defined property

### DIFF
--- a/spec/core/SpecSpec.js
+++ b/spec/core/SpecSpec.js
@@ -78,6 +78,17 @@ describe('Spec', function() {
     });
   });
 
+  describe('#getSpecProperty', function() {
+    it('get the property value', function() {
+      const spec = new jasmineUnderTest.Spec({
+        queueableFn: { fn: () => {} }
+      });
+
+      spec.setSpecProperty('a', 4);
+      expect(spec.getSpecProperty('a')).toBe(4);
+    });
+  });
+
   describe('#setSpecProperty', function() {
     it('adds the property to the result', function() {
       const spec = new jasmineUnderTest.Spec({
@@ -87,6 +98,21 @@ describe('Spec', function() {
       spec.setSpecProperty('a', 4);
 
       expect(spec.result.properties).toEqual({ a: 4 });
+    });
+
+    it('replace the property result when it was previously set', function() {
+      const spec = new jasmineUnderTest.Spec({
+        queueableFn: { fn: () => {} }
+      });
+
+      spec.setSpecProperty('a', 'original-value');
+      spec.setSpecProperty('b', 'original-value');
+      spec.setSpecProperty('a', 'new-value');
+
+      expect(spec.result.properties).toEqual({
+        a: 'new-value',
+        b: 'original-value'
+      });
     });
   });
 

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -2303,7 +2303,7 @@ describe('Env integration', function() {
     env.afterEach(function() {
       env.setSpecProperty(
         'willChangeInAfterEach',
-        env.getSpecProperty('willChange') + 1
+        env.getSpecProperty('willChangeInAfterEach') + 1
       );
       env.setSpecProperty('fromAfterEach', 'Cheese');
     });

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -780,6 +780,26 @@ getJasmineRequireObj().Env = function(j$) {
     };
 
     /**
+     * Get a user-defined property as part of the properties field of {@link SpecResult}
+     * @name Env#getSpecProperty
+     * @since 5.10.0
+     * @function
+     * @param {String} key The name of the property
+     * @returns {*} The value of the property
+     */
+    this.getSpecProperty = function(key) {
+      if (
+        !runner.currentRunable() ||
+        runner.currentRunable() == runner.currentSuite()
+      ) {
+        throw new Error(
+          "'getSpecProperty' was used when there was no current spec"
+        );
+      }
+      return runner.currentRunable().getSpecProperty(key);
+    };
+
+    /**
      * Sets a user-defined property that will be provided to reporters as part of the properties field of {@link SpecResult}
      * @name Env#setSpecProperty
      * @since 3.6.0

--- a/src/core/Spec.js
+++ b/src/core/Spec.js
@@ -63,6 +63,11 @@ getJasmineRequireObj().Spec = function(j$) {
     }
   };
 
+  Spec.prototype.getSpecProperty = function(key) {
+    this.result.properties = this.result.properties || {};
+    return this.result.properties[key];
+  };
+
   Spec.prototype.setSpecProperty = function(key, value) {
     this.result.properties = this.result.properties || {};
     this.result.properties[key] = value;

--- a/src/core/requireInterface.js
+++ b/src/core/requireInterface.js
@@ -169,6 +169,18 @@ getJasmineRequireObj().interface = function(jasmine, env) {
     },
 
     /**
+     * Get a user-defined property as part of the properties field of {@link SpecResult}
+     * @name getSpecProperty
+     * @since 5.10.0
+     * @function
+     * @param {String} key The name of the property
+     * @returns {*} The value of the property
+     */
+    getSpecProperty: function(key) {
+      return env.getSpecProperty(key);
+    },
+
+    /**
      * Sets a user-defined property that will be provided to reporters as part of the properties field of {@link SpecResult}
      * @name setSpecProperty
      * @since 3.6.0


### PR DESCRIPTION


## Description

Add the ability to retrieve a current spec user-defined property by adding a `getSpecProperty` global function

## Example

```ts
afterEach(function() {
  setSpecProperty(
    'some-key',
    env.getSpecProperty('some-key') + 1 // `some-key` = 2
  );
});

it('getSpecProperty/setSpecProperty example', function() {
  setSpecProperty('some-key', 1); // `some-key` = 1
});
```

## Motivation and Context

AFAIK, there is no jasmine public API that gives the capacity to easily mutate a spec user-defined property.

The `getSpecProperty` will allow me to ease mutating information about "what happened" in a spec (e.g: network requests, console logs, usage tracking...), without the need to keep reference of these information.

## How Has This Been Tested?

By adding unit & integration tests for `getSpecProperty` and `setSpecProperty` that follows patters that I would like to use.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly: TODO - I will submit a PR to https://github.com/jasmine/jasmine.github.io once I got your approval on the overall philosophy/approach
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

