### PR TITLE
Add private wrapper function for console.error() calls

### DIFF
--- a/spec/core/DeprecatorSpec.js
+++ b/spec/core/DeprecatorSpec.js
@@ -1,8 +1,7 @@
-/* eslint no-console: 0 */
 describe('Deprecator', function() {
   describe('#deprecate', function() {
     beforeEach(function() {
-      spyOn(console, 'error');
+      spyOn(privateUnderTest, 'consoleError');
     });
 
     it('logs the mesage without context when the runnable is the top suite', function() {
@@ -14,7 +13,9 @@ describe('Deprecator', function() {
         omitStackTrace: true
       });
 
-      expect(console.error).toHaveBeenCalledWith('DEPRECATION: the message');
+      expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
+        'DEPRECATION: the message'
+      );
     });
 
     it('logs the message in a descendant suite', function() {
@@ -32,7 +33,7 @@ describe('Deprecator', function() {
         omitStackTrace: true
       });
 
-      expect(console.error).toHaveBeenCalledWith(
+      expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
         'DEPRECATION: the message (in suite: the suite)'
       );
     });
@@ -51,7 +52,7 @@ describe('Deprecator', function() {
         omitStackTrace: true
       });
 
-      expect(console.error).toHaveBeenCalledWith(
+      expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
         'DEPRECATION: the message (in spec: the spec)'
       );
     });
@@ -78,10 +79,10 @@ describe('Deprecator', function() {
         })
       );
       expect(runnable.addDeprecationWarning).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalledWith(
+      expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
         jasmine.stringMatching(/the message/)
       );
-      expect(console.error).not.toHaveBeenCalledWith(
+      expect(privateUnderTest.consoleError).not.toHaveBeenCalledWith(
         jasmine.stringMatching(/a spec/)
       );
     });
