### PR TITLE
Fix jasmine-core reset in Node

### DIFF
--- a/lib/jasmine-core.js
+++ b/lib/jasmine-core.js
@@ -30,13 +30,12 @@ const {
   globals,
   installGlobals,
   version,
-  private$
+  reset: resetCore
 } = require('./jasmine-core/jasmine.js');
 
 function reset() {
-  private$.currentEnv_ = null;
-  const env = jasmine.getEnv({ suppressLoadErrors: true });
-  rebindInterface(env);
+  resetCore();
+  Object.assign(module.exports, globals);
 }
 
 const rootPath = path.join(__dirname, 'jasmine-core');

--- a/lib/jasmine-core/jasmine.js
+++ b/lib/jasmine-core/jasmine.js
@@ -12387,25 +12387,47 @@ getJasmineRequireObj().version = function() {
   const jasmineRequire = getJasmineRequireObj();
 
   function bootJasmine(options) {
-    const jasmine = jasmineRequire.core(jasmineRequire).jasmine;
-    const env = jasmine.getEnv(options);
-    const jasmineInterface = jasmineRequire.interface(jasmine, env);
+    const core = jasmineRequire.core(jasmineRequire);
+    const jasmine = core.jasmine;
+    const private$ = core.private;
     const globals = {
       jasmine,
-      ...jasmineInterface
+      ...jasmineRequire.interface(jasmine, jasmine.getEnv(options))
     };
+    const installedDestinations = new Set();
+
+    function installGlobals(dest) {
+      dest = dest ?? globalThis;
+      installedDestinations.add(dest);
+
+      for (const [k, v] of Object.entries(globals)) {
+        dest[k] = v;
+      }
+    }
+
+    function reset() {
+      private$.currentEnv_ = null;
+      const env = jasmine.getEnv({ suppressLoadErrors: true });
+      const jasmineInterface = jasmineRequire.interface(jasmine, env);
+
+      for (const key of Object.keys(globals)) {
+        if (key !== 'jasmine') {
+          delete globals[key];
+        }
+      }
+      Object.assign(globals, { jasmine, ...jasmineInterface });
+
+      for (const dest of installedDestinations) {
+        installGlobals(dest);
+      }
+    }
 
     return {
       jasmine,
       globals,
       version: jasmineRequire.version,
-      installGlobals(dest) {
-        dest = dest ?? globalThis;
-
-        for (const [k, v] of Object.entries(globals)) {
-          dest[k] = v;
-        }
-      }
+      installGlobals,
+      reset
     };
   }
 

--- a/spec/npmPackage/npmPackageSpec.js
+++ b/spec/npmPackage/npmPackageSpec.js
@@ -49,6 +49,22 @@ describe('npm package', function() {
     );
   });
 
+  it('resets the environment and rebinds the interface', function() {
+    const sandbox = {};
+    this.packagedCore.installGlobals(sandbox);
+
+    const before = this.packagedCore.jasmine.getEnv();
+    const previousDescribe = this.packagedCore.describe;
+    const previousInstalledDescribe = sandbox.describe;
+
+    this.packagedCore.reset();
+
+    expect(this.packagedCore.jasmine.getEnv()).not.toBe(before);
+    expect(this.packagedCore.describe).not.toBe(previousDescribe);
+    expect(sandbox.describe).not.toBe(previousInstalledDescribe);
+    expect(sandbox.describe).toBe(this.packagedCore.describe);
+  });
+
   it('has a bootDir', function() {
     expect(this.packagedCore.files.bootDir).toEqual(
       fs.realpathSync(path.resolve(this.tmpDir, 'package/lib/jasmine-core'))

--- a/src/boot/jasmine-core.js
+++ b/src/boot/jasmine-core.js
@@ -6,13 +6,12 @@ const {
   globals,
   installGlobals,
   version,
-  private$
+  reset: resetCore
 } = require('./jasmine-core/jasmine.js');
 
 function reset() {
-  private$.currentEnv_ = null;
-  const env = jasmine.getEnv({ suppressLoadErrors: true });
-  rebindInterface(env);
+  resetCore();
+  Object.assign(module.exports, globals);
 }
 
 const rootPath = path.join(__dirname, 'jasmine-core');

--- a/src/core/requireSuffix.js
+++ b/src/core/requireSuffix.js
@@ -5,25 +5,47 @@
   const jasmineRequire = getJasmineRequireObj();
 
   function bootJasmine(options) {
-    const jasmine = jasmineRequire.core(jasmineRequire).jasmine;
-    const env = jasmine.getEnv(options);
-    const jasmineInterface = jasmineRequire.interface(jasmine, env);
+    const core = jasmineRequire.core(jasmineRequire);
+    const jasmine = core.jasmine;
+    const private$ = core.private;
     const globals = {
       jasmine,
-      ...jasmineInterface
+      ...jasmineRequire.interface(jasmine, jasmine.getEnv(options))
     };
+    const installedDestinations = new Set();
+
+    function installGlobals(dest) {
+      dest = dest ?? globalThis;
+      installedDestinations.add(dest);
+
+      for (const [k, v] of Object.entries(globals)) {
+        dest[k] = v;
+      }
+    }
+
+    function reset() {
+      private$.currentEnv_ = null;
+      const env = jasmine.getEnv({ suppressLoadErrors: true });
+      const jasmineInterface = jasmineRequire.interface(jasmine, env);
+
+      for (const key of Object.keys(globals)) {
+        if (key !== 'jasmine') {
+          delete globals[key];
+        }
+      }
+      Object.assign(globals, { jasmine, ...jasmineInterface });
+
+      for (const dest of installedDestinations) {
+        installGlobals(dest);
+      }
+    }
 
     return {
       jasmine,
       globals,
       version: jasmineRequire.version,
-      installGlobals(dest) {
-        dest = dest ?? globalThis;
-
-        for (const [k, v] of Object.entries(globals)) {
-          dest[k] = v;
-        }
-      }
+      installGlobals,
+      reset
     };
   }
 


### PR DESCRIPTION
## Summary

- fix `jasmine-core.reset()` so it can access the active core state
- recreate the environment and rebind exported and installed interface functions
- add an npm package regression test for the reset behavior

Fixes #2116

## Validation

- `node -e "...jasmineCore.reset()..."` reset smoke test
- `npm test` (1874 specs, 0 failures; lint and Prettier passed)
