### PR TITLE
fix: add pendingReason message for xdescribe

### DIFF
--- a/spec/core/SuiteBuilderSpec.js
+++ b/spec/core/SuiteBuilderSpec.js
@@ -86,6 +86,20 @@ describe('SuiteBuilder', function() {
 
       expect(suite.markedExcluding).toBeTrue();
     });
+
+    it('sets pendingReason to "Temporarily disabled with xdescribe"', function() {
+      const env = { configuration: () => ({}) };
+      const suiteBuilder = new privateUnderTest.SuiteBuilder({ env });
+
+      let spec;
+      suiteBuilder.xdescribe('a suite', function() {
+        spec = suiteBuilder.it('a spec');
+      });
+
+      expect(spec.doneEvent().pendingReason).toEqual(
+        'Temporarily disabled with xdescribe'
+      );
+    });
   });
 
   describe('#it', function() {

--- a/spec/core/SuiteBuilderSpec.js
+++ b/spec/core/SuiteBuilderSpec.js
@@ -96,6 +96,7 @@ describe('SuiteBuilder', function() {
         spec = suiteBuilder.it('a spec');
       });
 
+      spec.reset();
       expect(spec.doneEvent().pendingReason).toEqual(
         'Temporarily disabled with xdescribe'
       );

--- a/src/core/Spec.js
+++ b/src/core/Spec.js
@@ -238,7 +238,7 @@ getJasmineRequireObj().Spec = function(j$) {
     // Useful for fit, xit, where pending state remains.
     exclude(message) {
       this.markedExcluding = true;
-      if (this.message) {
+      if (message) {
         this.excludeMessage = message;
       }
       this.pend(message);

--- a/src/core/Suite.js
+++ b/src/core/Suite.js
@@ -67,9 +67,12 @@ getJasmineRequireObj().Suite = function(j$) {
 
     // Like pend(), but pending state will survive reset().
     // Useful for fdescribe, xdescribe, where pending state should remain.
-    exclude() {
+    exclude(message) {
       this.pend();
       this.markedExcluding = true;
+      if (message) {
+        this.excludeMessage = message;
+      }
     }
 
     beforeEach(fn) {

--- a/src/core/SuiteBuilder.js
+++ b/src/core/SuiteBuilder.js
@@ -40,7 +40,7 @@ getJasmineRequireObj().SuiteBuilder = function(j$) {
         throw new Error('describe does not expect any arguments');
       }
       if (this.currentDeclarationSuite_.markedExcluding) {
-        suite.exclude();
+        suite.exclude(this.currentDeclarationSuite_.excludeMessage);
       }
       this.addSpecsToSuite_(suite, definitionFn);
       return suite;
@@ -61,7 +61,7 @@ getJasmineRequireObj().SuiteBuilder = function(j$) {
     xdescribe(description, definitionFn, filename) {
       ensureIsFunction(definitionFn, 'xdescribe');
       const suite = this.suiteFactory_(description, filename);
-      suite.exclude();
+      suite.exclude('Temporarily disabled with xdescribe');
       this.addSpecsToSuite_(suite, definitionFn);
 
       return suite;
@@ -165,7 +165,7 @@ getJasmineRequireObj().SuiteBuilder = function(j$) {
 
       const spec = this.specFactory_(description, fn, timeout, filename);
       if (this.currentDeclarationSuite_.markedExcluding) {
-        spec.exclude();
+        spec.exclude(this.currentDeclarationSuite_.excludeMessage);
       }
       this.currentDeclarationSuite_.addChild(spec);
 


### PR DESCRIPTION
## Description
When a spec is disabled via xdescribe, the pendingReason in 
specDone reporter event was empty. This fix threads the message 
"Temporarily disabled with xdescribe" through Suite, Spec, and 
SuiteBuilder. Also fixes a bug in Spec.exclude() where this.message 
was used instead of the message argument.

## Motivation and Context
Fixes #2079

## How Has This Been Tested?
Added a new test in SuiteBuilderSpec.js verifying that
spec.doneEvent().pendingReason equals 
"Temporarily disabled with xdescribe" for specs inside xdescribe.
All 1875 specs pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING guide.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.