@@ -176,8 +177,8 @@ describe('Deprecator', function() {
       expect(
         runnable.addDeprecationWarning.calls.argsFor(0)[0].message
       ).toContain(verboseDeprecationsNote());
-      expect(console.error).toHaveBeenCalledTimes(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain(
+      expect(privateUnderTest.consoleError).toHaveBeenCalledTimes(1);
+      expect(privateUnderTest.consoleError.calls.argsFor(0)[0]).toContain(
         verboseDeprecationsNote()
       );
     });
@@ -196,8 +197,8 @@ describe('Deprecator', function() {
       expect(
         runnable.addDeprecationWarning.calls.argsFor(0)[0].message
       ).not.toContain(verboseDeprecationsNote());
-      expect(console.error).toHaveBeenCalledTimes(1);
-      expect(console.error.calls.argsFor(0)[0]).not.toContain(
+      expect(privateUnderTest.consoleError).toHaveBeenCalledTimes(1);
+      expect(privateUnderTest.consoleError.calls.argsFor(0)[0]).not.toContain(
         verboseDeprecationsNote()
       );
     });
@@ -230,11 +231,13 @@ describe('Deprecator', function() {
         expect(runnable.addDeprecationWarning.calls.argsFor(0)[0].stack).toBe(
           originalStack
         );
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error.calls.argsFor(0)[0].message).toEqual(
-          'the deprecation'
+        expect(privateUnderTest.consoleError).toHaveBeenCalledTimes(1);
+        expect(
+          privateUnderTest.consoleError.calls.argsFor(0)[0].message
+        ).toEqual('the deprecation');
+        expect(privateUnderTest.consoleError.calls.argsFor(0)[0].stack).toEqual(
+          originalStack
         );
-        expect(console.error.calls.argsFor(0)[0].stack).toEqual(originalStack);
       });
 
       it('reports the deprecation every time, regardless of config.verboseDeprecations', function() {
@@ -255,7 +258,7 @@ describe('Deprecator', function() {
         deprecator.addDeprecationWarning(runnable, deprecation);
 
         expect(runnable.addDeprecationWarning).toHaveBeenCalledTimes(2);
-        expect(console.error).toHaveBeenCalledTimes(2);
+        expect(privateUnderTest.consoleError).toHaveBeenCalledTimes(2);
       });
 
       it('omits the note about verboseDeprecations', function() {
@@ -278,8 +281,8 @@ describe('Deprecator', function() {
         expect(
           runnable.addDeprecationWarning.calls.argsFor(0)[0].message
         ).not.toContain(verboseDeprecationsNote());
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error.calls.argsFor(0)[0]).not.toContain(
+        expect(privateUnderTest.consoleError).toHaveBeenCalledTimes(1);
+        expect(privateUnderTest.consoleError.calls.argsFor(0)[0]).not.toContain(
           verboseDeprecationsNote()
         );
       });
@@ -305,9 +308,13 @@ describe('Deprecator', function() {
         message: jasmine.stringMatching(/^the message/),
         omitStackTrace: false
       });
-      expect(console.error).toHaveBeenCalledTimes(1);
-      expect(console.error.calls.argsFor(0)[0]).toContain('the message');
-      expect(console.error.calls.argsFor(0)[0]).toContain('DeprecatorSpec.js');
+      expect(privateUnderTest.consoleError).toHaveBeenCalledTimes(1);
+      expect(privateUnderTest.consoleError.calls.argsFor(0)[0]).toContain(
+        'the message'
+      );
+      expect(privateUnderTest.consoleError.calls.argsFor(0)[0]).toContain(
+        'DeprecatorSpec.js'
+      );
     }
 
     function testNoStackTrace(options) {

--- a/spec/core/baseSpec.js
+++ b/spec/core/baseSpec.js
@@ -152,7 +152,7 @@ describe('base helpers', function() {
       if (typeof process !== 'undefined' && process.emitWarning) {
         spyOn(process, 'emitWarning'); // Node 22
       }
-      spyOn(console, 'error'); // Node <22
+      spyOn(privateUnderTest, 'consoleError'); // Node <22
 
       let id = setTimeout(f1, max);
       setTimeout(function() {

--- a/spec/core/integration/DeprecationSpec.js
+++ b/spec/core/integration/DeprecationSpec.js
@@ -1,4 +1,3 @@
-/* eslint no-console: 0 */
 describe('Deprecation (integration)', function() {
   let env;
 
@@ -13,7 +12,7 @@ describe('Deprecation (integration)', function() {
   it('reports a deprecation on the top suite', async function() {
     const reporter = jasmine.createSpyObj('reporter', ['jasmineDone']);
     env.addReporter(reporter);
-    spyOn(console, 'error');
+    spyOn(privateUnderTest, 'consoleError');
 
     env.beforeAll(function() {
       env.deprecated('the message');
@@ -31,7 +30,7 @@ describe('Deprecation (integration)', function() {
         ]
       })
     );
-    expect(console.error).toHaveBeenCalledWith(
+    expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
       jasmine.stringMatching(/^DEPRECATION: the message/)
     );
   });
@@ -39,7 +38,7 @@ describe('Deprecation (integration)', function() {
   it('reports a deprecation on a descendent suite', async function() {
     const reporter = jasmine.createSpyObj('reporter', ['suiteDone']);
     env.addReporter(reporter);
-    spyOn(console, 'error');
+    spyOn(privateUnderTest, 'consoleError');
 
     env.describe('a suite', function() {
       env.beforeAll(function() {
@@ -59,7 +58,7 @@ describe('Deprecation (integration)', function() {
         ]
       })
     );
-    expect(console.error).toHaveBeenCalledWith(
+    expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
       jasmine.stringMatching(/^DEPRECATION: the message \(in suite: a suite\)/)
     );
   });
@@ -67,7 +66,7 @@ describe('Deprecation (integration)', function() {
   it('reports a deprecation on a spec', async function() {
     const reporter = jasmine.createSpyObj('reporter', ['specDone']);
     env.addReporter(reporter);
-    spyOn(console, 'error');
+    spyOn(privateUnderTest, 'consoleError');
 
     env.describe('a suite', function() {
       env.it('a spec', function() {
@@ -86,7 +85,7 @@ describe('Deprecation (integration)', function() {
         ]
       })
     );
-    expect(console.error).toHaveBeenCalledWith(
+    expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
       jasmine.stringMatching(
         /^DEPRECATION: the message \(in spec: a suite a spec\)/
       )
@@ -96,7 +95,7 @@ describe('Deprecation (integration)', function() {
   it('omits the suite or spec context when ignoreRunnable is true', async function() {
     const reporter = jasmine.createSpyObj('reporter', ['jasmineDone']);
     env.addReporter(reporter);
-    spyOn(console, 'error');
+    spyOn(privateUnderTest, 'consoleError');
 
     env.it('a spec', function() {
       env.deprecated('the message', { ignoreRunnable: true });
@@ -113,10 +112,10 @@ describe('Deprecation (integration)', function() {
         ]
       })
     );
-    expect(console.error).toHaveBeenCalledWith(
+    expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
       jasmine.stringMatching(/the message/)
     );
-    expect(console.error).not.toHaveBeenCalledWith(
+    expect(privateUnderTest.consoleError).not.toHaveBeenCalledWith(
       jasmine.stringMatching(/a spec/)
     );
   });
@@ -124,7 +123,7 @@ describe('Deprecation (integration)', function() {
   it('includes the stack trace', async function() {
     const reporter = jasmine.createSpyObj('reporter', ['specDone']);
     env.addReporter(reporter);
-    spyOn(console, 'error');
+    spyOn(privateUnderTest, 'consoleError');
 
     env.describe('a suite', function() {
       env.it('a spec', function() {
@@ -143,8 +142,10 @@ describe('Deprecation (integration)', function() {
         ]
       })
     );
-    expect(console.error).toHaveBeenCalled();
-    expect(console.error.calls.argsFor(0)[0].replace(/\n/g, 'NL')).toMatch(
+    expect(privateUnderTest.consoleError).toHaveBeenCalled();
+    expect(
+      privateUnderTest.consoleError.calls.argsFor(0)[0].replace(/\n/g, 'NL')
+    ).toMatch(
       /^DEPRECATION: the message \(in spec: a suite a spec\)NL.*DeprecationSpec.js/
     );
   });
@@ -152,7 +153,7 @@ describe('Deprecation (integration)', function() {
   it('excludes the stack trace when omitStackTrace is true', async function() {
     const reporter = jasmine.createSpyObj('reporter', ['specDone']);
     env.addReporter(reporter);
-    spyOn(console, 'error');
+    spyOn(privateUnderTest, 'consoleError');
 
     env.describe('a suite', function() {
       env.it('a spec', function() {
@@ -171,8 +172,8 @@ describe('Deprecation (integration)', function() {
         ]
       })
     );
-    expect(console.error).toHaveBeenCalled();
-    expect(console.error).not.toHaveBeenCalledWith(
+    expect(privateUnderTest.consoleError).toHaveBeenCalled();
+    expect(privateUnderTest.consoleError).not.toHaveBeenCalledWith(
       jasmine.stringMatching(/DeprecationSpec.js/)
     );
   });
@@ -183,7 +184,7 @@ describe('Deprecation (integration)', function() {
       'suiteDone'
     ]);
     env.addReporter(reporter);
-    spyOn(console, 'error');
+    spyOn(privateUnderTest, 'consoleError');
 
     env.describe('a suite', function() {
       env.beforeAll(function() {
@@ -219,11 +220,11 @@ describe('Deprecation (integration)', function() {
         ]
       })
     );
-    expect(console.error).toHaveBeenCalledTimes(2);
-    expect(console.error).toHaveBeenCalledWith(
+    expect(privateUnderTest.consoleError).toHaveBeenCalledTimes(2);
+    expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
       jasmine.stringMatching(/^DEPRECATION: the message \(in suite: a suite\)/)
     );
-    expect(console.error).toHaveBeenCalledWith(
+    expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
       jasmine.stringMatching(
         /^DEPRECATION: a different message \(in spec: a suite a spec\)/
       )
@@ -236,7 +237,7 @@ describe('Deprecation (integration)', function() {
       'suiteDone'
     ]);
     env.addReporter(reporter);
-    spyOn(console, 'error');
+    spyOn(privateUnderTest, 'consoleError');
 
     env.configure({ verboseDeprecations: true });
 
@@ -274,17 +275,17 @@ describe('Deprecation (integration)', function() {
         ]
       })
     );
-    expect(console.error).toHaveBeenCalledTimes(3);
-    expect(console.error.calls.argsFor(0)[0]).toMatch(
+    expect(privateUnderTest.consoleError).toHaveBeenCalledTimes(3);
+    expect(privateUnderTest.consoleError.calls.argsFor(0)[0]).toMatch(
       /^DEPRECATION: the message \(in suite: a suite\)/
     );
-    expect(console.error.calls.argsFor(1)[0]).toMatch(
+    expect(privateUnderTest.consoleError.calls.argsFor(1)[0]).toMatch(
       /^DEPRECATION: the message \(in suite: a suite\)/
     );
-    expect(console.error.calls.argsFor(2)[0]).toMatch(
+    expect(privateUnderTest.consoleError.calls.argsFor(2)[0]).toMatch(
       /^DEPRECATION: the message \(in spec: a suite a spec\)/
     );
-    expect(console.error.calls.argsFor(2)[0]).toMatch(
+    expect(privateUnderTest.consoleError.calls.argsFor(2)[0]).toMatch(
       /^DEPRECATION: the message \(in spec: a suite a spec\)/
     );
   });
@@ -292,7 +293,7 @@ describe('Deprecation (integration)', function() {
   it('handles deprecations that occur before execute() is called', async function() {
     const reporter = jasmine.createSpyObj('reporter', ['jasmineDone']);
     env.addReporter(reporter);
-    spyOn(console, 'error');
+    spyOn(privateUnderTest, 'consoleError');
 
     env.deprecated('the message');
     env.it('a spec', function() {});
@@ -308,7 +309,7 @@ describe('Deprecation (integration)', function() {
         ]
       })
     );
-    expect(console.error).toHaveBeenCalledWith(
+    expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
       jasmine.stringMatching(/^DEPRECATION: the message/)
     );
   });

--- a/spec/core/integration/EnvSpec.js
+++ b/spec/core/integration/EnvSpec.js
@@ -2949,7 +2949,7 @@ describe('Env integration', function() {
     const specLevelError = new Error('spec level deprecation');
 
     // prevent deprecation from being displayed
-    spyOn(console, 'error');
+    spyOn(privateUnderTest, 'consoleError');
 
     env.addReporter(reporter);
 

--- a/spec/core/integration/GlobalErrorHandlingSpec.js
+++ b/spec/core/integration/GlobalErrorHandlingSpec.js
@@ -301,7 +301,7 @@ describe('Global error handling (integration)', function() {
         env.cleanup_();
         env = new privateUnderTest.Env({ global });
 
-        spyOn(console, 'error');
+        spyOn(privateUnderTest, 'consoleError');
 
         env.addReporter({
           jasmineDone: function() {
@@ -313,12 +313,10 @@ describe('Global error handling (integration)', function() {
 
         await env.execute();
 
-        /* eslint-disable-next-line no-console */
-        expect(console.error).toHaveBeenCalledWith(
+        expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
           'Jasmine received a result after the suite finished:'
         );
-        /* eslint-disable-next-line no-console */
-        expect(console.error).toHaveBeenCalledWith(
+        expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
           jasmine.objectContaining({
             message: 'a very late error thrown',
             globalErrorType: 'afterAll'
@@ -349,7 +347,7 @@ describe('Global error handling (integration)', function() {
         realClearStack(fn);
       });
       spyOn(privateUnderTest, 'getStackClearer').and.returnValue(stackClearer);
-      spyOn(console, 'error');
+      spyOn(privateUnderTest, 'consoleError');
 
       env.cleanup_();
       env = new privateUnderTest.Env({ global });
@@ -382,8 +380,7 @@ describe('Global error handling (integration)', function() {
       }
 
       for (const message of expectedErrorsAfterJasmineDone) {
-        /* eslint-disable-next-line no-console */
-        expect(console.error).toHaveBeenCalledWith(
+        expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
           jasmine.objectContaining({ message })
         );
       }
@@ -584,7 +581,7 @@ describe('Global error handling (integration)', function() {
         env.cleanup_();
         env = new privateUnderTest.Env({ global });
 
-        spyOn(console, 'error');
+        spyOn(privateUnderTest, 'consoleError');
 
         env.addReporter({
           jasmineDone: function() {
@@ -598,12 +595,10 @@ describe('Global error handling (integration)', function() {
 
         await env.execute();
 
-        /* eslint-disable-next-line no-console */
-        expect(console.error).toHaveBeenCalledWith(
+        expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
           'Jasmine received a result after the suite finished:'
         );
-        /* eslint-disable-next-line no-console */
-        expect(console.error).toHaveBeenCalledWith(
+        expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
           jasmine.objectContaining({
             message: 'Unhandled promise rejection: a very late error thrown',
             globalErrorType: 'afterAll'
@@ -635,7 +630,7 @@ describe('Global error handling (integration)', function() {
         realClearStack(fn);
       });
       spyOn(privateUnderTest, 'getStackClearer').and.returnValue(stackClearer);
-      spyOn(console, 'error');
+      spyOn(privateUnderTest, 'consoleError');
 
       env.cleanup_();
       env = new privateUnderTest.Env({ global });
@@ -668,8 +663,7 @@ describe('Global error handling (integration)', function() {
       }
 
       for (const message of expectedErrorsAfterJasmineDone) {
-        /* eslint-disable-next-line no-console */
-        expect(console.error).toHaveBeenCalledWith(
+        expect(privateUnderTest.consoleError).toHaveBeenCalledWith(
           jasmine.objectContaining({ message })
         );
       }

--- a/src/core/Deprecator.js
+++ b/src/core/Deprecator.js
@@ -38,8 +38,7 @@ getJasmineRequireObj().Deprecator = function(j$, private$) {
 
   Deprecator.prototype.log_ = function(runnable, deprecation, options) {
     if (private$.isError(deprecation)) {
-      // eslint-disable-next-line no-console
-      console.error(deprecation);
+      private$.consoleError(deprecation);
       return;
     }
 
@@ -61,8 +60,7 @@ getJasmineRequireObj().Deprecator = function(j$, private$) {
       context += '\n' + verboseNote;
     }
 
-    // eslint-disable-next-line no-console
-    console.error('DEPRECATION: ' + deprecation + context);
+    private$.consoleError('DEPRECATION: ' + deprecation + context);
   };
 
   Deprecator.prototype.stackTrace_ = function() {

--- a/src/core/Env.js
+++ b/src/core/Env.js
@@ -256,10 +256,10 @@ getJasmineRequireObj().Env = function(j$, private$) {
 
       // If we get here, all results have been reported and there's nothing we
       // can do except log the result and hope the user sees it.
-      // eslint-disable-next-line no-console
-      console.error('Jasmine received a result after the suite finished:');
-      // eslint-disable-next-line no-console
-      console.error(expectationResult);
+      private$.consoleError(
+        'Jasmine received a result after the suite finished:'
+      );
+      private$.consoleError(expectationResult);
     }
 
     const asyncExpectationFactory = function(actual, spec, runableType) {

--- a/src/core/QueueRunner.js
+++ b/src/core/QueueRunner.js
@@ -24,8 +24,7 @@ getJasmineRequireObj().QueueRunner = function(j$, private$) {
   }
 
   function fallbackOnMultipleDone() {
-    // eslint-disable-next-line no-console
-    console.error(
+    private$.consoleError(
       new Error(
         "An asynchronous function called its 'done' " +
           'callback more than once, in a QueueRunner without a onMultipleDone ' +
@@ -149,8 +148,7 @@ getJasmineRequireObj().QueueRunner = function(j$, private$) {
           // Any error we catch here is probably due to a bug in Jasmine,
           // and it's not likely to end up anywhere useful if we let it
           // propagate. Log it so it can at least show up when debugging.
-          // eslint-disable-next-line no-console
-          console.error(error);
+          private$.consoleError(error);
         }
       }
     );

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -229,6 +229,11 @@ getJasmineRequireObj().base = function(j$, private$, jasmineGlobal) {
     );
   };
 
+  private$.consoleError = function(...args) {
+    // eslint-disable-next-line no-console
+    console.error(...args);
+  };
+
   /**
    * Get an {@link AsymmetricEqualityTester} that will succeed if the actual
    * value being compared matches every provided equality tester.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a private `consoleError()` function, that simply forwards all arguments to `console.error()`, and patch it in tests instead of the real console object.

## Motivation and Context

1. This is a fix for Jasmine's own tests on a runtime where console object is read-only (GJS: https://github.com/GNOME/gjs/blob/d7f5ba748123f7d4a3bd57095ae499a990cd1dd2/modules/esm/console.js#L657). The wrapper can be monkey-patched regardless of the "real" console object.

2. Repeated ESLint "no-console" rule suppressions are not necessary anymore.

## How Has This Been Tested?

I have a working port of Jasmine 7.0.0-pre.2 to GJS in the `main` branch here: https://github.com/ddterm/jasmine. Some tests are disabled because of missing APIs (`URL`, global errors), but most of the test suite passes - both on GJS, Node, browsers. This is one of the changes that was needed to fix the tests.

This PR was also tested separately on Node v26.0.4, Firefox 152.0.3, Chromium 149.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

