### PR TITLE
Fix missing pendingReason in pending suite results

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -551,7 +551,7 @@ jasmineRequire.HtmlReporter = function(j$) {
             specDescription = 'SPEC HAS NO EXPECTATIONS ' + specDescription;
           }
           if (resultNode.result.status === 'pending') {
-            if (resultNode.result.pendingReason !== '') {
+            if (resultNode.result.pendingReason) {
               specDescription +=
                 ' PENDING WITH MESSAGE: ' + resultNode.result.pendingReason;
             } else {

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -10570,14 +10570,20 @@ getJasmineRequireObj().Suite = function(j$) {
     }
 
     // Mark the suite with "pending" status
-    pend() {
+    pend(message) {
       this.markedPending = true;
+      if (message) {
+        this.result.pendingReason = message;
+      }
     }
 
     // Like pend(), but pending state will survive reset().
     // Useful for fdescribe, xdescribe, where pending state should remain.
-    exclude() {
-      this.pend();
+    exclude(message) {
+      if (this.message) {
+        this.excludeMessage = message;
+      }
+      this.pend(message);
       this.markedExcluding = true;
     }
 
@@ -10904,7 +10910,7 @@ getJasmineRequireObj().SuiteBuilder = function(j$) {
         throw new Error('describe does not expect any arguments');
       }
       if (this.currentDeclarationSuite_.markedExcluding) {
-        suite.exclude();
+        suite.exclude(this.currentDeclarationSuite_.result.pendingReason);
       }
       this.addSpecsToSuite_(suite, definitionFn);
       return suite;
@@ -10925,7 +10931,7 @@ getJasmineRequireObj().SuiteBuilder = function(j$) {
     xdescribe(description, definitionFn, filename) {
       ensureIsFunction(definitionFn, 'xdescribe');
       const suite = this.suiteFactory_(description, filename);
-      suite.exclude();
+      suite.exclude('Temporarily disabled with xdescribe');
       this.addSpecsToSuite_(suite, definitionFn);
 
       return suite;
@@ -11029,7 +11035,7 @@ getJasmineRequireObj().SuiteBuilder = function(j$) {
 
       const spec = this.specFactory_(description, fn, timeout, filename);
       if (this.currentDeclarationSuite_.markedExcluding) {
-        spec.exclude();
+        spec.exclude(this.currentDeclarationSuite_.result.pendingReason);
       }
       this.currentDeclarationSuite_.addChild(spec);
 

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -1635,16 +1635,31 @@ describe('Env integration', function() {
       });
     });
 
+    env.describe('Another Suite', function() {
+      env.describe('with xdescribes in it', function() {
+        env.xdescribe('xd out', function() {
+          env.describe('nested again', function() {
+            env.it('with a spec', function() {
+              env.expect().nothing();
+            });
+          });
+          env.it('with another spec', function() {
+            env.expect().nothing();
+          });
+        });
+      });
+    });
+
     await env.execute();
 
     expect(reporter.jasmineStarted).toHaveBeenCalledWith({
-      totalSpecsDefined: 6,
+      totalSpecsDefined: 8,
       order: jasmine.any(jasmineUnderTest.Order),
       parallel: false
     });
 
-    expect(reporter.specStarted.calls.count()).toBe(6);
-    expect(reporter.specDone.calls.count()).toBe(6);
+    expect(reporter.specStarted.calls.count()).toBe(8);
+    expect(reporter.specDone.calls.count()).toBe(8);
 
     const baseSpecEvent = {
       passedExpectations: [],
@@ -1762,9 +1777,31 @@ describe('Env integration', function() {
       pendingReason: 'Temporarily disabled with xit',
       duration: jasmine.any(Number)
     });
-
-    expect(reporter.suiteStarted.calls.count()).toBe(3);
-    expect(reporter.suiteDone.calls.count()).toBe(3);
+    expect(reporter.specDone.calls.argsFor(6)[0]).toEqual({
+      ...baseSpecEvent,
+      description: 'with a spec',
+      status: 'pending',
+      fullName:
+        'Another Suite with xdescribes in it xd out nested again with a spec',
+      parentSuiteId:
+        suiteFullNameToId[
+          'Another Suite with xdescribes in it xd out nested again'
+        ],
+      pendingReason: 'Temporarily disabled with xdescribe',
+      duration: jasmine.any(Number)
+    });
+    expect(reporter.specDone.calls.argsFor(7)[0]).toEqual({
+      ...baseSpecEvent,
+      description: 'with another spec',
+      status: 'pending',
+      fullName: 'Another Suite with xdescribes in it xd out with another spec',
+      parentSuiteId:
+        suiteFullNameToId['Another Suite with xdescribes in it xd out'],
+      pendingReason: 'Temporarily disabled with xdescribe',
+      duration: jasmine.any(Number)
+    });
+    expect(reporter.suiteStarted.calls.count()).toBe(7);
+    expect(reporter.suiteDone.calls.count()).toBe(7);
 
     const baseSuiteEvent = {
       id: jasmine.any(String),

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -50,14 +50,20 @@ getJasmineRequireObj().Suite = function(j$) {
     }
 
     // Mark the suite with "pending" status
-    pend() {
+    pend(message) {
       this.markedPending = true;
+      if (message) {
+        this.result.pendingReason = message;
+      }
     }
 
     // Like pend(), but pending state will survive reset().
     // Useful for fdescribe, xdescribe, where pending state should remain.
-    exclude() {
-      this.pend();
+    exclude(message) {
+      if (this.message) {
+        this.excludeMessage = message;
+      }
+      this.pend(message);
       this.markedExcluding = true;
     }
 

--- a/src/core/SuiteBuilder.js
+++ b/src/core/SuiteBuilder.js
@@ -38,7 +38,7 @@ getJasmineRequireObj().SuiteBuilder = function(j$) {
         throw new Error('describe does not expect any arguments');
       }
       if (this.currentDeclarationSuite_.markedExcluding) {
-        suite.exclude();
+        suite.exclude(this.currentDeclarationSuite_.result.pendingReason);
       }
       this.addSpecsToSuite_(suite, definitionFn);
       return suite;
@@ -59,7 +59,7 @@ getJasmineRequireObj().SuiteBuilder = function(j$) {
     xdescribe(description, definitionFn, filename) {
       ensureIsFunction(definitionFn, 'xdescribe');
       const suite = this.suiteFactory_(description, filename);
-      suite.exclude();
+      suite.exclude('Temporarily disabled with xdescribe');
       this.addSpecsToSuite_(suite, definitionFn);
 
       return suite;
@@ -163,7 +163,7 @@ getJasmineRequireObj().SuiteBuilder = function(j$) {
 
       const spec = this.specFactory_(description, fn, timeout, filename);
       if (this.currentDeclarationSuite_.markedExcluding) {
-        spec.exclude();
+        spec.exclude(this.currentDeclarationSuite_.result.pendingReason);
       }
       this.currentDeclarationSuite_.addChild(spec);
 

--- a/src/html/HtmlReporter.js
+++ b/src/html/HtmlReporter.js
@@ -517,7 +517,7 @@ jasmineRequire.HtmlReporter = function(j$) {
             specDescription = 'SPEC HAS NO EXPECTATIONS ' + specDescription;
           }
           if (resultNode.result.status === 'pending') {
-            if (resultNode.result.pendingReason !== '') {
+            if (resultNode.result.pendingReason) {
               specDescription +=
                 ' PENDING WITH MESSAGE: ' + resultNode.result.pendingReason;
             } else {


### PR DESCRIPTION
## Description
A parent xdescribe will now be reported in the specs as "Temporarily disabled with xdescribe"

## Motivation and Context

fixes #2079 

## How Has This Been Tested?

tested `xit`, `it`, `xdescribe` (parent and grandparent only)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
