### PR TITLE
Catch invalid path in url parsing

### DIFF
--- a/lib/jasmine-core/jasmine-html.js
+++ b/lib/jasmine-core/jasmine-html.js
@@ -1314,7 +1314,12 @@ jasmineRequire.HtmlSpecFilterV2 = function() {
       const params = this.#getFilterParams();
 
       if (params.path) {
-        return this.#matchesPath(spec, JSON.parse(params.path));
+        try {
+          return this.#matchesPath(spec, JSON.parse(params.path));
+          // eslint-disable-next-line no-unused-vars
+        } catch (error) {
+          return true;
+        }
       } else if (params.spec) {
         // Like legacy HtmlSpecFilter, retained because it's convenient for
         // hand-constructing filter URLs

--- a/src/html/HtmlSpecFilterv2.js
+++ b/src/html/HtmlSpecFilterv2.js
@@ -10,7 +10,12 @@ jasmineRequire.HtmlSpecFilterV2 = function() {
       const params = this.#getFilterParams();
 
       if (params.path) {
-        return this.#matchesPath(spec, JSON.parse(params.path));
+        try {
+          return this.#matchesPath(spec, JSON.parse(params.path));
+          // eslint-disable-next-line no-unused-vars
+        } catch (error) {
+          return true;
+        }
       } else if (params.spec) {
         // Like legacy HtmlSpecFilter, retained because it's convenient for
         // hand-constructing filter URLs


### PR DESCRIPTION
Before this, putting a filter in `path` instead of `spec`

http://localhost:8888/?hideDisabled=true&spec=&path=subPath

fails without a visual feedback

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
