### PR TITLE
Proposal: jasmine.allOf AsymmetricEqualityTester

### DIFF
--- a/spec/core/asymmetric_equality/AllOfSpec.js
+++ b/spec/core/asymmetric_equality/AllOfSpec.js
@@ -1,0 +1,63 @@
+describe('AllOf', function() {
+  it('matches a single value', function() {
+    const matchersUtil = new jasmineUnderTest.MatchersUtil();
+    const allOf = new jasmineUnderTest.AllOf('foo');
+
+    expect(allOf.asymmetricMatch('foo', matchersUtil)).toBeTrue();
+  });
+
+  it('matches a single matcher', function() {
+    const matchersUtil = new jasmineUnderTest.MatchersUtil();
+    const allOf = new jasmineUnderTest.AllOf(
+      new jasmineUnderTest.StringContaining('oo')
+    );
+
+    expect(allOf.asymmetricMatch('foo', matchersUtil)).toBeTrue();
+  });
+
+  it('matches multiple matchers', function() {
+    const matchersUtil = new jasmineUnderTest.MatchersUtil();
+    const allOf = new jasmineUnderTest.AllOf(
+      new jasmineUnderTest.StringContaining('o'),
+      new jasmineUnderTest.StringContaining('f')
+    );
+
+    expect(allOf.asymmetricMatch('foo', matchersUtil)).toBeTrue();
+  });
+
+  it('does not match when value does not match', function() {
+    const matchersUtil = new jasmineUnderTest.MatchersUtil();
+    const allOf = new jasmineUnderTest.AllOf('bar');
+
+    expect(allOf.asymmetricMatch('foo', matchersUtil)).toBeFalse();
+  });
+
+  it('does not match when any matchers fail', function() {
+    const matchersUtil = new jasmineUnderTest.MatchersUtil();
+    const allOf = new jasmineUnderTest.AllOf(
+      new jasmineUnderTest.StringContaining('o'),
+      new jasmineUnderTest.StringContaining('x')
+    );
+
+    expect(allOf.asymmetricMatch('foo', matchersUtil)).toBeFalse();
+  });
+
+  it('jasmineToStrings itself', function() {
+    const matcher = new jasmineUnderTest.AllOf('o');
+    const pp = jasmine.createSpy('pp').and.returnValue('sample');
+
+    expect(matcher.jasmineToString(pp)).toEqual('<jasmine.allOf(sample)>');
+    expect(pp).toHaveBeenCalledWith(['o']);
+  });
+
+  describe('when called without an argument', function() {
+    it('tells the user to pass a constructor argument', function() {
+      expect(function() {
+        new jasmineUnderTest.AllOf();
+      }).toThrowError(
+        TypeError,
+        'jasmine.allOf() expects at least one argument to be passed.'
+      );
+    });
+  });
+});

--- a/src/core/asymmetric_equality/AllOf.js
+++ b/src/core/asymmetric_equality/AllOf.js
@@ -1,0 +1,27 @@
+getJasmineRequireObj().AllOf = function(j$) {
+  function AllOf() {
+    const expectedValues = Array.from(arguments);
+    if (expectedValues.length === 0) {
+      throw new TypeError(
+        'jasmine.allOf() expects at least one argument to be passed.'
+      );
+    }
+    this.expectedValues = expectedValues;
+  }
+
+  AllOf.prototype.asymmetricMatch = function(other, matchersUtil) {
+    for (const expectedValue of this.expectedValues) {
+      if (!matchersUtil.equals(other, expectedValue)) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  AllOf.prototype.jasmineToString = function(pp) {
+    return '<jasmine.allOf(' + pp(this.expectedValues) + ')>';
+  };
+
+  return AllOf;
+};

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -223,6 +223,19 @@ getJasmineRequireObj().base = function(j$, jasmineGlobal) {
 
   /**
    * Get an {@link AsymmetricEqualityTester} that will succeed if the actual
+   * value being compared matches every provided equality tester.
+   * @name asymmetricEqualityTesters.allOf
+   * @emittedName jasmine.allOf
+   * @since 5.13.0
+   * @function
+   * @param {...*} arguments - The asymmetric equality checkers to compare.
+   */
+  j$.allOf = function() {
+    return new j$.AllOf(...arguments);
+  };
+
+  /**
+   * Get an {@link AsymmetricEqualityTester} that will succeed if the actual
    * value being compared is an instance of the specified class/constructor.
    * @name asymmetricEqualityTesters.any
    * @emittedName jasmine.any

--- a/src/core/requireCore.js
+++ b/src/core/requireCore.js
@@ -35,6 +35,7 @@ var getJasmineRequireObj = (function(jasmineGlobal) {
     j$.util = jRequire.util(j$);
     j$.errors = jRequire.errors();
     j$.formatErrorMsg = jRequire.formatErrorMsg();
+    j$.AllOf = jRequire.AllOf(j$);
     j$.Any = jRequire.Any(j$);
     j$.Anything = jRequire.Anything(j$);
     j$.CallTracker = jRequire.CallTracker(j$);


### PR DESCRIPTION
New asymmetric equality tester that accepts a variable number of arguments, and will pass if all of them evaluate as being equal to the input value. Includes unit tests

<!--- Provide a general summary of your changes in the Title above -->

## Description
Creates a new asymmetric equality tester that will accept multiple arguments and require all of them to test `equal` against the value.

## Motivation and Context
There are cases where it's desirable to evaluate multiple types of asymmetric equality testers against a single value.  A simple example is to combine multiple `stringContaining` checks into one, but it could also be used to check (for example) that a value is an instance of a class (`jasmine.any`) **and** make assertions about its properties (`jasmine.objectContaining`).

fixes #2083

## How Has This Been Tested?
The changes are covered by unit tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.\
    - **I think the changes are covered by generated docs but tell me if that's not the case**.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

