### PR TITLE
Check whether `URL` class is present again

### DIFF
--- a/spec/core/baseSpec.js
+++ b/spec/core/baseSpec.js
@@ -69,6 +69,7 @@ describe('base helpers', function() {
 
   describe('isURL', function() {
     it('returns true when the object is a URL', function() {
+      specHelpers.requireUrls();
       expect(privateUnderTest.isURL(new URL('http://localhost/'))).toBe(true);
     });
 

--- a/spec/core/matchers/matchersUtilSpec.js
+++ b/spec/core/matchers/matchersUtilSpec.js
@@ -662,6 +662,8 @@ describe('matchersUtil', function() {
     });
 
     it('passes when comparing two identical URLs', function() {
+      specHelpers.requireUrls();
+
       const matchersUtil = new privateUnderTest.MatchersUtil();
 
       expect(
@@ -673,6 +675,8 @@ describe('matchersUtil', function() {
     });
 
     it('fails when comparing two different URLs', function() {
+      specHelpers.requireUrls();
+
       const matchersUtil = new privateUnderTest.MatchersUtil();
       const url1 = new URL('http://localhost/1');
 

--- a/spec/helpers/checkForUrl.js
+++ b/spec/helpers/checkForUrl.js
@@ -1,0 +1,16 @@
+(function() {
+  function hasUrlConstructor() {
+    try {
+      new URL('http://localhost/');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  specHelpers.requireUrls = function() {
+    if (!hasUrlConstructor()) {
+      pending('Environment does not support URLs');
+    }
+  };
+})();

--- a/spec/support/jasmine-browser.js
+++ b/spec/support/jasmine-browser.js
@@ -21,6 +21,7 @@ module.exports = {
     'helpers/init.js',
     'helpers/generator.js',
     'helpers/BrowserFlags.js',
+    'helpers/checkForUrl.js',
     'helpers/domHelpers.js',
     'helpers/integrationMatchers.js',
     'helpers/callerFilenameShim.js',

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -6,6 +6,7 @@
   ],
   "helpers": [
     "helpers/init.js",
+    "helpers/checkForUrl.js",
     "helpers/domHelpers.js",
     "helpers/integrationMatchers.js",
     "helpers/callerFilenameShim.js",

--- a/src/core/base.js
+++ b/src/core/base.js
@@ -177,13 +177,19 @@ getJasmineRequireObj().base = function(j$, private$, jasmineGlobal) {
     );
   };
 
-  private$.isURL = function(obj) {
-    return (
-      obj !== null &&
-      typeof obj !== 'undefined' &&
-      obj.constructor === jasmineGlobal.URL
-    );
-  };
+  if (typeof jasmineGlobal.URL !== 'undefined') {
+    private$.isURL = function(obj) {
+      return (
+        obj !== null &&
+        typeof obj !== 'undefined' &&
+        obj.constructor === jasmineGlobal.URL
+      );
+    };
+  } else {
+    private$.isURL = function(obj) {
+      return false;
+    };
+  }
 
   private$.isIterable = function(value) {
     return value && !!value[Symbol.iterator];


### PR DESCRIPTION
## Description

Restore the check for presence of `URL` class.

## Motivation and Context

Jasmine had this check before. Then it was removed in v4.0.0, commit fe0a83b "Removed support for Internet Explorer".

Unfortunately, GJS has no built-in `URL` too (even though it's SpiderMonkey under the hood).

## How Has This Been Tested?

Ran the test suite on Node v26.4.0, Firefox 152.0.3, Chromium 149.

Together with other changes from `main` branch of https://github.com/ddterm/jasmine, tested on GJS 1.88.1 and 1.80.2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/jasmine/jasmine/blob/main/.github/CONTRIBUTING.md) guide.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

